### PR TITLE
Enable the sending of break frames on TX of a U(S)ART.

### DIFF
--- a/nuttx/arch/arm/src/stm32/stm32_serial.c
+++ b/nuttx/arch/arm/src/stm32/stm32_serial.c
@@ -1908,20 +1908,24 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
 #ifdef CONFIG_USART_BREAKS
     case TIOCSBRK:  /* BSD compatibility: Turn break on, unconditionally */
       {
-        irqstate_t flags = irqsave();
-        uint32_t cr2 = up_serialin(priv, STM32_USART_CR2_OFFSET);
-        up_serialout(priv, STM32_USART_CR2_OFFSET, cr2 | USART_CR2_LINEN);
-        irqrestore(flags);
+	irqstate_t flags = irqsave();
+	uint32_t cr1 = up_serialin(priv, STM32_USART_CR1_OFFSET);
+	up_serialout(priv, STM32_USART_CR1_OFFSET, cr1 | USART_CR1_SBK);
+	uint32_t cr2 = up_serialin(priv, STM32_USART_CR2_OFFSET);
+	up_serialout(priv, STM32_USART_CR2_OFFSET, cr2 | USART_CR2_LINEN);
+	irqrestore(flags);
       }
       break;
 
     case TIOCCBRK:  /* BSD compatibility: Turn break off, unconditionally */
       {
-        irqstate_t flags;
+	irqstate_t flags;
         flags = irqsave();
-        uint32_t cr1 = up_serialin(priv, STM32_USART_CR2_OFFSET);
+	uint32_t cr1 = up_serialin(priv, STM32_USART_CR1_OFFSET);
+        up_serialout(priv, STM32_USART_CR1_OFFSET, cr1 & ~USART_CR1_SBK);
+	uint32_t cr2 = up_serialin(priv, STM32_USART_CR2_OFFSET);
         up_serialout(priv, STM32_USART_CR2_OFFSET, cr2 & ~USART_CR2_LINEN);
-        irqrestore(flags);
+	irqrestore(flags);
       }
       break;
 #endif


### PR DESCRIPTION
According to the Reference Manual of STM32F4XX MCUs (http://www.st.com/st-web-ui/static/active/cn/resource/technical/document/reference_manual/DM00031020.pdf, page 1004,1005), setting the SBK bit in CR1 enables the U(S)ART to send a break frame of 10/11-bit long. By simultaneously setting the LINEN bit in CR2 changes the duration of the break frame to 13-bit. 

A break frame is sometimes required by some sensors, e.g. the SRF01 rangefinder. While the original code for this function is not implemented properly and a modification is proposed, which implements a 13-bit break frame.

The modification is obviously not compatible with the description here (https://en.wikibooks.org/wiki/Serial_Programming/Unix_V7) which says that the TIOCSBRK command starts sending break signals and TIOCCBRK stops sending break signals. The way stm32f4 works is more similar to a TCSBRK command which sends a break for between 0.25 to 0.5 seconds, but the duration is rather different. I haven't got a better idea to solve these incompatibilities and decide to leave the code like what I currently proposed.
