### PR TITLE
Handle ftell quickly in fat driver

### DIFF
--- a/nuttx/fs/fat/fs_fat32.c
+++ b/nuttx/fs/fat/fs_fat32.c
@@ -962,6 +962,14 @@ static off_t fat_seek(FAR struct file *filep, off_t offset, int whence)
 
   DEBUGASSERT(fs != NULL);
 
+  /* Special case for ftell */
+
+  if (offset == 0 && whence == SEEK_CUR) {
+	  /* Quickly return current position */
+
+	  return filep->f_pos;
+  }
+
   /* Map the offset according to the whence option */
 
   switch (whence)


### PR DESCRIPTION
The default implementation resets the current position to 0 and performs a full seek back to the current position. This is particularly expensive for large files.

This fix allows us to greatly accelerate log download transfers. 