### PR TITLE
Workaround for SD write when SD card is ejected

### DIFF
--- a/arch/arm/src/stm32/stm32_sdio.c
+++ b/arch/arm/src/stm32/stm32_sdio.c
@@ -686,7 +686,7 @@ static void stm32_configwaitints(struct stm32_dev_s *priv, uint32_t waitmask,
     {
       /* Do not use this in STM32_SDIO_MASK register */
 
-      waitmask &= !SDIOWAIT_WRCOMPLETE;
+      waitmask &= ~SDIOWAIT_WRCOMPLETE;
 
       pinset = GPIO_SDIO_D0 & (GPIO_PORT_MASK | GPIO_PIN_MASK);
       pinset |= (GPIO_INPUT | GPIO_FLOAT | GPIO_EXTI);
@@ -2513,7 +2513,12 @@ static sdio_eventset_t stm32_eventwait(FAR struct sdio_dev_s *dev,
    */
 
   flags = enter_critical_section();
-  DEBUGASSERT(priv->waitevents != 0 || priv->wkupevent != 0);
+
+  if (priv->waitevents == 0 && priv->wkupevent == 0)
+    {
+      wkupevent = SDIOWAIT_ERROR;
+      goto errout;
+    }
 
   /* Check if the timeout event is specified in the event set */
 

--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -1788,7 +1788,7 @@ static ssize_t mmcsd_writesingle(FAR struct mmcsd_state_s *priv,
 #if defined(CONFIG_MMCSD_SDIOWAIT_WRCOMPLETE)
   /* Arm the write complete detection with timeout */
 
-  SDIO_WAITENABLE(priv->dev, SDIOWAIT_WRCOMPLETE | SDIOWAIT_TIMEOUT);
+  SDIO_WAITENABLE(priv->dev, SDIOWAIT_WRCOMPLETE | SDIOWAIT_TIMEOUT | SDIOWAIT_ERROR);
 #endif
 
   /* On success, return the number of blocks written */


### PR DESCRIPTION
When the SD card has been ejected, a write() to the card never returns.

This only happens if CONFIG_SDIOWAIT_WRCOMPLETE is set.

It turns out that in the blocking case waitevents and wkupevent are both 0, hence we get stuck later waiting for a semaphore.

The "fix" is to check waitevents and wkupevent for 0 and return with an error for this case.

The other changes are drive-by changes but did no seem to make a difference.

This seems to fix:
https://github.com/PX4/Firmware/issues/12071
https://github.com/PX4/Firmware/issues/13087

@davids5 it looks like the regression/problem appeared with:
https://github.com/PX4/NuttX/commit/1ace391fcffcceb4f8c3672204383224063c551e