### PR TITLE
[WIP]: stm32f7 serial TX DMA

### DIFF
--- a/arch/arm/src/stm32f7/Kconfig
+++ b/arch/arm/src/stm32f7/Kconfig
@@ -1701,6 +1701,13 @@ config USART1_RXDMA
 	---help---
 		In high data rate usage, Rx DMA may eliminate Rx overrun errors
 
+config USART1_TXDMA
+	bool "USART1 Tx DMA"
+	default n
+	depends on STM32F7_USART1 && STM32F7_DMA1
+	---help---
+		In high data rate usage, Tx DMA may eliminate Tx overrun errors
+
 config USART2_RS485
 	bool "RS-485 on USART2"
 	default n
@@ -1725,6 +1732,13 @@ config USART2_RXDMA
 	depends on STM32F7_USART2 && STM32F7_DMA1
 	---help---
 		In high data rate usage, Rx DMA may eliminate Rx overrun errors
+
+config USART2_TXDMA
+	bool "USART2 Tx DMA"
+	default n
+	depends on STM32F7_USART2 && STM32F7_DMA1
+	---help---
+		In high data rate usage, Tx DMA may eliminate Tx overrun errors
 
 config USART3_RS485
 	bool "RS-485 on USART3"
@@ -1751,6 +1765,13 @@ config USART3_RXDMA
 	---help---
 		In high data rate usage, Rx DMA may eliminate Rx overrun errors
 
+config USART3_TXDMA
+	bool "USART3 Tx DMA"
+	default n
+	depends on STM32F7_USART3 && STM32F7_DMA1
+	---help---
+		In high data rate usage, Tx DMA may eliminate Tx overrun errors
+
 config UART4_RS485
 	bool "RS-485 on UART4"
 	default n
@@ -1775,6 +1796,13 @@ config UART4_RXDMA
 	depends on STM32F7_UART4 && STM32F7_DMA1
 	---help---
 		In high data rate usage, Rx DMA may eliminate Rx overrun errors
+
+config UART4_TXDMA
+	bool "UART4 Tx DMA"
+	default n
+	depends on STM32F7_UART4 && STM32F7_DMA1
+	---help---
+		In high data rate usage, Tx DMA may eliminate Tx overrun errors
 
 config UART5_RS485
 	bool "RS-485 on UART5"
@@ -1801,6 +1829,13 @@ config UART5_RXDMA
 	---help---
 		In high data rate usage, Rx DMA may eliminate Rx overrun errors
 
+config UART5_TXDMA
+	bool "UART5 Tx DMA"
+	default n
+	depends on STM32F7_UART5 && STM32F7_DMA1
+	---help---
+		In high data rate usage, Tx DMA may eliminate Tx overrun errors
+
 config USART6_RS485
 	bool "RS-485 on USART6"
 	default n
@@ -1825,6 +1860,13 @@ config USART6_RXDMA
 	depends on STM32F7_USART6 && STM32F7_DMA2
 	---help---
 		In high data rate usage, Rx DMA may eliminate Rx overrun errors
+
+config USART6_TXDMA
+	bool "USART1 Tx DMA"
+	default n
+	depends on STM32F7_USART6 && STM32F7_DMA1
+	---help---
+		In high data rate usage, Tx DMA may eliminate Tx overrun errors
 
 config UART7_RS485
 	bool "RS-485 on UART7"
@@ -1851,6 +1893,13 @@ config UART7_RXDMA
 	---help---
 		In high data rate usage, Rx DMA may eliminate Rx overrun errors
 
+config UART7_TXDMA
+	bool "UART7 Tx DMA"
+	default n
+	depends on STM32F7_UART7 && STM32F7_DMA1
+	---help---
+		In high data rate usage, Tx DMA may eliminate Tx overrun errors
+
 config UART8_RS485
 	bool "RS-485 on UART8"
 	default n
