### PR TITLE
Fix compilation errors with arm-none-eabi-gcc 7

### DIFF
--- a/fs/vfs/fs_lseek.c
+++ b/fs/vfs/fs_lseek.c
@@ -99,7 +99,7 @@ off_t file_seek(FAR struct file *filep, off_t offset, int whence)
         {
           case SEEK_CUR:
             offset += filep->f_pos;
-
+            /* FALLTHROUGH */
           case SEEK_SET:
             if (offset >= 0)
               {

--- a/libc/stdio/lib_dtoa.c
+++ b/libc/stdio/lib_dtoa.c
@@ -1190,7 +1190,7 @@ char *__dtoa(double d, int mode, int ndigits, int *decpt, int *sign, char **rve)
 
     case 2:
       leftright = 0;
-      /* no break */
+      /* FALLTHROUGH */
     case 4:
       if (ndigits <= 0)
         {
@@ -1202,7 +1202,7 @@ char *__dtoa(double d, int mode, int ndigits, int *decpt, int *sign, char **rve)
 
     case 3:
       leftright = 0;
-      /* no break */
+      /* FALLTHROUGH */
     case 5:
       i = ndigits + k + 1;
       ilim = i;

--- a/libc/stdio/lib_dtoa.c
+++ b/libc/stdio/lib_dtoa.c
@@ -817,10 +817,11 @@ static const double bigtens[] =
   1e16, 1e32, 1e64, 1e128, 1e256
 };
 
-static const double tinytens[] =
-{
-  1e-16, 1e-32, 1e-64, 1e-128, 1e-256
-};
+// Unused
+// static const double tinytens[] =
+// {
+//   1e-16, 1e-32, 1e-64, 1e-128, 1e-256
+// };
 
 #  define n_bigtens 5
 #else

--- a/libc/stdio/lib_sscanf.c
+++ b/libc/stdio/lib_sscanf.c
@@ -417,6 +417,7 @@ int vsscanf(FAR const char *buf, FAR const char *fmt, va_list ap)
                     default:
                     case 'd':
                       sign = true;
+                      /* FALLTHROUGH */
                     case 'u':
                       base = 10;
                       break;

--- a/libc/stdlib/lib_strtod.c
+++ b/libc/stdlib/lib_strtod.c
@@ -113,8 +113,10 @@ double strtod(FAR const char *str, FAR char **endptr)
     {
     case '-':
       negative = 1; /* Fall through to increment position */
+      /* FALLTHROUGH */
     case '+':
       p++;
+      /* FALLTHROUGH */
     default:
       break;
     }
@@ -175,8 +177,10 @@ double strtod(FAR const char *str, FAR char **endptr)
         {
         case '-':
           negative = 1;   /* Fall through to increment pos */
+          /* FALLTHROUGH */
         case '+':
           p++;
+          /* FALLTHROUGH */          
         default:
           break;
         }

--- a/libc/stdlib/lib_strtof.c
+++ b/libc/stdlib/lib_strtof.c
@@ -115,8 +115,10 @@ float strtof(FAR const char *str, FAR char **endptr)
     {
     case '-':
       negative = 1; /* Fall through to increment position */
+      /* FALLTHROUGH */
     case '+':
       p++;
+      /* FALLTHROUGH */
     default:
       break;
     }
@@ -177,8 +179,10 @@ float strtof(FAR const char *str, FAR char **endptr)
         {
         case '-':
           negative = 1;   /* Fall through to increment pos */
+          /* FALLTHROUGH */          
         case '+':
           p++;
+          /* FALLTHROUGH */
         default:
           break;
         }

--- a/libc/stdlib/lib_strtold.c
+++ b/libc/stdlib/lib_strtold.c
@@ -113,8 +113,10 @@ long double strtold(FAR const char *str, FAR char **endptr)
     {
     case '-':
       negative = 1; /* Fall through to increment position */
+      /* FALLTHROUGH */
     case '+':
       p++;
+      /* FALLTHROUGH */
     default:
       break;
     }
@@ -175,8 +177,10 @@ long double strtold(FAR const char *str, FAR char **endptr)
         {
         case '-':
           negative = 1;   /* Fall through to increment pos */
+          /* FALLTHROUGH */
         case '+':
           p++;
+          /* FALLTHROUGH */
         default:
           break;
         }


### PR DESCRIPTION
With newer versions of GCC, new warnings are emitted and prevent building on PX4 master.