### PR TITLE
mtd: Add Fujistu MB85RS256B ramtron support

### DIFF
--- a/nuttx/drivers/mtd/ramtron.c
+++ b/nuttx/drivers/mtd/ramtron.c
@@ -257,7 +257,7 @@ static const struct ramtron_parts_s ramtron_parts[] =
    "MB85RS256B",                  /* name */
    0x05,                         /* id1 */
    0x09,                         /* id2 */
-   256L*1024L,                   /* size */
+   32L*1024L,                   /* size */
    3,                            /* addr_len */
    25000000                      /* speed */
  },

--- a/nuttx/drivers/mtd/ramtron.c
+++ b/nuttx/drivers/mtd/ramtron.c
@@ -253,6 +253,14 @@ static const struct ramtron_parts_s ramtron_parts[] =
    3,                            /* addr_len */
    25000000                      /* speed */
  },
+ {
+   "MB85RS256B",                  /* name */
+   0x05,                         /* id1 */
+   0x09,                         /* id2 */
+   256L*1024L,                   /* size */
+   3,                            /* addr_len */
+   25000000                      /* speed */
+ },
 #ifdef CONFIG_RAMTRON_FRAM_NON_JEDEC
   {
     "FM25H20",                    /* name */


### PR DESCRIPTION
This adds support for the Fujistu MB85RS256B FRAM module. 

See https://www.fujitsu.com/us/Images/MB85RS256B-DS501-00021-2v0-E.pdf for the data sheet. 