### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/tools/discover.py
+++ b/tools/discover.py
@@ -34,6 +34,7 @@
 #
 ############################################################################
 
+from __future__ import print_function
 import array
 import time
 from socket import *
@@ -85,7 +86,7 @@ def read_responses(socket):
         return res
 
 if __name__ == '__main__':
-    print 'Sending discover...'
+    print('Sending discover...')
 
     s = socket(AF_INET, SOCK_DGRAM)
     s.bind(('0.0.0.0', PORT))
@@ -95,4 +96,4 @@ if __name__ == '__main__':
     devices = read_responses(s)
     socket.close(s)
 
-    print devices
+    print(devices)

--- a/tools/xmlrpc_test.py
+++ b/tools/xmlrpc_test.py
@@ -34,15 +34,16 @@
 #
 ############################################################################
 
+from __future__ import print_function
 import sys
 import xmlrpclib
 
 if __name__ == '__main__':
     if len(sys.argv) != 2:
-        print 'Usage: %s <ip address>' % sys.argv[0]
+        print('Usage: %s <ip address>' % sys.argv[0])
         quit(1)
 
     server_url = 'http://%s/device' % sys.argv[1]
     server = xmlrpclib.ServerProxy(server_url)
     result = server.get_device_stats("username", "password", 0)
-    print result
+    print(result)


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.