### PR TITLE
drivers: remove Scandinavian letter from help text

### DIFF
--- a/drivers/analog/Kconfig
+++ b/drivers/analog/Kconfig
@@ -90,7 +90,7 @@ config ADC_PGA11X
 	default n
 	select SPI
 	---help---
-		Enables support for the  PGA112, PGA113, PGA116, PGA117 Zerø-Drift
+		Enables support for the  PGA112, PGA113, PGA116, PGA117 Zero-Drift
 		PROGRAMMABLE GAIN AMPLIFIER with MUX
 
 if ADC_PGA11X


### PR DESCRIPTION
This prevents Python scripts from choking on the character complaining about malformed utf-8.

The letter is not displayed by GitHub either but it's this one "ø" (https://en.wikipedia.org/wiki/%C3%98) :smile:.

Related to https://github.com/PX4/Firmware/issues/11702.