### PR TITLE
[BACKPORT] drivers/pipes: poll: fix off-by-one error

### DIFF
--- a/drivers/pipes/pipe_common.c
+++ b/drivers/pipes/pipe_common.c
@@ -696,7 +696,7 @@ int pipecommon_poll(FAR struct file *filep, FAR struct pollfd *fds,
         }
       else
         {
-          nbytes = (dev->d_bufsize - 1) + dev->d_wrndx - dev->d_rdndx;
+          nbytes = dev->d_bufsize + dev->d_wrndx - dev->d_rdndx;
         }
 
       /* Notify the POLLOUT event if the pipe is not full, but only if


### PR DESCRIPTION
   From Jussi Kivilinna <jussi.kivilinna@haltian.com>
   c73dd8973accd312ca7675fde044df80e9cc62d5

   fix off-by-one error in calculation of
   bytes in the buffer

   Buffer calculation in pipe poll setup is off-by-one when read index
   is larger than write index. This causes poll() not getting POLLIN
   when buffer has one byte as calculation gives zero bytes in buffer.

   Reproducible with:

     {
       char buf[8] = { 0, };
       int fds[2];
       struct pollfd in_pfd;

       pipe2(fds, 8);

       write(fds[1], buf, 7);
       read(fds[0], buf, 7);
       write(fds[1], buf, 1);

       in_pfd.fd = fds[0];
       in_pfd.events = POLLIN;
       ret = poll(&in_pfd, 1, -1); // pipe bug => stuck waiting
       assert(ret == 1);
     }