### PR TITLE
[WIP]: NuttX SPI DMA improvements

### DIFF
--- a/arch/arm/src/stm32/Kconfig
+++ b/arch/arm/src/stm32/Kconfig
@@ -8756,6 +8756,15 @@ config STM32_SPI1_DMA
 	---help---
 		Use DMA to improve SPI1 transfer performance.
 
+config STM32_SPI_DMATHRESHOLD
+	int "SPI DMA threshold"
+	default 4
+	depends on STM32_SPI_DMA
+	---help---
+		When SPI DMA is enabled, small DMA transfers will still be performed
+		by polling logic.  But we need a threshold value to determine what
+		is small.
+
 config STM32_SPI2_DMA
 	bool "SPI2 DMA"
 	default n

--- a/arch/arm/src/stm32f7/Kconfig
+++ b/arch/arm/src/stm32f7/Kconfig
@@ -2184,6 +2184,15 @@ config STM32F7_SPI_DMA
 	---help---
 		Use DMA to improve SPI transfer performance.  Cannot be used with STM32F7_SPI_INTERRUPT.
 
+config STM32F7_SPI_DMATHRESHOLD
+	int "SPI DMA threshold"
+	default 4
+	depends on STM32F7_SPI_DMA
+	---help---
+		When SPI DMA is enabled, small DMA transfers will still be performed
+		by polling logic.  But we need a threshold value to determine what
+		is small.
+
 config STM32F7_SPI1_DMA
 	bool "SPI1 DMA"
 	default n

--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -562,6 +562,15 @@ config STM32H7_SPI_DMA
 	---help---
 		Use DMA to improve SPI transfer performance.  Cannot be used with STM32H7_SPI_INTERRUPT.
 
+config STM32H7_SPI_DMATHRESHOLD
+	int "SPI DMA threshold"
+	default 4
+	depends on STM32H7_SPI_DMA
+	---help---
+		When SPI DMA is enabled, small DMA transfers will still be performed
+		by polling logic.  But we need a threshold value to determine what
+		is small.
+
 endmenu # "SPI Configuration"
 
 menu "U[S]ART Configuration"


### PR DESCRIPTION
TODO:
 - [ ] Add DMA buffers in SPI per channel
    - [ ] stm32
    - [ ] stm32f7
    - [ ] stm32h7
    - [ ] imxrt?
    - [ ] kinetis? (SPI DMA not needed here for PX4 due to particular sensors)
 - [ ] remove DMA capable check in SPI
 - [ ] DMA threshold option (possibly per channel) ce74734
 - [ ] generic NuttX mechanism for static buffer placement (LD sections, etc)
      - [ ] SPI DMA buffers
      - [ ] serial DMA buffers
      - [ ] serial DMA buffers
      - [ ] consider CONFIG_FAT_DMAMEMORY while we're at it?
 - [ ] stm32f7 dedicate SRAM2 100% to DMA
 - [ ] stm32h7 dedicate SRAM3 100% to DMA