### PR TITLE
[REJECTED] arm/include/math.h: remove _PARAMS macro

### DIFF
--- a/arch/arm/include/math.h
+++ b/arch/arm/include/math.h
@@ -84,34 +84,34 @@ _BEGIN_STD_C
 /* Reentrant ANSI C functions.  */
 
 #ifndef __math_68881
-extern double atan _PARAMS((double));
-extern double cos _PARAMS((double));
-extern double sin _PARAMS((double));
-extern double tan _PARAMS((double));
-extern double tanh _PARAMS((double));
-extern double frexp _PARAMS((double, int *));
-extern double modf _PARAMS((double, double *));
-extern double ceil _PARAMS((double));
-extern double fabs _PARAMS((double));
-extern double floor _PARAMS((double));
+extern double atan (double);
+extern double cos (double);
+extern double sin (double);
+extern double tan (double);
+extern double tanh (double);
+extern double frexp (double, int *);
+extern double modf (double, double *);
+extern double ceil (double);
+extern double fabs (double);
+extern double floor (double);
 #endif /* ! defined (__math_68881) */
 
 /* Non reentrant ANSI C functions.  */
 
 #ifndef _REENT_ONLY
 #ifndef __math_68881
-extern double acos _PARAMS((double));
-extern double asin _PARAMS((double));
-extern double atan2 _PARAMS((double, double));
-extern double cosh _PARAMS((double));
-extern double sinh _PARAMS((double));
-extern double exp _PARAMS((double));
-extern double ldexp _PARAMS((double, int));
-extern double log _PARAMS((double));
-extern double log10 _PARAMS((double));
-extern double pow _PARAMS((double, double));
-extern double sqrt _PARAMS((double));
-extern double fmod _PARAMS((double, double));
+extern double acos (double);
+extern double asin (double);
+extern double atan2 (double, double);
+extern double cosh (double);
+extern double sinh (double);
+extern double exp (double);
+extern double ldexp (double, int);
+extern double log (double);
+extern double log10 (double);
+extern double pow (double, double);
+extern double sqrt (double);
+extern double fmod (double, double);
 #endif /* ! defined (__math_68881) */
 #endif /* ! defined (_REENT_ONLY) */
 
@@ -208,202 +208,202 @@ extern int __signbitd (double x);
 
 /* Non ANSI double precision functions.  */
 
-extern double infinity _PARAMS((void));
-extern double nan _PARAMS((const char *));
-extern int finite _PARAMS((double));
-extern double copysign _PARAMS((double, double));
-extern double logb _PARAMS((double));
-extern int ilogb _PARAMS((double));
+extern double infinity (void);
+extern double nan (const char *);
+extern int finite (double);
+extern double copysign (double, double);
+extern double logb (double);
+extern int ilogb (double);
 
-extern double asinh _PARAMS((double));
-extern double cbrt _PARAMS((double));
-extern double nextafter _PARAMS((double, double));
-extern double rint _PARAMS((double));
-extern double scalbn _PARAMS((double, int));
+extern double asinh (double);
+extern double cbrt (double);
+extern double nextafter (double, double);
+extern double rint (double);
+extern double scalbn (double, int);
 
-extern double exp2 _PARAMS((double));
-extern double scalbln _PARAMS((double, long int));
-extern double tgamma _PARAMS((double));
-extern double nearbyint _PARAMS((double));
-extern long int lrint _PARAMS((double));
-extern long long int llrint _PARAMS((double));
-extern double round _PARAMS((double));
-extern long int lround _PARAMS((double));
-extern long long int llround _PARAMS((double));
-extern double trunc _PARAMS((double));
-extern double remquo _PARAMS((double, double, int *));
-extern double fdim _PARAMS((double, double));
-extern double fmax _PARAMS((double, double));
-extern double fmin _PARAMS((double, double));
-extern double fma _PARAMS((double, double, double));
+extern double exp2 (double);
+extern double scalbln (double, long int);
+extern double tgamma (double);
+extern double nearbyint (double);
+extern long int lrint (double);
+extern long long int llrint (double);
+extern double round (double);
+extern long int lround (double);
+extern long long int llround (double);
+extern double trunc (double);
+extern double remquo (double, double, int *);
+extern double fdim (double, double);
+extern double fmax (double, double);
+extern double fmin (double, double);
+extern double fma (double, double, double);
 
 #ifndef __math_68881
