### PR TITLE
Support tool of mknxfat and ldnxflat

### DIFF
--- a/nuttx/configs/fire-stm32v2/nsh/Make.defs
+++ b/nuttx/configs/fire-stm32v2/nsh/Make.defs
@@ -71,6 +71,9 @@ NM = $(ARCROSSDEV)nm
 OBJCOPY = $(CROSSDEV)objcopy
 OBJDUMP = $(CROSSDEV)objdump
 
+MKNXFLAT = mknxflat
+LDNXFLAT = ldnxflat
+
 ARCHCCVERSION = ${shell $(CC) -v 2>&1 | sed -n '/^gcc version/p' | sed -e 's/^gcc version \([0-9\.]\)/\1/g' -e 's/[-\ ].*//g' -e '1q'}
 ARCHCCMAJOR = ${shell echo $(ARCHCCVERSION) | cut -d'.' -f1}
 


### PR DESCRIPTION
So the test app locating in apps/examples/nxflat/tests can be compiled successfully when use the configuration in fire-stm32v2/nsh.
Support Nxflat test app.