@@ -1875,6 +1924,13 @@ config UART8_RXDMA
 	depends on STM32F7_UART8 && STM32F7_DMA2
 	---help---
 		In high data rate usage, Rx DMA may eliminate Rx overrun errors
+
+config UART8_TXDMA
+	bool "UART8 Tx DMA"
+	default n
+	depends on STM32F7_UART8 && STM32F7_DMA1
+	---help---
+		In high data rate usage, Tx DMA may eliminate Tx overrun errors
 
 config STM32F7_SERIAL_RXDMA_BUFFER_SIZE
 	int "Rx DMA buffer size"
@@ -2119,7 +2175,7 @@ config STM32F7_SPI_DMA
 	default n
 	---help---
 		Use DMA to improve SPI transfer performance.  Cannot be used with STM32F7_SPI_INTERRUPT.
-		
+
 config STM32F7_SPI1_DMA
 	bool "SPI1 DMA"
 	default n

--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -85,7 +85,11 @@ config SERIAL_OFLOWCONTROL
 	bool
 	default n
 
-config SERIAL_DMA
+config SERIAL_TXDMA
+	bool
+	default n
+
+config SERIAL_RXDMA
 	bool
 	default n
 
@@ -466,10 +470,17 @@ config UART_OFLOWCONTROL
 	---help---
 		Enable UART CTS flow control
 
-config UART_DMA
-	bool "UART DMA support"
+config UART_TXDMA
+	bool "UART Tx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_TXDMA
+	---help---
+		Enable DMA transfers on UART
+
+config UART_RXDMA
+	bool "UART Rx DMA support"
+	default n
+	select SERIAL_RXDMA
 	---help---
 		Enable DMA transfers on UART
 

--- a/drivers/serial/Kconfig-uart
+++ b/drivers/serial/Kconfig-uart
@@ -109,12 +109,19 @@ config UART0_OFLOWCONTROL
 	---help---
 		Enable UART0 CTS flow control
 
-config UART0_DMA
-	bool "UART0 DMA support"
+config UART0_RXDMA
+	bool "UART0 RX DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on UART0
+		Enable RX DMA transfers on UART0
+
+config UART0_TXDMA
+	bool "UART0 TX DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable TX DMA transfers on UART0
 
 endmenu
 
@@ -174,12 +181,19 @@ config UART1_OFLOWCONTROL
 	---help---
 		Enable UART1 CTS flow control
 
-config UART1_DMA
-	bool "UART1 DMA support"
+config UART1_RXDMA
+	bool "UART1 RX DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on UART1
+		Enable RX DMA transfers on UART1
+
+config UART1_TXDMA
+	bool "UART1 TX DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable TX DMA transfers on UART1
 
 endmenu
 
@@ -239,12 +253,19 @@ config UART2_OFLOWCONTROL
 	---help---
 		Enable UART2 CTS flow control
 
-config UART2_DMA
-	bool "UART2 DMA support"
+config UART2_RXDMA
+	bool "UART2 RX DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on UART2
+		Enable RX DMA transfers on UART2
+
+config UART2_TXDMA
+	bool "UART2 TX DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable TX DMA transfers on UART2
 
 endmenu
 
@@ -304,12 +325,19 @@ config UART3_OFLOWCONTROL
 	---help---
 		Enable UART3 CTS flow control
 
-config UART3_DMA
-	bool "UART3 DMA support"
+config UART3_RXDMA
+	bool "UART3 RX DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on UART3
+		Enable RX DMA transfers on UART3
+
+config UART3_TXDMA
+	bool "UART3 TX DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable TX DMA transfers on UART3
 
 endmenu
 
@@ -369,12 +397,19 @@ config UART4_OFLOWCONTROL
 	---help---
 		Enable UART4 CTS flow control
 
-config UART4_DMA
-	bool "UART4 DMA support"
+config UART4_RXDMA
+	bool "UART4 RX DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on UART4
+		Enable RX DMA transfers on UART4
+
+config UART4_TXDMA
+	bool "UART4 TX DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable TX DMA transfers on UART4
 
 endmenu
 