-extern double log1p _PARAMS((double));
-extern double expm1 _PARAMS((double));
+extern double log1p (double);
+extern double expm1 (double);
 #endif /* ! defined (__math_68881) */
 
 #ifndef _REENT_ONLY
-extern double acosh _PARAMS((double));
-extern double atanh _PARAMS((double));
-extern double remainder _PARAMS((double, double));
-extern double gamma _PARAMS((double));
-extern double lgamma _PARAMS((double));
-extern double erf _PARAMS((double));
-extern double erfc _PARAMS((double));
-extern double log2 _PARAMS((double));
+extern double acosh (double);
+extern double atanh (double);
+extern double remainder (double, double);
+extern double gamma (double);
+extern double lgamma (double);
+extern double erf (double);
+extern double erfc (double);
+extern double log2 (double);
 
 #ifndef __math_68881
-extern double hypot _PARAMS((double, double));
+extern double hypot (double, double);
 #endif
 
 #endif /* ! defined (_REENT_ONLY) */
 
 /* Single precision versions of ANSI functions.  */
 
-extern float atanf _PARAMS((float));
-extern float cosf _PARAMS((float));
-extern float sinf _PARAMS((float));
-extern float tanf _PARAMS((float));
-extern float tanhf _PARAMS((float));
-extern float frexpf _PARAMS((float, int *));
-extern float modff _PARAMS((float, float *));
-extern float ceilf _PARAMS((float));
-extern float fabsf _PARAMS((float));
-extern float floorf _PARAMS((float));
+extern float atanf (float);
+extern float cosf (float);
+extern float sinf (float);
+extern float tanf (float);
+extern float tanhf (float);
+extern float frexpf (float, int *);
+extern float modff (float, float *);
+extern float ceilf (float);
+extern float fabsf (float);
+extern float floorf (float);
 
 #ifndef _REENT_ONLY
-extern float acosf _PARAMS((float));
-extern float asinf _PARAMS((float));
-extern float atan2f _PARAMS((float, float));
-extern float coshf _PARAMS((float));
-extern float sinhf _PARAMS((float));
-extern float expf _PARAMS((float));
-extern float ldexpf _PARAMS((float, int));
-extern float logf _PARAMS((float));
-extern float log10f _PARAMS((float));
-extern float powf _PARAMS((float, float));
-extern float sqrtf _PARAMS((float));
-extern float fmodf _PARAMS((float, float));
+extern float acosf (float);
+extern float asinf (float);
+extern float atan2f (float, float);
+extern float coshf (float);
+extern float sinhf (float);
+extern float expf (float);
+extern float ldexpf (float, int);
+extern float logf (float);
+extern float log10f (float);
+extern float powf (float, float);
+extern float sqrtf (float);
+extern float fmodf (float, float);
 #endif /* ! defined (_REENT_ONLY) */
 
 /* Other single precision functions.  */
 
-extern float exp2f _PARAMS((float));
-extern float scalblnf _PARAMS((float, long int));
-extern float tgammaf _PARAMS((float));
-extern float nearbyintf _PARAMS((float));
-extern long int lrintf _PARAMS((float));
-extern long long llrintf _PARAMS((float));
-extern float roundf _PARAMS((float));
-extern long int lroundf _PARAMS((float));
-extern long long int llroundf _PARAMS((float));
-extern float truncf _PARAMS((float));
-extern float remquof _PARAMS((float, float, int *));
-extern float fdimf _PARAMS((float, float));
-extern float fmaxf _PARAMS((float, float));
-extern float fminf _PARAMS((float, float));
-extern float fmaf _PARAMS((float, float, float));
+extern float exp2f (float);
+extern float scalblnf (float, long int);
+extern float tgammaf (float);
+extern float nearbyintf (float);
+extern long int lrintf (float);
+extern long long llrintf (float);
+extern float roundf (float);
+extern long int lroundf (float);
+extern long long int llroundf (float);
+extern float truncf (float);
+extern float remquof (float, float, int *);
+extern float fdimf (float, float);
+extern float fmaxf (float, float);
+extern float fminf (float, float);
+extern float fmaf (float, float, float);
 
