### PR TITLE
Fix to compilation error on enabling ramlog

### DIFF
--- a/drivers/syslog/ramlog.c
+++ b/drivers/syslog/ramlog.c
@@ -60,6 +60,7 @@
 #include <nuttx/syslog/ramlog.h>
 
 #include <nuttx/irq.h>
+#include "syslog.h"
 
 #ifdef CONFIG_RAMLOG
 


### PR DESCRIPTION
Fixes the following compilation error on enabling syslog ramlog 
syslog/ramlog.c:131:3: error: 'syslog_default_write' undeclared here