@@ -434,12 +469,19 @@ config UART5_OFLOWCONTROL
 	---help---
 		Enable UART5 CTS flow control
 
-config UART5_DMA
-	bool "UART5 DMA support"
+config UART5_RXDMA
+	bool "UART5 RX DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on UART5
+		Enable RX DMA transfers on UART5
+
+config UART5_TXDMA
+	bool "UART5 TX DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable TX DMA transfers on UART5
 
 endmenu
 
@@ -499,12 +541,19 @@ config UART6_OFLOWCONTROL
 	---help---
 		Enable UART6 CTS flow control
 
-config UART6_DMA
-	bool "UART6 DMA support"
+config UART6_RXDMA
+	bool "UART6 RX DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on UART6
+		Enable RX DMA transfers on UART6
+
+config UART6_TXDMA
+	bool "UART6 TX DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable TX DMA transfers on UART6
 
 endmenu
 
@@ -564,12 +613,19 @@ config UART7_OFLOWCONTROL
 	---help---
 		Enable UART7 CTS flow control
 
-config UART7_DMA
-	bool "UART7 DMA support"
+config UART7_RXDMA
+	bool "UART7 RX DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on UART7
+		Enable RX DMA transfers on UART7
+
+config UART7_DMA
+	bool "UART7 TX DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable TX DMA transfers on UART7
 
 endmenu
 
@@ -629,11 +685,18 @@ config UART8_OFLOWCONTROL
 	---help---
 		Enable UART8 CTS flow control
 
-config UART8_DMA
-	bool "UART8 DMA support"
+config UART8_RXDMA
+	bool "UART8 RX DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on UART8
+		Enable RX DMA transfers on UART8
+
+config UART8_TXDMA
+	bool "UART8 TX DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable TX DMA transfers on UART8
 
 endmenu

--- a/drivers/serial/Kconfig-usart
+++ b/drivers/serial/Kconfig-usart
@@ -109,12 +109,19 @@ config USART0_OFLOWCONTROL
 	---help---
 		Enable USART0 CTS flow control
 
-config USART0_DMA
-	bool "USART0 DMA support"
+config USART0_RXDMA
+	bool "USART0 RX DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on USART0
+		Enable RX DMA transfers on USART0
+
+config USART0_TXDMA
+	bool "USART0 TX DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable TX DMA transfers on USART0
 
 endmenu
 
@@ -174,12 +181,19 @@ config USART1_OFLOWCONTROL
 	---help---
 		Enable USART1 CTS flow control
 
-config USART1_DMA
-	bool "USART1 DMA support"
+config USART1_RXDMA
+	bool "USART1 RX DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on USART1
+		Enable RX DMA transfers on USART1
+
+config USART1_TXDMA
+	bool "USART1 TX DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable TX DMA transfers on USART1
 
 endmenu
 
@@ -239,12 +253,19 @@ config USART2_OFLOWCONTROL
 	---help---
 		Enable USART2 CTS flow control
 
-config USART2_DMA
-	bool "USART2 DMA support"
+config USART2_RXDMA
+	bool "USART2 RX DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on USART2
+		Enable RX DMA transfers on USART2
+
+config USART2_TXDMA
+	bool "USART2 TX DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable TX DMA transfers on USART2
 endmenu
 
 menu "USART3 Configuration"
@@ -303,12 +324,19 @@ config USART3_OFLOWCONTROL
 	---help---
 		Enable USART3 CTS flow control
 
-config USART3_DMA
-	bool "USART3 DMA support"
+config USART3_RXDMA
+	bool "USART3 RX DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on USART3
+		Enable RX DMA transfers on USART3
+
+config USART3_TXDMA
+	bool "USART3 TX DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable TX DMA transfers on USART3
 
 endmenu
 