-extern float infinityf _PARAMS((void));
-extern float nanf _PARAMS((const char *));
-extern int finitef _PARAMS((float));
-extern float copysignf _PARAMS((float, float));
-extern float logbf _PARAMS((float));
-extern int ilogbf _PARAMS((float));
+extern float infinityf (void);
+extern float nanf (const char *);
+extern int finitef (float);
+extern float copysignf (float, float);
+extern float logbf (float);
+extern int ilogbf (float);
 
-extern float asinhf _PARAMS((float));
-extern float cbrtf _PARAMS((float));
-extern float nextafterf _PARAMS((float, float));
-extern float rintf _PARAMS((float));
-extern float scalbnf _PARAMS((float, int));
-extern float log1pf _PARAMS((float));
-extern float expm1f _PARAMS((float));
+extern float asinhf (float);
+extern float cbrtf (float);
+extern float nextafterf (float, float);
+extern float rintf (float);
+extern float scalbnf (float, int);
+extern float log1pf (float);
+extern float expm1f (float);
 
 #ifndef _REENT_ONLY
-extern float acoshf _PARAMS((float));
-extern float atanhf _PARAMS((float));
-extern float remainderf _PARAMS((float, float));
-extern float gammaf _PARAMS((float));
-extern float lgammaf _PARAMS((float));
-extern float erff _PARAMS((float));
-extern float erfcf _PARAMS((float));
-extern float log2f _PARAMS((float));
-extern float hypotf _PARAMS((float, float));
+extern float acoshf (float);
+extern float atanhf (float);
+extern float remainderf (float, float);
+extern float gammaf (float);
+extern float lgammaf (float);
+extern float erff (float);
+extern float erfcf (float);
+extern float log2f (float);
+extern float hypotf (float, float);
 #endif /* ! defined (_REENT_ONLY) */
 
 /* On platforms where long double equals double.  */
 #ifdef _LDBL_EQ_DBL
 /* Reentrant ANSI C functions.  */
 #ifndef __math_68881
-extern long double atanl _PARAMS((long double));
-extern long double cosl _PARAMS((long double));
-extern long double sinl _PARAMS((long double));
-extern long double tanl _PARAMS((long double));
-extern long double tanhl _PARAMS((long double));
-extern long double frexpl _PARAMS((long double value, int *));
-extern long double modfl _PARAMS((long double, long double *));
-extern long double ceill _PARAMS((long double));
-extern long double fabsl _PARAMS((long double));
-extern long double floorl _PARAMS((long double));
-extern long double log1pl _PARAMS((long double));
-extern long double expm1l _PARAMS((long double));
+extern long double atanl (long double);
+extern long double cosl (long double);
+extern long double sinl (long double);
+extern long double tanl (long double);
+extern long double tanhl (long double);
+extern long double frexpl (long double value, int *);
+extern long double modfl (long double, long double *);
+extern long double ceill (long double);
+extern long double fabsl (long double);
+extern long double floorl (long double);
+extern long double log1pl (long double);
+extern long double expm1l (long double);
 #endif /* ! defined (__math_68881) */
 /* Non reentrant ANSI C functions.  */
 #ifndef _REENT_ONLY
 #ifndef __math_68881
