### PR TITLE
stm32f76xx_77xx: Set correct backup register address

### DIFF
--- a/arch/arm/src/stm32f7/chip/stm32f76xx77xx_memorymap.h
+++ b/arch/arm/src/stm32f7/chip/stm32f76xx77xx_memorymap.h
@@ -113,7 +113,7 @@
 #define STM32_TIM14_BASE     0x40002000     /* 0x40002000-0x400023ff: TIM14 */
 #define STM32_LPTIM1_BASE    0x40002400     /* 0x40002400-0x400027ff: LPTIM1 */
 #define STM32_RTC_BASE       0x40002800     /* 0x40002800-0x40002bff: RTC & BKP Registers */
-#define STM32_BKP_BASE       0x40002800     /* 0x40002800-0x40002bff: RTC & BKP Registers */
+#define STM32_BKP_BASE       0x40002850     /* BKP Registers Address offset from RTC base: 0x50 to 0xCC*/
 #define STM32_WWDG_BASE      0x40002c00     /* 0x40002c00-0x40002fff: WWDG */
 #define STM32_IWDG_BASE      0x40003000     /* 0x40003000-0x400033ff: IWDG */
 #define STM32_CAN3_BASE      0x40003400     /* 0x40003400-0x400037ff: CAN3 */


### PR DESCRIPTION
From the stmf76xx77xx reference manual the RTC_BKP0 register as an offset of 0x50 from the RTC base address (page 1171, section 32.6.20)
![image](https://user-images.githubusercontent.com/9131453/34881355-a41a145c-f7b3-11e7-9a01-90bff080b933.png)
