### PR TITLE
Configure I2C pins as GPIO output

### DIFF
--- a/arch/arm/src/stm32f7/stm32_i2c.c
+++ b/arch/arm/src/stm32f7/stm32_i2c.c
@@ -2526,6 +2526,9 @@ static int stm32_i2c_reset(FAR struct i2c_master_s * dev)
   scl_gpio = MKI2C_OUTPUT(priv->config->scl_pin);
   sda_gpio = MKI2C_OUTPUT(priv->config->sda_pin);
 
+  stm32_configgpio(sda_gpio);
+  stm32_configgpio(scl_gpio);
+
   /* Let SDA go high */
 
   stm32_gpiowrite(sda_gpio, 1);


### PR DESCRIPTION
I2C pins need to be configured before used as GPIO . 