### PR TITLE
fix make jobserver error

### DIFF
--- a/nuttx/Makefile.unix
+++ b/nuttx/Makefile.unix
@@ -705,7 +705,7 @@ menuconfig:
 # that the archiver is 'ar'
 
 export: pass2deps
-	$(Q) tools/mkexport.sh -w$(WINTOOL) -t "$(TOPDIR)" -l "$(NUTTXLIBS)"
+	$(Q) MAKE=$(MAKE) tools/mkexport.sh -w$(WINTOOL) -t "$(TOPDIR)" -l "$(NUTTXLIBS)"
 
 # General housekeeping targets:  dependencies, cleaning, etc.
 #

--- a/nuttx/drivers/mmcsd/mmcsd_sdio.c
+++ b/nuttx/drivers/mmcsd/mmcsd_sdio.c
@@ -1628,7 +1628,7 @@ static ssize_t mmcsd_writesingle(FAR struct mmcsd_state_s *priv,
 #ifdef CONFIG_SDIO_DMA
   if (priv->dma)
     { 
-      ret = SDIO_DMAPREFLIGHT(priv->dev, buffer, priv->blocksize);
+      ret = SDIO_DMAPREFLIGHT(priv->dev, (uint8_t *)buffer, priv->blocksize);
 
       if (ret != OK)
         {

--- a/nuttx/tools/mkexport.sh
+++ b/nuttx/tools/mkexport.sh
@@ -151,7 +151,7 @@ grep -v "WINTOOL[ \t]*=[ \t]y" "${TOPDIR}/Make.defs"  > "${EXPORTDIR}/Make.defs"
 
 # Extract information from the Make.defs file.  A Makefile can do this best
 
-make -C "${TOPDIR}/tools" -f Makefile.export TOPDIR="${TOPDIR}" EXPORTDIR="${EXPORTDIR}"
+${MAKE} -C "${TOPDIR}/tools" -f Makefile.export TOPDIR="${TOPDIR}" EXPORTDIR="${EXPORTDIR}"
 source "${EXPORTDIR}/makeinfo.sh"
 rm -f "${EXPORTDIR}/makeinfo.sh"
 rm -f "${EXPORTDIR}/Make.defs"


### PR DESCRIPTION
This removes the jobserver errors.

    warning: jobserver unavailable: using -j1. Add `+' to parent make rule