### PR TITLE
[BACKPORT] kinetis:i2c On failed reset re-init i2c and clocking

### DIFF
--- a/arch/arm/src/kinetis/kinetis_i2c.c
+++ b/arch/arm/src/kinetis/kinetis_i2c.c
@@ -1324,17 +1324,16 @@ static int kinetis_i2c_reset(struct i2c_master_s *dev)
 
   kinetis_pinconfig(MKI2C_INPUT(sda_gpio));
   kinetis_pinconfig(MKI2C_INPUT(scl_gpio));
+  ret = OK;
 
-  /* Re-init the port */
+  /* Re-init the port (even on error to enable clock) */
 
+out:
   kinetis_i2c_init(priv);
 
   /* Restore the frequency */
 
   kinetis_i2c_setfrequency(priv, frequency);
-  ret = OK;
-
-out:
 
   /* Release the port for re-use by other clients */
 


### PR DESCRIPTION
  If a reset fails, we still must reinitializes the
  i2c block so that subsequent transfers will not
  cause a hardfault due to the clock being off.
  If that transfer fails it can try to reset
  again.