### PR TITLE
sched/wdog: fix signature for wdentry_t

### DIFF
--- a/drivers/usbdev/cdcacm.c
+++ b/drivers/usbdev/cdcacm.c
@@ -176,7 +176,7 @@ static int     cdcacm_recvpacket(FAR struct cdcacm_dev_s *priv,
 static int     cdcacm_requeue_rdrequest(FAR struct cdcacm_dev_s *priv,
                  FAR struct cdcacm_rdreq_s *rdcontainer);
 static int     cdcacm_release_rxpending(FAR struct cdcacm_dev_s *priv);
-static void    cdcacm_rxtimeout(int argc, wdparm_t arg1, ...);
+static void    cdcacm_rxtimeout(int argc, ...);
 
 /* Request helpers *********************************************************/
 
@@ -763,8 +763,14 @@ static int cdcacm_release_rxpending(FAR struct cdcacm_dev_s *priv)
  *
  ****************************************************************************/
 
-static void cdcacm_rxtimeout(int argc, wdparm_t arg1, ...)
+static void cdcacm_rxtimeout(int argc, ...)
 {
+  va_list valist;
+
+  va_start(valist, argc);
+  wdparm_t arg1 = va_arg(valist, wdparm_t);
+  va_end(valist);
+
   FAR struct cdcacm_dev_s *priv = (FAR struct cdcacm_dev_s *)arg1;
 
   DEBUGASSERT(priv != NULL);

--- a/include/nuttx/wdog.h
+++ b/include/nuttx/wdog.h
@@ -127,7 +127,7 @@ typedef uint32_t  wdparm_t;
  * watchdog function expires.  Up to four parameters may be passed.
  */
 
-typedef CODE void (*wdentry_t)(int argc, wdparm_t arg1, ...);
+typedef CODE void (*wdentry_t)(int argc, ...);
 
 /* This is the internal representation of the watchdog timer structure.  The
  * WDOG_ID is a pointer to a watchdog structure.


### PR DESCRIPTION
gcc 8.2.1. doesn't allow lazy function pointer casting anymore. When building
px4-firmware 'make omnibus_f4sd_default' it complains:
wdog/wd_start.c:151:20: error: cast between incompatible function types from 'wdentry_t'

Changing the signature for wdentry_t will break cdcacm_rxtimeout(). To fix
this we use a va_list there.

Related to https://github.com/PX4/Firmware/issues/12283