### PR TITLE
[BACKPORT] for F7 network and type errors

### DIFF
--- a/fs/procfs/fs_procfsuptime.c
+++ b/fs/procfs/fs_procfsuptime.c
@@ -268,7 +268,7 @@ static ssize_t uptime_read(FAR struct file *filep, FAR char *buffer,
 #ifdef CONFIG_SYSTEM_TIME64
       linesize = snprintf(attr->line, UPTIME_LINELEN, "%7llu.%02u\n", sec, csec);
 #else
-      linesize = snprintf(attr->line, UPTIME_LINELEN, "%7lu.%02u\n", sec, csec);
+      linesize = snprintf(attr->line, UPTIME_LINELEN, "%7lu.%02u\n", (unsigned long)sec, csec);
 #endif
 
 #endif

--- a/net/socket/getpeername.c
+++ b/net/socket/getpeername.c
@@ -105,7 +105,7 @@ int psock_getpeername(FAR struct socket *psock, FAR struct sockaddr *addr, FAR s
    */
 
 #ifdef CONFIG_DEBUG_FEATURES
-  if (addr == NULL || addrlen <= 0)
+  if (addr == NULL || *addrlen <= 0)
     {
       return -EINVAL;
     }

--- a/net/socket/getsockname.c
+++ b/net/socket/getsockname.c
@@ -105,7 +105,7 @@ int psock_getsockname(FAR struct socket *psock, FAR struct sockaddr *addr, FAR s
    */
 
 #ifdef CONFIG_DEBUG_FEATURES
-  if (addr == NULL || addrlen <= 0)
+  if (addr == NULL || *addrlen <= 0)
     {
       return -EINVAL;
     }


### PR DESCRIPTION
FYI @dinomani 

This ensures the the F7 Ethernet will not hang on the MAC SW reset.

This also fixes some type errors while building for network debug

```
index b9cbe0412a..9569e385a1 100644
--- a/boards/px4/fmu-v5x/nuttx-config/nsh/defconfig
+++ b/boards/px4/fmu-v5x/nuttx-config/nsh/defconfig
@@ -49,9 +49,17 @@ CONFIG_CDCACM_TXBUFSIZE=12000
 CONFIG_CDCACM_VENDORID=0x3185
 CONFIG_CDCACM_VENDORSTR="Auterion"
 CONFIG_CLOCK_MONOTONIC=y
+CONFIG_DEBUG_ERROR=y
+CONFIG_DEBUG_FEATURES=y
 CONFIG_DEBUG_FULLOPT=y
 CONFIG_DEBUG_HARDFAULT_ALERT=y
+CONFIG_DEBUG_INFO=y
+CONFIG_DEBUG_NET=y
+CONFIG_DEBUG_NET_ERROR=y
+CONFIG_DEBUG_NET_INFO=y
+CONFIG_DEBUG_NET_WARN=y
 CONFIG_DEBUG_SYMBOLS=y
+CONFIG_DEBUG_WARN=y
 CONFIG_DEFAULT_SMALL=y
 CONFIG_DEV_FIFO_SIZE=0
 CONFIG_DEV_PIPE_MAXSIZE=1024
```
