### PR TITLE
Added FIONREAD and FIONWRITE support for pipes

### DIFF
--- a/nuttx/drivers/pipes/fifo.c
+++ b/nuttx/drivers/pipes/fifo.c
@@ -71,7 +71,7 @@ static const struct file_operations fifo_fops =
   pipecommon_read,  /* read */
   pipecommon_write, /* write */
   0,                /* seek */
-  0                 /* ioctl */
+  pipecommon_ioctl  /* ioctl */
 #ifndef CONFIG_DISABLE_POLL
   , pipecommon_poll /* poll */
 #endif

--- a/nuttx/drivers/pipes/pipe.c
+++ b/nuttx/drivers/pipes/pipe.c
@@ -82,7 +82,7 @@ static const struct file_operations pipe_fops =
   pipecommon_read,   /* read */
   pipecommon_write,  /* write */
   0,                 /* seek */
-  0                  /* ioctl */
+  pipecommon_ioctl   /* ioctl */
 #ifndef CONFIG_DISABLE_POLL
   , pipecommon_poll  /* poll */
 #endif

--- a/nuttx/drivers/pipes/pipe_common.h
+++ b/nuttx/drivers/pipes/pipe_common.h
@@ -125,6 +125,7 @@ EXTERN int     pipecommon_open(FAR struct file *filep);
 EXTERN int     pipecommon_close(FAR struct file *filep);
 EXTERN ssize_t pipecommon_read(FAR struct file *, FAR char *, size_t);
 EXTERN ssize_t pipecommon_write(FAR struct file *, FAR const char *, size_t);
+EXTERN int     pipecommon_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
 #ifndef CONFIG_DISABLE_POLL
 EXTERN int     pipecommon_poll(FAR struct file *filep, FAR struct pollfd *fds,
                                bool setup);


### PR DESCRIPTION
This is needed for nsh shell support over MAVLink