### PR TITLE
minor apm cleanups

### DIFF
--- a/apps/examples/can/can_main.c
+++ b/apps/examples/can/can_main.c
@@ -241,7 +241,7 @@ int can_main(int argc, char *argv[])
 #endif
 
 #ifndef CONFIG_EXAMPLES_CAN_READONLY
-    message("  ID: %4d DLC: %d\n", rxmsg.cm_hdr.id, rxmsg.cm_hdr.dlc);
+    message("  ID: %4d DLC: %d\n", rxmsg.cm_hdr.ch_id, rxmsg.cm_hdr.ch_dlc);
 #endif
 
     /* Verify that the received messages are the same */

--- a/nuttx/Makefile.unix
+++ b/nuttx/Makefile.unix
@@ -352,6 +352,8 @@ include/nuttx/version.h: $(TOPDIR)/.version tools/mkversion$(HOSTEXEEXT)
 # part of the overall NuttX configuration sequence. Notice that the
 # tools/mkconfig tool is built and used to create include/nuttx/config.h
 
+.NOTPARALLEL: tools/mkconfig$(HOSTEXEEXT) include/nuttx/config.h
+
 tools/mkconfig$(HOSTEXEEXT):
 	$(Q) $(MAKE) -C tools -f Makefile.host TOPDIR="$(TOPDIR)"  mkconfig$(HOSTEXEEXT)
 

--- a/nuttx/drivers/mtd/ramtron.c
+++ b/nuttx/drivers/mtd/ramtron.c
@@ -155,7 +155,7 @@ struct ramtron_dev_s
 #define RAMTRON_CLK_MAX      40*1000*1000UL
 #define RAMTRON_INIT_CLK_DEFAULT  11*1000*1000UL
 
-static struct ramtron_parts_s ramtron_parts[] =
+static const struct ramtron_parts_s ramtron_parts[] =
 {
   {
     "FM25V01",                    /* name */

--- a/nuttx/include/sys/statfs.h
+++ b/nuttx/include/sys/statfs.h
@@ -135,7 +135,11 @@ extern "C" {
  * form of the struct statfs.
  */
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
 EXTERN int statfs(const char *path, struct statfs *buf);
+#pragma GCC diagnostic pop
+
 EXTERN int fstatfs(int fd, struct statfs *buf);
 
 #undef EXTERN


### PR DESCRIPTION
This is a small set of patches to bring ArduPilot PX4NuttX tree in line with PX4 tree