@@ -368,12 +396,19 @@ config USART4_OFLOWCONTROL
 	---help---
 		Enable USART4 CTS flow control
 
-config USART4_DMA
-	bool "USART4 DMA support"
+config USART4_RXDMA
+	bool "USART4 RX DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on USART4
+		Enable RX DMA transfers on USART4
+
+config USART4_TXDMA
+	bool "USART4 TX DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable TX DMA transfers on USART4
 
 endmenu
 
@@ -433,12 +468,19 @@ config USART5_OFLOWCONTROL
 	---help---
 		Enable USART5 CTS flow control
 
-config USART5_DMA
-	bool "USART5 DMA support"
+config USART5_RXDMA
+	bool "USART5 RX DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on USART5
+		Enable RX DMA transfers on USART5
+
+config USART5_TXDMA
+	bool "USART5 TX DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable TX DMA transfers on USART5
 
 endmenu
 
@@ -498,12 +540,19 @@ config USART6_OFLOWCONTROL
 	---help---
 		Enable USART6 CTS flow control
 
-config USART6_DMA
-	bool "USART6 DMA support"
+config USART6_RXDMA
+	bool "USART6 RX DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on USART6
+		Enable RX DMA transfers on USART6
+
+config USART6_TXDMA
+	bool "USART6 TX DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable TX DMA transfers on USART6
 
 endmenu
 
@@ -563,12 +612,19 @@ config USART7_OFLOWCONTROL
 	---help---
 		Enable USART7 CTS flow control
 
-config USART7_DMA
-	bool "USART7 DMA support"
+config USART7_RXDMA
+	bool "USART7 RX DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on USART7
+		Enable RX DMA transfers on USART7
+
+config USART7_TXDMA
+	bool "USART7 TX DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable TX DMA transfers on USART7
 
 endmenu
 
@@ -628,12 +684,19 @@ config USART8_OFLOWCONTROL
 	---help---
 		Enable USART8 CTS flow control
 
-config USART8_DMA
-	bool "USART8 DMA support"
+config USART8_RXDMA
+	bool "USART8 RX DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on USART8
+		Enable RX DMA transfers on USART8
+
+config USART8_TXDMA
+	bool "USART8 TX DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable TX DMA transfers on USART8
 
 endmenu
 
@@ -693,11 +756,18 @@ config USART9_OFLOWCONTROL
 	---help---
 		Enable USART9 CTS flow control
 
-config USART9_DMA
-	bool "USART9 DMA support"
+config USART9_RXDMA
+	bool "USART9 RX DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on USART9
+		Enable RX DMA transfers on USART9
+
+config USART9_TXDMA
+	bool "USART9 TX DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable TX DMA transfers on USART9
 
 endmenu

--- a/drivers/serial/Make.defs
+++ b/drivers/serial/Make.defs
@@ -37,7 +37,9 @@
 
 CSRCS += serial.c serial_io.c lowconsole.c
 
-ifeq ($(CONFIG_SERIAL_DMA),y)
+ifeq ($(CONFIG_SERIAL_RXDMA),y)
+  CSRCS += serial_dma.c
+else ifeq ($(CONFIG_SERIAL_TXDMA),y)
   CSRCS += serial_dma.c
 endif
 

--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -302,7 +302,7 @@ static int uart_putxmitchar(FAR uart_dev_t *dev, int ch, bool oktoblock)
                * the semaphore.
                */
 
-#ifdef CONFIG_SERIAL_DMA
+#ifdef CONFIG_SERIAL_TXDMA
               uart_dmatxavail(dev);
 #endif
               uart_enabletxint(dev);
@@ -485,7 +485,7 @@ static int uart_tcdrain(FAR uart_dev_t *dev, clock_t timeout)
                * the semaphore.
                */
 
-#ifdef CONFIG_SERIAL_DMA
+#ifdef CONFIG_SERIAL_TXDMA
               uart_dmatxavail(dev);
 #endif
               uart_enabletxint(dev);
