### PR TITLE
Fix transmission status handling in the serial interrupt

### DIFF
--- a/arch/arm/src/kinetis/kinetis_serial.c
+++ b/arch/arm/src/kinetis/kinetis_serial.c
@@ -950,7 +950,7 @@ static int up_interrupts(int irq, void *context, FAR void *arg)
        * the TX data register.
        */
 
-      if ((s1 & UART_S1_TDRE) != 0)
+      if ((s1 & UART_S1_TDRE) != 0 && (priv->ie & UART_C2_TIE) != 0)
 #endif
         {
           /* Process outgoing bytes */


### PR DESCRIPTION
Loop was not exited and thus did block interrupt longer than necessary. A check is added if there is something to transmit, and the loop is only continued in that case.