### PR TITLE
fat: use DMA memory for mkfatfs when needed

### DIFF
--- a/nuttx/fs/fat/fs_mkfatfs.c
+++ b/nuttx/fs/fat/fs_mkfatfs.c
@@ -277,8 +277,11 @@ int mkfatfs(FAR const char *pathname, FAR struct fat_format_s *fmt)
     }
 
   /* Allocate a buffer that will be working sector memory */
-
+#ifdef CONFIG_FAT_DMAMEMORY
+  var.fv_sect = (uint8_t*)fat_dma_alloc(var.fv_sectorsize);
+#else
   var.fv_sect = (uint8_t*)kmalloc(var.fv_sectorsize);
+#endif
   if (!var.fv_sect)
     {
       fdbg("Failed to allocate working buffers\n");
@@ -299,7 +302,11 @@ errout:
 
   if (var.fv_sect)
     {
+#ifdef CONFIG_FAT_DMAMEMORY
+      fat_dma_free(var.fv_sect, var.fv_sectorsize);
+#else
       kfree(var.fv_sect);
+#endif
     }
 
   /* Return any reported errors */


### PR DESCRIPTION
this makes mkfatfs use fat_dma_alloc() when CONFIG_FAT_DMAMEMORY is
set. This is needed to ensure mkfatfs operates with boards that use
DMA for microSD