-extern long double acosl _PARAMS((long double));
-extern long double asinl _PARAMS((long double));
-extern long double atan2l _PARAMS((long double, long double));
-extern long double coshl _PARAMS((long double));
-extern long double sinhl _PARAMS((long double));
-extern long double expl _PARAMS((long double));
-extern long double ldexpl _PARAMS((long double, int));
-extern long double logl _PARAMS((long double));
-extern long double log2l _PARAMS((long double));
-extern long double log10l _PARAMS((long double));
-extern long double powl _PARAMS((long double, long double));
-extern long double sqrtl _PARAMS((long double));
-extern long double fmodl _PARAMS((long double, long double));
-extern long double hypotl _PARAMS((long double, long double));
+extern long double acosl (long double);
+extern long double asinl (long double);
+extern long double atan2l (long double, long double);
+extern long double coshl (long double);
+extern long double sinhl (long double);
+extern long double expl (long double);
+extern long double ldexpl (long double, int);
+extern long double logl (long double);
+extern long double log2l (long double);
+extern long double log10l (long double);
+extern long double powl (long double, long double);
+extern long double sqrtl (long double);
+extern long double fmodl (long double, long double);
+extern long double hypotl (long double, long double);
 #endif /* ! defined (__math_68881) */
 #endif /* ! defined (_REENT_ONLY) */
-extern long double copysignl _PARAMS((long double, long double));
-extern long double nanl _PARAMS((const char *));
-extern int ilogbl _PARAMS((long double));
-extern long double asinhl _PARAMS((long double));
-extern long double cbrtl _PARAMS((long double));
-extern long double nextafterl _PARAMS((long double, long double));
-extern long double rintl _PARAMS((long double));
-extern long double scalbnl _PARAMS((long double, int));
-extern long double exp2l _PARAMS((long double));
-extern long double scalblnl _PARAMS((long double, long));
-extern long double tgammal _PARAMS((long double));
-extern long double nearbyintl _PARAMS((long double));
-extern long int lrintl _PARAMS((long double));
-extern long long int llrintl _PARAMS((long double));
-extern long double roundl _PARAMS((long double));
-extern long lroundl _PARAMS((long double));
-extern long long int llroundl _PARAMS((long double));
-extern long double truncl _PARAMS((long double));
-extern long double remquol _PARAMS((long double, long double, int *));
-extern long double fdiml _PARAMS((long double, long double));
-extern long double fmaxl _PARAMS((long double, long double));
-extern long double fminl _PARAMS((long double, long double));
-extern long double fmal _PARAMS((long double, long double, long double));
+extern long double copysignl (long double, long double);
+extern long double nanl (const char *);
+extern int ilogbl (long double);
+extern long double asinhl (long double);
+extern long double cbrtl (long double);
+extern long double nextafterl (long double, long double);
+extern long double rintl (long double);
+extern long double scalbnl (long double, int);
+extern long double exp2l (long double);
+extern long double scalblnl (long double, long);
+extern long double tgammal (long double);
+extern long double nearbyintl (long double);
+extern long int lrintl (long double);
+extern long long int llrintl (long double);
+extern long double roundl (long double);
+extern long lroundl (long double);
+extern long long int llroundl (long double);
+extern long double truncl (long double);
+extern long double remquol (long double, long double, int *);
+extern long double fdiml (long double, long double);
+extern long double fmaxl (long double, long double);
+extern long double fminl (long double, long double);
+extern long double fmal (long double, long double, long double);
 #ifndef _REENT_ONLY
-extern long double acoshl _PARAMS((long double));
-extern long double atanhl _PARAMS((long double));
-extern long double remainderl _PARAMS((long double, long double));
-extern long double lgammal _PARAMS((long double));
-extern long double erfl _PARAMS((long double));
-extern long double erfcl _PARAMS((long double));
+extern long double acoshl (long double);
+extern long double atanhl (long double);
+extern long double remainderl (long double, long double);
+extern long double lgammal (long double);
+extern long double erfl (long double);
+extern long double erfcl (long double);
 #endif /* ! defined (_REENT_ONLY) */
 #else /* !_LDBL_EQ_DBL */
 #ifdef __i386__
 /* Other long double precision functions.  */