@@ -624,7 +624,7 @@ static int uart_open(FAR struct file *filep)
            goto errout_with_sem;
         }
 
-#ifdef CONFIG_SERIAL_DMA
+#ifdef CONFIG_SERIAL_RXDMA
       /* Notify DMA that there is free space in the RX buffer */
 
       uart_dmarxfree(dev);
@@ -887,7 +887,7 @@ static ssize_t uart_read(FAR struct file *filep, FAR char *buffer, size_t buflen
 
       else
         {
-#ifdef CONFIG_SERIAL_DMA
+#ifdef CONFIG_SERIAL_RXDMA
           /* Disable all interrupts and test again...
            * uart_disablerxint() is insufficient for the check in DMA mode.
            */
@@ -910,7 +910,7 @@ static ssize_t uart_read(FAR struct file *filep, FAR char *buffer, size_t buflen
                * additional data to be received.
                */
 
-#ifdef CONFIG_SERIAL_DMA
+#ifdef CONFIG_SERIAL_RXDMA
               /* Notify DMA that there is free space in the RX buffer */
 
               uart_dmarxfree(dev);
@@ -991,7 +991,7 @@ static ssize_t uart_read(FAR struct file *filep, FAR char *buffer, size_t buflen
                * the loop.
                */
 
-#ifdef CONFIG_SERIAL_DMA
+#ifdef CONFIG_SERIAL_RXDMA
               leave_critical_section(flags);
 #else
               uart_enablerxint(dev);
@@ -1000,7 +1000,7 @@ static ssize_t uart_read(FAR struct file *filep, FAR char *buffer, size_t buflen
         }
     }
 
-#ifdef CONFIG_SERIAL_DMA
+#ifdef CONFIG_SERIAL_RXDMA
   /* Notify DMA that there is free space in the RX buffer */
 
   flags = enter_critical_section();
@@ -1008,7 +1008,7 @@ static ssize_t uart_read(FAR struct file *filep, FAR char *buffer, size_t buflen
   leave_critical_section(flags);
 #endif
 
-#ifndef CONFIG_SERIAL_DMA
+#ifndef CONFIG_SERIAL_RXDMA
   /* RX interrupt could be disabled by RX buffer overflow. Enable it now. */
 
   uart_enablerxint(dev);
@@ -1224,7 +1224,7 @@ static ssize_t uart_write(FAR struct file *filep, FAR const char *buffer,
 
   if (dev->xmit.head != dev->xmit.tail)
     {
-#ifdef CONFIG_SERIAL_DMA
+#ifdef CONFIG_SERIAL_TXDMA
       uart_dmatxavail(dev);
 #endif
       uart_enabletxint(dev);

--- a/drivers/serial/serial_dma.c
+++ b/drivers/serial/serial_dma.c
@@ -46,7 +46,7 @@
 
 #include <nuttx/serial/serial.h>
 
-#ifdef CONFIG_SERIAL_DMA
+#if defined(CONFIG_SERIAL_TXDMA) || defined(CONFIG_SERIAL_RXDMA)
 
 /************************************************************************************
  * Private Functions
@@ -105,7 +105,8 @@ static int uart_check_signo(const char *buf, size_t size)
  *
  ************************************************************************************/
 
-#if defined(CONFIG_TTY_SIGINT) || defined(CONFIG_TTY_SIGSTP)
+#if defined(CONFIG_SERIAL_RXDMA) && \
+   (defined(CONFIG_TTY_SIGINT) || defined(CONFIG_TTY_SIGSTP))
 static int uart_recvchars_signo(FAR uart_dev_t *dev)
 {
   FAR struct uart_dmaxfer_s *xfer = &dev->dmarx;
@@ -144,6 +145,7 @@ static int uart_recvchars_signo(FAR uart_dev_t *dev)
  *
  ************************************************************************************/
 
+#ifdef CONFIG_SERIAL_TXDMA
 void uart_xmitchars_dma(FAR uart_dev_t *dev)
 {
   FAR struct uart_dmaxfer_s *xfer = &dev->dmatx;
@@ -172,6 +174,7 @@ void uart_xmitchars_dma(FAR uart_dev_t *dev)
 
   uart_dmasend(dev);
 }
+#endif
 
 /************************************************************************************
  * Name: uart_xmitchars_done
@@ -183,6 +186,7 @@ void uart_xmitchars_dma(FAR uart_dev_t *dev)
  *
  ************************************************************************************/
 
+#ifdef CONFIG_SERIAL_TXDMA
 void uart_xmitchars_done(FAR uart_dev_t *dev)
 {
   FAR struct uart_dmaxfer_s *xfer = &dev->dmatx;
@@ -204,6 +208,7 @@ void uart_xmitchars_done(FAR uart_dev_t *dev)
       uart_datasent(dev);
     }
 }
+#endif
 
 /************************************************************************************
  * Name: uart_recvchars_dma
@@ -213,6 +218,7 @@ void uart_xmitchars_done(FAR uart_dev_t *dev)
  *
  ************************************************************************************/
 
+#ifdef CONFIG_SERIAL_RXDMA
 void uart_recvchars_dma(FAR uart_dev_t *dev)
 {
   FAR struct uart_dmaxfer_s *xfer = &dev->dmarx;
@@ -331,6 +337,7 @@ void uart_recvchars_dma(FAR uart_dev_t *dev)
 
   uart_dmareceive(dev);
 }
+#endif
 
 /************************************************************************************
  * Name: uart_recvchars_done
@@ -342,6 +349,7 @@ void uart_recvchars_dma(FAR uart_dev_t *dev)
  *
  ************************************************************************************/
 
+#ifdef CONFIG_SERIAL_RXDMA
 void uart_recvchars_done(FAR uart_dev_t *dev)
 {
   FAR struct uart_dmaxfer_s *xfer = &dev->dmarx;
@@ -383,5 +391,6 @@ void uart_recvchars_done(FAR uart_dev_t *dev)
     }
 #endif
 }
+#endif
 
-#endif /* CONFIG_SERIAL_DMA */
+#endif /* CONFIG_SERIAL_TXDMA || CONFIG_SERIAL_RXDMA */

--- a/drivers/serial/uart_16550.c
+++ b/drivers/serial/uart_16550.c
@@ -103,8 +103,11 @@ static bool u16550_rxavailable(FAR struct uart_dev_s *dev);
 static bool u16550_rxflowcontrol(struct uart_dev_s *dev, unsigned int nbuffered,
                                  bool upper);
 #endif
-#ifdef CONFIG_SERIAL_DMA
+#ifdef CONFIG_SERIAL_TXDMA
 static void u16550_dmasend(FAR struct uart_dev_s *dev);
+static void u16550_dmatxavail(FAR struct uart_dev_s *dev);
+#endif
+#ifdef CONFIG_SERIAL_RXDMA
 static void u16550_dmareceive(FAR struct uart_dev_s *dev);
 static void u16550_dmarxfree(FAR struct uart_dev_s *dev);
 static void u16550_dmatxavail(FAR struct uart_dev_s *dev);
@@ -131,10 +134,14 @@ static const struct uart_ops_s g_uart_ops =
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
   .rxflowcontrol  = u16550_rxflowcontrol,
 #endif
-#ifdef CONFIG_SERIAL_DMA
+#ifdef CONFIG_SERIAL_TXDMA
   .dmasend        = u16550_dmasend,
+#endif
+#ifdef CONFIG_SERIAL_RXDMA
   .dmareceive     = u16550_dmareceive,
   .dmarxfree      = u16550_dmarxfree,
+#endif
+#ifdef CONFIG_SERIAL_TXDMA
   .dmatxavail     = u16550_dmatxavail,
 #endif
   .send           = u16550_send,
@@ -1164,11 +1171,13 @@ static bool u16550_rxflowcontrol(struct uart_dev_s *dev, unsigned int nbuffered,
  *
  ****************************************************************************/
 
-#ifdef CONFIG_SERIAL_DMA
+#ifdef CONFIG_SERIAL_TXDMA
 static void u16550_dmasend(FAR struct uart_dev_s *dev)
 {
 }
+#endif
 
+#ifdef CONFIG_SERIAL_RXDMA
 static void u16550_dmareceive(FAR struct uart_dev_s *dev)
 {
 }
@@ -1176,7 +1185,9 @@ static void u16550_dmareceive(FAR struct uart_dev_s *dev)
 static void u16550_dmarxfree(FAR struct uart_dev_s *dev)
 {
 }
+#endif
 
+#ifdef CONFIG_SERIAL_TXDMA
 static void u16550_dmatxavail(FAR struct uart_dev_s *dev)
 {
 }

--- a/drivers/usbdev/cdcacm.c
+++ b/drivers/usbdev/cdcacm.c
@@ -281,10 +281,14 @@ static const struct uart_ops_s g_uartops =
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
   cdcuart_rxflowcontrol, /* rxflowcontrol */
 #endif
-#ifdef CONFIG_SERIAL_DMA
+#ifdef CONFIG_SERIAL_TXDMA
   NULL,                  /* dmasend */
+#endif
+#ifdef CONFIG_SERIAL_RXDMA
   NULL,                  /* dmareceive */
   NULL,                  /* dmarxfree */
+#endif
+#ifdef CONFIG_SERIAL_TXDMA
   NULL,                  /* dmatxavail */
 #endif
   NULL,                  /* send */

--- a/include/nuttx/serial/serial.h
+++ b/include/nuttx/serial/serial.h
@@ -105,19 +105,20 @@
 #define uart_send(dev,ch)        dev->ops->send(dev,ch)
 #define uart_receive(dev,s)      dev->ops->receive(dev,s)
 
-#ifdef CONFIG_SERIAL_DMA
+#ifdef CONFIG_SERIAL_TXDMA
 #define uart_dmasend(dev)      \
   ((dev)->ops->dmasend ? (dev)->ops->dmasend(dev) : -ENOSYS)
 
+#define uart_dmatxavail(dev)   \
+  ((dev)->ops->dmatxavail ? (dev)->ops->dmatxavail(dev) : -ENOSYS)
+#endif
+
+#ifdef CONFIG_SERIAL_RXDMA
 #define uart_dmareceive(dev)   \
   ((dev)->ops->dmareceive ? (dev)->ops->dmareceive(dev) : -ENOSYS)
 
 #define uart_dmarxfree(dev)    \
   ((dev)->ops->dmarxfree ? (dev)->ops->dmarxfree(dev) : -ENOSYS)
-
-#define uart_dmatxavail(dev)   \
-  ((dev)->ops->dmatxavail ? (dev)->ops->dmatxavail(dev) : -ENOSYS)
-
 #endif
 
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
@@ -143,7 +144,7 @@ struct uart_buffer_s
   FAR char        *buffer; /* Pointer to the allocated buffer memory */
 };
 
-#ifdef CONFIG_SERIAL_DMA
+#if defined(CONFIG_SERIAL_RXDMA) || defined(CONFIG_SERIAL_TXDMA)
 struct uart_dmaxfer_s
 {
   FAR char        *buffer;  /* First DMA buffer */
@@ -152,7 +153,7 @@ struct uart_dmaxfer_s
   size_t           nlength; /* Length of next DMA buffer */
   size_t           nbytes;  /* Bytes actually transferred by DMA from both buffers */
 };
-#endif /* CONFIG_SERIAL_DMA */
+#endif /* CONFIG_SERIAL_RXDMA || CONFIG_SERIAL_TXDMA */
 
 /* This structure defines all of the operations providd by the architecture specific
  * logic.  All fields must be provided with non-NULL function pointers by the
@@ -226,11 +227,13 @@ struct uart_ops_s
                              unsigned int nbuffered, bool upper);
 #endif
 
-#ifdef CONFIG_SERIAL_DMA
+#ifdef CONFIG_SERIAL_TXDMA
   /* Start transfer bytes from the TX circular buffer using DMA */
 
   CODE void (*dmasend)(FAR struct uart_dev_s *dev);
+#endif
 
+#ifdef CONFIG_SERIAL_RXDMA
   /* Start transfer bytes from the TX circular buffer using DMA */
 
   CODE void (*dmareceive)(FAR struct uart_dev_s *dev);
@@ -238,7 +241,9 @@ struct uart_ops_s
   /* Notify DMA that there is free space in the RX buffer */
 
   CODE void (*dmarxfree)(FAR struct uart_dev_s *dev);
+#endif
 
+#ifdef CONFIG_SERIAL_TXDMA
   /* Notify DMA that there is data to be transferred in the TX buffer */
 
   CODE void (*dmatxavail)(FAR struct uart_dev_s *dev);
@@ -314,11 +319,12 @@ struct uart_dev_s
   struct uart_buffer_s xmit;         /* Describes transmit buffer */
   struct uart_buffer_s recv;         /* Describes receive buffer */
 
-#ifdef CONFIG_SERIAL_DMA
-
   /* DMA transfers */
 
+#ifdef CONFIG_SERIAL_TXDMA
   struct uart_dmaxfer_s dmatx;       /* Describes transmit DMA transfer */
+#endif
+#ifdef CONFIG_SERIAL_RXDMA
   struct uart_dmaxfer_s dmarx;       /* Describes receive DMA transfer */
 #endif
 
@@ -449,7 +455,7 @@ void uart_connected(FAR uart_dev_t *dev, bool connected);
  *
  ************************************************************************************/
 
-#ifdef CONFIG_SERIAL_DMA
+#ifdef CONFIG_SERIAL_TXDMA
 void uart_xmitchars_dma(FAR uart_dev_t *dev);
 #endif
 
@@ -463,7 +469,7 @@ void uart_xmitchars_dma(FAR uart_dev_t *dev);
  *
  ************************************************************************************/
 
-#ifdef CONFIG_SERIAL_DMA
+#ifdef CONFIG_SERIAL_TXDMA
 void uart_xmitchars_done(FAR uart_dev_t *dev);
 #endif
 
@@ -475,7 +481,7 @@ void uart_xmitchars_done(FAR uart_dev_t *dev);
  *
  ************************************************************************************/
 
-#ifdef CONFIG_SERIAL_DMA
+#ifdef CONFIG_SERIAL_RXDMA
 void uart_recvchars_dma(FAR uart_dev_t *dev);
 #endif
 
@@ -489,7 +495,7 @@ void uart_recvchars_dma(FAR uart_dev_t *dev);
  *
  ************************************************************************************/
 
-#ifdef CONFIG_SERIAL_DMA
+#ifdef CONFIG_SERIAL_RXDMA
 void uart_recvchars_done(FAR uart_dev_t *dev);
 #endif
 


### PR DESCRIPTION
https://bitbucket.org/nuttx/nuttx/pull-requests/858/arch-arm-src-stm32f7-stm32_serialc-add-dma/diff

TODO: 

> When using the drivers/serial/serial.c DMA, the buffers are provided by the upper half driver, not by the lower half driver at stm32_serial. You would have to remove CONFIG_STM32F7_SERIAL_RXDMA_BUFFER_SIZE from the Kconfig file and RXDMA_BUFFER_SIZE, g_usartNrxfifo, and the rxfifo filed from the stm32_serial driver.

> All DMA buffering is managed by drivers/serial/serial.c driver and must be removed from the lower half driver. The dumb only circular rxfifo is just left over garbage from an old data overrun workaround that was added by PX4 years ago. It is not a proper DMA solution!

