### PR TITLE
[BACKPORT] stm32f7:Added Kconfig knob for STM32F7_USART_SINGLEWIRE

### DIFF
--- a/arch/arm/src/stm32f7/Kconfig
+++ b/arch/arm/src/stm32f7/Kconfig
@@ -1683,6 +1683,14 @@ config STM32F7_SERIALBRK_BSDCOMPAT
 		on because the SW starts the break and then the HW automatically clears
 		the break. This makes it is difficult to sent a long break.
 
+config STM32F7_USART_SINGLEWIRE
+	bool "Single Wire Support"
+	default n
+	depends on STM32F7_USART
+	---help---
+		Enable single wire UART support.  The option enables support for the
+		TIOCSSINGLEWIRE ioctl in the STM32F7 serial driver.
+
 endmenu # U[S]ART Configuration
 
 menu "SPI Configuration"


### PR DESCRIPTION
   Partial back port from https://bitbucket.org/nuttx/nuttx/pull-requests/679 for F7