-extern _LONG_DOUBLE rintl _PARAMS((_LONG_DOUBLE));
-extern long int lrintl _PARAMS((_LONG_DOUBLE));
-extern long long llrintl _PARAMS((_LONG_DOUBLE));
+extern _LONG_DOUBLE rintl (_LONG_DOUBLE);
+extern long int lrintl (_LONG_DOUBLE);
+extern long long llrintl (_LONG_DOUBLE);
 #endif /* __i386__ */
 #endif /* !_LDBL_EQ_DBL */
 
@@ -411,42 +411,42 @@ extern long long llrintl _PARAMS((_LONG_DOUBLE));
 
 #if !defined (__STRICT_ANSI__) || defined(__cplusplus)
 
-extern double drem _PARAMS((double, double));
-extern void sincos _PARAMS((double, double *, double *));
-extern double gamma_r _PARAMS((double, int *));
-extern double lgamma_r _PARAMS((double, int *));
+extern double drem (double, double);
+extern void sincos (double, double *, double *);
+extern double gamma_r (double, int *);
+extern double lgamma_r (double, int *);
 
-extern double y0 _PARAMS((double));
-extern double y1 _PARAMS((double));
-extern double yn _PARAMS((int, double));
-extern double j0 _PARAMS((double));
-extern double j1 _PARAMS((double));
-extern double jn _PARAMS((int, double));
+extern double y0 (double);
+extern double y1 (double);
+extern double yn (int, double);
+extern double j0 (double);
+extern double j1 (double);
+extern double jn (int, double);
 
-extern float dremf _PARAMS((float, float));
-extern void sincosf _PARAMS((float, float *, float *));
-extern float gammaf_r _PARAMS((float, int *));
-extern float lgammaf_r _PARAMS((float, int *));
+extern float dremf (float, float);
+extern void sincosf (float, float *, float *);
+extern float gammaf_r (float, int *);
+extern float lgammaf_r (float, int *);
 
-extern float y0f _PARAMS((float));
-extern float y1f _PARAMS((float));
-extern float ynf _PARAMS((int, float));
-extern float j0f _PARAMS((float));
-extern float j1f _PARAMS((float));
-extern float jnf _PARAMS((int, float));
+extern float y0f (float);
+extern float y1f (float);
+extern float ynf (int, float);
+extern float j0f (float);
+extern float j1f (float);
+extern float jnf (int, float);
 
 /* GNU extensions */
 # ifndef exp10
-extern double exp10 _PARAMS((double));
+extern double exp10 (double);
 # endif
 # ifndef pow10
-extern double pow10 _PARAMS((double));
+extern double pow10 (double);
 # endif
 # ifndef exp10f
-extern float exp10f _PARAMS((float));
+extern float exp10f (float);
 # endif
 # ifndef pow10f
-extern float pow10f _PARAMS((float));
+extern float pow10f (float);
 # endif
 
 #endif /* !defined (__STRICT_ANSI__) || defined(__cplusplus) */
@@ -456,7 +456,7 @@ extern float pow10f _PARAMS((float));
 /* The gamma functions use a global variable, signgam.  */
 #ifndef _REENT_ONLY
 #define signgam (*__signgam())
-extern int *__signgam _PARAMS((void));
+extern int *__signgam (void);
 #endif /* ! defined (_REENT_ONLY) */
 
 #define __signgam_r(ptr) _REENT_SIGNGAM(ptr)
@@ -479,9 +479,9 @@ struct exception
 };
 
 #ifdef __cplusplus
-extern int matherr _PARAMS((struct __exception *e));
+extern int matherr (struct __exception *e);
 #else
-extern int matherr _PARAMS((struct exception *e));
+extern int matherr (struct exception *e);
 #endif
 
 /* Values for the type field of struct exception.  */


### PR DESCRIPTION
_PARAMS got removed in upstream newlib:
https://github.com/bminor/newlib/commit/eea249da3bc81776246ad5163f5eb887afdd3659

I marked this as [REJECTED] because it is based on a rejected commit (c44095ffacf4bc470d93a22fde601763685668d5) and the file is not present in upstream.