### PR TITLE
Px4 firmware nuttx 7.29+ sdio fixes

### DIFF
--- a/binfmt/elf.c
+++ b/binfmt/elf.c
@@ -238,7 +238,7 @@ static int elf_loadbinary(FAR struct binary_s *binp)
   if (ret != 0)
     {
       berr("Failed to initialize for load of ELF program: %d\n", ret);
-      goto errout;
+      goto errout_with_init;
     }
 
   /* Load the program binary */
@@ -309,7 +309,6 @@ errout_with_load:
   elf_unload(&loadinfo);
 errout_with_init:
   elf_uninit(&loadinfo);
-errout:
   return ret;
 }
 


### PR DESCRIPTION
[ch5378]: Px4 firmware nuttx 7.29+ sdio fixes

https://github.com/PX4/Firmware/issues/13087
https://github.com/PX4/Firmware/pull/13311
https://github.com/PX4/NuttX/pull/68/
