### PR TITLE
[BACKPORT] Merged in kekiefer/nuttx/stm32f7-serial-fix-tiocssinglewire-upstream (pull request #658)

### DIFF
--- a/arch/arm/src/stm32f7/stm32_serial.c
+++ b/arch/arm/src/stm32f7/stm32_serial.c
@@ -1924,6 +1924,22 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
 #ifdef CONFIG_STM32F7_USART_SINGLEWIRE
     case TIOCSSINGLEWIRE:
       {
+        uint32_t cr1;
+        uint32_t cr1_ue;
+        irqstate_t flags;
+
+        flags = enter_critical_section();
+
+        /* Get the original state of UE */
+
+        cr1  = up_serialin(priv, STM32_USART_CR1_OFFSET);
+        cr1_ue = cr1 & USART_CR1_UE;
+        cr1 &= ~USART_CR1_UE;
+
+        /* Disable UE, HDSEL can only be written when UE=0 */
+
+        up_serialout(priv, STM32_USART_CR1_OFFSET, cr1);
+
         /* Change the TX port to be open-drain/push-pull and enable/disable
          * half-duplex mode.
          */
@@ -1942,6 +1958,11 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
           }
 
         up_serialout(priv, STM32_USART_CR3_OFFSET, cr);
+
+        /* Re-enable UE if appropriate */
+
+        up_serialout(priv, STM32_USART_CR1_OFFSET, cr1 | cr1_ue);
+        leave_critical_section(flags);
       }
      break;
 #endif


### PR DESCRIPTION
According to the STM32F77xx/76xx TRM 34.8.3, the HDSEL bit of USART_CR3 can only be set when the USART is disabled:

```
Bit3 HDSEL:Half-duplexselection
Selection of Single-wire Half-duplex mode
0: Half duplex mode is not selected
1: Half duplex mode is selected
This bit can only be written when the USART is disabled (UE=0).
```

NuttX's F7 TIOCSSINGLEWIRE implementation does not disable UE before changing this bit, and therefore this ioctl has no effect. Presumably, this code was ported from the F4xx, for which the TRM does not make the same note. Whether the setting actually works on the F4 or not, I can't say.

I have tested a fix for this issue that clears UE (if enabled) before changing HDSEL on the F7, and can submit a PR if desired.