### PR TITLE
Fixes MAC El Capitan reconnect taking forever.

### DIFF
--- a/nuttx/arch/arm/src/stm32/stm32_otgfsdev.c
+++ b/nuttx/arch/arm/src/stm32/stm32_otgfsdev.c
@@ -3215,6 +3215,9 @@ static inline void stm32_rxinterrupt(FAR struct stm32_usbdev_s *priv)
 			 * last SETUP packet will be processed.
 			 */
 
+			/* workaround for FIFO lost data */
+			up_udelay(28);
+
 			stm32_rxfifo_read(&priv->epout[EP0], (FAR uint8_t*)&priv->ctrlreq,
 							 USB_SIZEOF_CTRLREQ);
 


### PR DESCRIPTION
 This is a work around for missing data in the FIFO that could be observerd in Windows.
 Using Putty the SetLineCoding transaction would mis read data from the FIFO. The first 4 bytes (one pop) were missing
 The bad value was then stored as the linecoding and when read back was incorrect.

The full cause is still under investigation and this work around anly addes a small delay to endopint setup packets's FIFO read.