### PR TITLE
[BACKPORT] 510b0f7e07 Correct all ARMv7-M architectures.

### DIFF
--- a/arch/arm/src/kinetis/kinetis_irq.c
+++ b/arch/arm/src/kinetis/kinetis_irq.c
@@ -347,11 +347,11 @@ void up_irqinitialize(void)
    * registers.
    */
 
-  for (i = nintlines, regaddr = NVIC_IRQ0_31_ENABLE;
+  for (i = nintlines, regaddr = NVIC_IRQ0_31_CLEAR;
        i > 0;
        i--, regaddr += 4)
     {
-      putreg32(0, regaddr);
+      putreg32(0xffffffff, regaddr);
     }
 
   /* Make sure that we are using the correct vector table.  The default

--- a/arch/arm/src/lc823450/lc823450_irq.c
+++ b/arch/arm/src/lc823450/lc823450_irq.c
@@ -442,8 +442,8 @@ void up_irqinitialize(void)
 
   /* Disable all interrupts */
 
-  putreg32(0, NVIC_IRQ0_31_ENABLE);
-  putreg32(0, NVIC_IRQ32_63_ENABLE);
+  putreg32(0xffffffff, NVIC_IRQ0_31_CLEAR);
+  putreg32(0xffffffff, NVIC_IRQ32_63_CLEAR);
 
   /* Colorize the interrupt stack for debug purposes */
 

--- a/arch/arm/src/lpc17xx/lpc17_irq.c
+++ b/arch/arm/src/lpc17xx/lpc17_irq.c
@@ -316,11 +316,11 @@ void up_irqinitialize(void)
    * registers.
    */
 
-  for (i = nintlines, regaddr = NVIC_IRQ0_31_ENABLE;
+  for (i = nintlines, regaddr = NVIC_IRQ0_31_CLEAR;
        i > 0;
        i--, regaddr += 4)
     {
-      putreg32(0, regaddr);
+      putreg32(0xffffffff, regaddr);
     }
 
   /* Make sure that we are using the correct vector table.  The default

--- a/arch/arm/src/sam34/sam_irq.c
+++ b/arch/arm/src/sam34/sam_irq.c
@@ -378,11 +378,11 @@ void up_irqinitialize(void)
    * registers.
    */
 
-  for (i = nintlines, regaddr = NVIC_IRQ0_31_ENABLE;
+  for (i = nintlines, regaddr = NVIC_IRQ0_31_CLEAR;
        i > 0;
        i--, regaddr += 4)
     {
-      putreg32(0, regaddr);
+      putreg32(0xffffffff, regaddr);
     }
 
   /* Make sure that we are using the correct vector table.  The default

--- a/arch/arm/src/samv7/sam_irq.c
+++ b/arch/arm/src/samv7/sam_irq.c
@@ -374,11 +374,11 @@ void up_irqinitialize(void)
    * registers.
    */
 
-  for (i = nintlines, regaddr = NVIC_IRQ0_31_ENABLE;
+  for (i = nintlines, regaddr = NVIC_IRQ0_31_CLEAR;
        i > 0;
        i--, regaddr += 4)
     {
-      putreg32(0, regaddr);
+      putreg32(0xffffffff, regaddr);
     }
 
   /* Make sure that we are using the correct vector table.  The default

--- a/arch/arm/src/stm32f7/stm32_irq.c
+++ b/arch/arm/src/stm32f7/stm32_irq.c
@@ -408,11 +408,11 @@ void up_irqinitialize(void)
    * registers.
    */
 
-  for (i = nintlines, regaddr = NVIC_IRQ0_31_ENABLE;
+  for (i = nintlines, regaddr = NVIC_IRQ0_31_CLEAR;
        i > 0;
        i--, regaddr += 4)
     {
-      putreg32(0, regaddr);
+      putreg32(0xffffffff, regaddr);
     }
 
   /* Make sure that we are using the correct vector table.  The default

--- a/arch/arm/src/tiva/tiva_irq.c
+++ b/arch/arm/src/tiva/tiva_irq.c
@@ -385,11 +385,11 @@ void up_irqinitialize(void)
    * registers.
    */
 
-  for (i = nintlines, regaddr = NVIC_IRQ0_31_ENABLE;
+  for (i = nintlines, regaddr = NVIC_IRQ0_31_CLEAR;
        i > 0;
        i--, regaddr += 4)
     {
-      putreg32(0, regaddr);
+      putreg32(0xffffffff, regaddr);
     }
 
   /* Make sure that we are using the correct vector table.  The default

--- a/arch/arm/src/xmc4/xmc4_irq.c
+++ b/arch/arm/src/xmc4/xmc4_irq.c
@@ -347,11 +347,11 @@ void up_irqinitialize(void)
    * registers.
    */
 
-  for (i = nintlines, regaddr = NVIC_IRQ0_31_ENABLE;
+  for (i = nintlines, regaddr = NVIC_IRQ0_31_CLEAR;
        i > 0;
        i--, regaddr += 4)
     {
-      putreg32(0, regaddr);
+      putreg32(0xffffffff, regaddr);
     }
 
   /* Make sure that we are using the correct vector table.  The default


### PR DESCRIPTION
   Interrupts were not be disabled correctly on power up.
   Writing zero to the NVIC SET-ENABLE registers has no
   effect.  In order to disable interrupts, it is
   necessary to write all ones to the NVIC CLEAR-ENABLE
   register.  Noted by David Sidrane.