### PR TITLE
[BACKPORT] stm32f7:Add Serial Tx DMA

### DIFF
--- a/arch/arm/src/stm32/Kconfig
+++ b/arch/arm/src/stm32/Kconfig
@@ -8020,6 +8020,14 @@ config USART1_RXDMA
 	---help---
 		In high data rate usage, Rx DMA may eliminate Rx overrun errors
 
+config USART1_TXDMA
+	bool "USART1 Tx DMA"
+	default n
+	depends on (((STM32_STM32F10XX || STM32_STM32L15XX) && STM32_DMA1) || (!STM32_STM32F10XX && STM32_DMA2))
+	select STM32_USART_TXDMA
+	---help---
+		In high data rate usage, Tx DMA may reduce CPU load
+
 endif # STM32_USART1_SERIALDRIVER
 
 if STM32_USART1_HCIUART
@@ -8106,6 +8114,14 @@ config USART2_RXDMA
 	select STM32_USART_RXDMA
 	---help---
 		In high data rate usage, Rx DMA may eliminate Rx overrun errors
+
+config USART2_TXDMA
+	bool "USART. Tx DMA"
+	default n
+	depends on STM32_DMA1
+	select STM32_USART_TXDMA
+	---help---
+		In high data rate usage, Tx DMA may reduce CPU load
 
 endif # STM32_USART2_SERIALDRIVER
 
@@ -8194,6 +8210,14 @@ config USART3_RXDMA
 	---help---
 		In high data rate usage, Rx DMA may eliminate Rx overrun errors
 
+config USART3_TXDMA
+	bool "USART. Tx DMA"
+	default n
+	depends on STM32_DMA1
+	select STM32_USART_TXDMA
+	---help---
+		In high data rate usage, Tx DMA may reduce CPU load
+
 endif # STM32_USART3_SERIALDRIVER
 
 if STM32_USART3_HCIUART
@@ -8276,6 +8300,14 @@ config UART4_RXDMA
 	---help---
 		In high data rate usage, Rx DMA may eliminate Rx overrun errors
 
+config UART4_TXDMA
+	bool "UART. Tx DMA"
+	default n
+	depends on STM32_DMA1
+	select STM32_USART_TXDMA
+	---help---
+		In high data rate usage, Tx DMA may reduce CPU load
+
 endif # STM32_UART4_SERIALDRIVER
 
 choice
@@ -8321,6 +8353,14 @@ config UART5_RXDMA
 	select STM32_USART_RXDMA
 	---help---
 		In high data rate usage, Rx DMA may eliminate Rx overrun errors
+
+config UART5_TXDMA
+	bool "UART. Tx DMA"
+	default n
+	depends on STM32_DMA1
+	select STM32_USART_TXDMA
+	---help---
+		In high data rate usage, Tx DMA may reduce CPU load
 
 endif # STM32_UART5_SERIALDRIVER
 
@@ -8372,6 +8412,14 @@ config USART6_RXDMA
 	select STM32_USART_RXDMA
 	---help---
 		In high data rate usage, Rx DMA may eliminate Rx overrun errors
+
+config USART6_TXDMA
+	bool "USART6 Tx DMA"
+	default n
+	depends on STM32_DMA2
+	select STM32_USART_TXDMA
+	---help---
+		In high data rate usage, Tx DMA may reduce CPU load
 
 endif # STM32_USART6_SERIALDRIVER
 
@@ -8455,10 +8503,18 @@ config UART7_RS485_DIR_POLARITY
 config UART7_RXDMA
 	bool "UART7 Rx DMA"
 	default n
-	depends on STM32_DMA2
+	depends on STM32_DMA1
 	select STM32_USART_RXDMA
 	---help---
 		In high data rate usage, Rx DMA may eliminate Rx overrun errors
+
+config UART7_TXDMA
+	bool "UART. Tx DMA"
+	default n
+	depends on STM32_DMA1
+	select STM32_USART_TXDMA
+	---help---
+		In high data rate usage, Tx DMA may reduce CPU load
 
 endif # STM32_UART7_SERIALDRIVER
 
@@ -8542,10 +8598,18 @@ config UART8_RS485_DIR_POLARITY
 config UART8_RXDMA
 	bool "UART8 Rx DMA"
 	default n
-	depends on STM32_DMA2
+	depends on STM32_DMA1
 	select STM32_USART_RXDMA
 	---help---
 		In high data rate usage, Rx DMA may eliminate Rx overrun errors
+
+config UART8_TXDMA
+	bool "UART. Tx DMA"
+	default n
+	depends on STM32_DMA1
+	select STM32_USART_TXDMA
+	---help---
+		In high data rate usage, Tx DMA may reduce CPU load
 
 endif # STM32_UART8_SERIALDRIVER
 
@@ -8668,7 +8732,7 @@ config STM32_HCIUART_RXDMA_BUFSIZE
 
 		Value given here will be rounded up to next multiple of 4 bytes.
 
-config STM32_HCIUART_DMAPRIO
+config STM32_HCIUART_RXDMAPRIO
 	hex "HCI UART DMA priority"
 	default 0x00001000 if STM32_STM32F10XX
 	default 0x00010000 if !STM32_STM32F10XX

--- a/arch/arm/src/stm32/stm32_hciuart.c
+++ b/arch/arm/src/stm32/stm32_hciuart.c
@@ -158,13 +158,13 @@
 
 /* DMA priority */
 
-#  ifndef CONFIG_STM32_HCIUART_DMAPRIO
+#  ifndef CONFIG_STM32_HCIUART_RXDMAPRIO
 #    if defined(CONFIG_STM32_STM32L15XX) || defined(CONFIG_STM32_STM32F10XX) || \
         defined(CONFIG_STM32_STM32F30XX) || defined(CONFIG_STM32_STM32F33XX) || \
         defined(CONFIG_STM32_STM32F37XX)
-#      define CONFIG_STM32_HCIUART_DMAPRIO  DMA_CCR_PRIMED
+#      define CONFIG_STM32_HCIUART_RXDMAPRIO  DMA_CCR_PRIMED
 #    elif defined(CONFIG_STM32_STM32F20XX) || defined(CONFIG_STM32_STM32F4XXX)
-#      define CONFIG_STM32_HCIUART_DMAPRIO  DMA_SCR_PRIMED
+#      define CONFIG_STM32_HCIUART_RXDMAPRIO  DMA_SCR_PRIMED
 #    else
 #      error "Unknown STM32 DMA"
 #    endif
@@ -172,12 +172,12 @@
 #    if defined(CONFIG_STM32_STM32L15XX) || defined(CONFIG_STM32_STM32F10XX) || \
         defined(CONFIG_STM32_STM32F30XX) || defined(CONFIG_STM32_STM32F33XX) || \
         defined(CONFIG_STM32_STM32F37XX)
-#    if (CONFIG_STM32_HCIUART_DMAPRIO & ~DMA_CCR_PL_MASK) != 0
-#      error "Illegal value for CONFIG_STM32_HCIUART_DMAPRIO"
+#    if (CONFIG_STM32_HCIUART_RXDMAPRIO & ~DMA_CCR_PL_MASK) != 0
+#      error "Illegal value for CONFIG_STM32_HCIUART_RXDMAPRIO"
 #    endif
 #  elif defined(CONFIG_STM32_STM32F20XX) || defined(CONFIG_STM32_STM32F4XXX)
-#    if (CONFIG_STM32_HCIUART_DMAPRIO & ~DMA_SCR_PL_MASK) != 0
-#      error "Illegal value for CONFIG_STM32_HCIUART_DMAPRIO"
+#    if (CONFIG_STM32_HCIUART_RXDMAPRIO & ~DMA_SCR_PL_MASK) != 0
+#      error "Illegal value for CONFIG_STM32_HCIUART_RXDMAPRIO"
 #    endif
 #  else
 #    error "Unknown STM32 DMA"
@@ -192,7 +192,7 @@
                  DMA_SCR_MINC          | \
                  DMA_SCR_PSIZE_8BITS   | \
                  DMA_SCR_MSIZE_8BITS   | \
-                 CONFIG_STM32_HCIUART_DMAPRIO  | \
+                 CONFIG_STM32_HCIUART_RXDMAPRIO  | \
                  DMA_SCR_PBURST_SINGLE | \
                  DMA_SCR_MBURST_SINGLE)
 #  else
@@ -201,7 +201,7 @@
                  DMA_CCR_MINC          | \
                  DMA_CCR_PSIZE_8BITS   | \
                  DMA_CCR_MSIZE_8BITS   | \
-                 CONFIG_STM32_HCIUART_DMAPRIO)
+                 CONFIG_STM32_HCIUART_RXDMAPRIO)
 # endif
 #endif
 

--- a/arch/arm/src/stm32/stm32_serial.c
+++ b/arch/arm/src/stm32/stm32_serial.c
@@ -79,7 +79,7 @@
  * have also been selected.
  */
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 
 #  if defined(CONFIG_STM32_STM32F20XX) || defined(CONFIG_STM32_STM32F4XXX)
 /* Verify that DMA has been enabled and the DMA channel has been defined.
@@ -194,13 +194,13 @@
 
 /* DMA priority */
 
-#  ifndef CONFIG_USART_DMAPRIO
+#  ifndef CONFIG_USART_RXDMAPRIO
 #    if defined(CONFIG_STM32_STM32L15XX) || defined(CONFIG_STM32_STM32F10XX) || \
         defined(CONFIG_STM32_STM32F30XX) || defined(CONFIG_STM32_STM32F33XX) || \
         defined(CONFIG_STM32_STM32F37XX)
-#      define CONFIG_USART_DMAPRIO  DMA_CCR_PRIMED
+#      define CONFIG_USART_RXDMAPRIO  DMA_CCR_PRIMED
 #    elif defined(CONFIG_STM32_STM32F20XX) || defined(CONFIG_STM32_STM32F4XXX)
-#      define CONFIG_USART_DMAPRIO  DMA_SCR_PRIMED
+#      define CONFIG_USART_RXDMAPRIO  DMA_SCR_PRIMED
 #    else
 #      error "Unknown STM32 DMA"
 #    endif
@@ -208,12 +208,12 @@
 #    if defined(CONFIG_STM32_STM32L15XX) || defined(CONFIG_STM32_STM32F10XX) || \
         defined(CONFIG_STM32_STM32F30XX) || defined(CONFIG_STM32_STM32F33XX) || \
         defined(CONFIG_STM32_STM32F37XX)
-#    if (CONFIG_USART_DMAPRIO & ~DMA_CCR_PL_MASK) != 0
-#      error "Illegal value for CONFIG_USART_DMAPRIO"
+#    if (CONFIG_USART_RXDMAPRIO & ~DMA_CCR_PL_MASK) != 0
+#      error "Illegal value for CONFIG_USART_RXDMAPRIO"
 #    endif
 #  elif defined(CONFIG_STM32_STM32F20XX) || defined(CONFIG_STM32_STM32F4XXX)
-#    if (CONFIG_USART_DMAPRIO & ~DMA_SCR_PL_MASK) != 0
-#      error "Illegal value for CONFIG_USART_DMAPRIO"
+#    if (CONFIG_USART_RXDMAPRIO & ~DMA_SCR_PL_MASK) != 0
+#      error "Illegal value for CONFIG_USART_RXDMAPRIO"
 #    endif
 #  else
 #    error "Unknown STM32 DMA"
@@ -222,14 +222,14 @@
 /* DMA control word */
 
 #  if defined(CONFIG_STM32_STM32F20XX) || defined(CONFIG_STM32_STM32F4XXX)
-#    define SERIAL_DMA_CONTROL_WORD      \
-                (DMA_SCR_DIR_P2M       | \
-                 DMA_SCR_CIRC          | \
-                 DMA_SCR_MINC          | \
-                 DMA_SCR_PSIZE_8BITS   | \
-                 DMA_SCR_MSIZE_8BITS   | \
-                 CONFIG_USART_DMAPRIO  | \
-                 DMA_SCR_PBURST_SINGLE | \
+#    define SERIAL_DMA_CONTROL_WORD       \
+                (DMA_SCR_DIR_P2M        | \
+                 DMA_SCR_CIRC           | \
+                 DMA_SCR_MINC           | \
+                 DMA_SCR_PSIZE_8BITS    | \
+                 DMA_SCR_MSIZE_8BITS    | \
+                 CONFIG_USART_RXDMAPRIO | \
+                 DMA_SCR_PBURST_SINGLE  | \
                  DMA_SCR_MBURST_SINGLE)
 #  else
 #    define SERIAL_DMA_CONTROL_WORD      \
@@ -237,7 +237,7 @@
                  DMA_CCR_MINC          | \
                  DMA_CCR_PSIZE_8BITS   | \
                  DMA_CCR_MSIZE_8BITS   | \
-                 CONFIG_USART_DMAPRIO)
+                 CONFIG_USART_RXDMAPRIO)
 # endif
 
 #endif
@@ -324,13 +324,13 @@ struct up_dev_s
   const uint32_t    cts_gpio;  /* U[S]ART CTS GPIO pin configuration */
 #endif
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
   const unsigned int rxdma_channel; /* DMA channel assigned */
 #endif
 
   /* RX DMA state */
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
   DMA_HANDLE        rxdma;     /* currently-open receive DMA stream */
   bool              rxenable;  /* DMA-based reception en/disable */
   uint32_t          rxdmanext; /* Next byte in the DMA buffer to be read */
@@ -367,7 +367,7 @@ static void up_send(struct uart_dev_s *dev, int ch);
 static void up_txint(struct uart_dev_s *dev, bool enable);
 static bool up_txready(struct uart_dev_s *dev);
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static int  up_dma_setup(struct uart_dev_s *dev);
 static void up_dma_shutdown(struct uart_dev_s *dev);
 static int  up_dma_receive(struct uart_dev_s *dev, unsigned int *status);
@@ -409,7 +409,7 @@ static const struct uart_ops_s g_uart_ops =
 };
 #endif
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static const struct uart_ops_s g_uart_dma_ops =
 {
   .setup          = up_dma_setup,
@@ -1149,7 +1149,7 @@ static void up_disableusartint(struct up_dev_s *priv, uint16_t *ie)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static int up_dma_nextrx(struct up_dev_s *priv)
 {
   size_t dmaresidual;
@@ -1576,7 +1576,7 @@ static int up_setup(struct uart_dev_s *dev)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static int up_dma_setup(struct uart_dev_s *dev)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
@@ -1703,7 +1703,7 @@ static void up_shutdown(struct uart_dev_s *dev)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static void up_dma_shutdown(struct uart_dev_s *dev)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
@@ -2371,7 +2371,7 @@ static bool up_rxflowcontrol(struct uart_dev_s *dev,
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static int up_dma_receive(struct uart_dev_s *dev, unsigned int *status)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
@@ -2400,7 +2400,7 @@ static int up_dma_receive(struct uart_dev_s *dev, unsigned int *status)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static void up_dma_rxint(struct uart_dev_s *dev, bool enable)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
@@ -2425,7 +2425,7 @@ static void up_dma_rxint(struct uart_dev_s *dev, bool enable)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static bool up_dma_rxavailable(struct uart_dev_s *dev)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
@@ -2546,7 +2546,7 @@ static bool up_txready(struct uart_dev_s *dev)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static void up_dma_rxcallback(DMA_HANDLE handle, uint8_t status, void *arg)
 {
   struct up_dev_s *priv = (struct up_dev_s *)arg;
@@ -2824,7 +2824,7 @@ void up_serialinit(void)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 void stm32_serial_dma_poll(void)
 {
     irqstate_t flags;

--- a/arch/arm/src/stm32/stm32_uart.h
+++ b/arch/arm/src/stm32/stm32_uart.h
@@ -325,12 +325,12 @@
 
 /* Is DMA available on any (enabled) USART? */
 
-#undef SERIAL_HAVE_DMA
+#undef SERIAL_HAVE_RXDMA
 #if defined(CONFIG_USART1_RXDMA) || defined(CONFIG_USART2_RXDMA) || \
     defined(CONFIG_USART3_RXDMA) || defined(CONFIG_UART4_RXDMA)  || \
     defined(CONFIG_UART5_RXDMA)  || defined(CONFIG_USART6_RXDMA) || \
     defined(CONFIG_UART7_RXDMA)  || defined(CONFIG_UART8_RXDMA)
-#  define SERIAL_HAVE_DMA 1
+#  define SERIAL_HAVE_RXDMA 1
 #endif
 
 /* Is DMA used on the console UART? */
@@ -436,7 +436,7 @@ FAR uart_dev_t *stm32_serial_get_uart(int uart_num);
  *
  ************************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 void stm32_serial_dma_poll(void);
 #endif
 

--- a/arch/arm/src/stm32f0l0g0/stm32_serial_v1.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_serial_v1.c
@@ -91,7 +91,7 @@
  *    5       X
  */
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 
 /* Verify that DMA has been enabled and the DMA channel has been defined.
  */
@@ -146,11 +146,11 @@
 
 /* DMA priority */
 
-#  ifndef CONFIG_USART_DMAPRIO
-#    define CONFIG_USART_DMAPRIO  DMA_CCR_PRIMED
+#  ifndef CONFIG_USART_RXDMAPRIO
+#    define CONFIG_USART_RXDMAPRIO  DMA_CCR_PRIMED
 #  endif
-#  if (CONFIG_USART_DMAPRIO & ~DMA_CCR_PL_MASK) != 0
-#    error "Illegal value for CONFIG_USART_DMAPRIO"
+#  if (CONFIG_USART_RXDMAPRIO & ~DMA_CCR_PL_MASK) != 0
+#    error "Illegal value for CONFIG_USART_RXDMAPRIO"
 #  endif
 
 /* DMA control words */
@@ -160,13 +160,13 @@
                DMA_CCR_MINC          | \
                DMA_CCR_PSIZE_8BITS   | \
                DMA_CCR_MSIZE_8BITS   | \
-               CONFIG_USART_DMAPRIO)
+               CONFIG_USART_RXDMAPRIO)
 #  ifdef CONFIG_SERIAL_IFLOWCONTROL
 #    define SERIAL_DMA_IFLOW_CONTROL_WORD \
               (DMA_CCR_MINC          | \
                DMA_CCR_PSIZE_8BITS   | \
                DMA_CCR_MSIZE_8BITS   | \
-               CONFIG_USART_DMAPRIO)
+               CONFIG_USART_RXDMAPRIO)
 #  endif
 
 #endif
@@ -249,13 +249,13 @@ struct stm32_serial_s
   const uint32_t    cts_gpio;  /* U[S]ART CTS GPIO pin configuration */
 #endif
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
   const unsigned int rxdma_channel; /* DMA channel assigned */
 #endif
 
   /* RX DMA state */
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
   DMA_HANDLE        rxdma;     /* currently-open receive DMA stream */
   bool              rxenable;  /* DMA-based reception en/disable */
   uint32_t          rxdmanext; /* Next byte in the DMA buffer to be read */
@@ -296,7 +296,7 @@ static void stm32serial_send(FAR struct uart_dev_s *dev, int ch);
 static void stm32serial_txint(FAR struct uart_dev_s *dev, bool enable);
 static bool stm32serial_txready(FAR struct uart_dev_s *dev);
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static int  stm32serial_dmasetup(FAR struct uart_dev_s *dev);
 static void stm32serial_dmashutdown(FAR struct uart_dev_s *dev);
 static int  stm32serial_dmareceive(FAR struct uart_dev_s *dev,
@@ -340,7 +340,7 @@ static const struct uart_ops_s g_uart_ops =
 };
 #endif
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static const struct uart_ops_s g_uart_dma_ops =
 {
   .setup          = stm32serial_dmasetup,
@@ -872,7 +872,7 @@ static void stm32serial_disableusartint(FAR struct stm32_serial_s *priv,
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static int stm32serial_dmanextrx(FAR struct stm32_serial_s *priv)
 {
   size_t dmaresidual;
@@ -1212,7 +1212,7 @@ static int stm32serial_setup(FAR struct uart_dev_s *dev)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static int stm32serial_dmasetup(FAR struct uart_dev_s *dev)
 {
   FAR struct stm32_serial_s *priv = (FAR struct stm32_serial_s *)dev->priv;
@@ -1366,7 +1366,7 @@ static void stm32serial_shutdown(FAR struct uart_dev_s *dev)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static void stm32serial_dmashutdown(FAR struct uart_dev_s *dev)
 {
   FAR struct stm32_serial_s *priv = (FAR struct stm32_serial_s *)dev->priv;
@@ -1990,7 +1990,7 @@ static bool stm32serial_rxflowcontrol(FAR struct uart_dev_s *dev,
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static int stm32serial_dmareceive(FAR struct uart_dev_s *dev,
                                   FAR unsigned int *status)
 {
@@ -2031,7 +2031,7 @@ static int stm32serial_dmareceive(FAR struct uart_dev_s *dev,
  *
  ****************************************************************************/
 
-#if defined(SERIAL_HAVE_DMA) && defined(CONFIG_SERIAL_IFLOWCONTROL)
+#if defined(SERIAL_HAVE_RXDMA) && defined(CONFIG_SERIAL_IFLOWCONTROL)
 static void stm32serial_dmareenable(FAR struct stm32_serial_s *priv)
 {
   /* Configure for non-circular DMA reception into the RX fifo */
@@ -2066,7 +2066,7 @@ static void stm32serial_dmareenable(FAR struct stm32_serial_s *priv)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static void stm32serial_dmarxint(FAR struct uart_dev_s *dev, bool enable)
 {
   FAR struct stm32_serial_s *priv = (FAR struct stm32_serial_s *)dev->priv;
@@ -2100,7 +2100,7 @@ static void stm32serial_dmarxint(FAR struct uart_dev_s *dev, bool enable)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static bool stm32serial_dmarxavailable(FAR struct uart_dev_s *dev)
 {
   FAR struct stm32_serial_s *priv = (FAR struct stm32_serial_s *)dev->priv;
@@ -2225,7 +2225,7 @@ static bool stm32serial_txready(FAR struct uart_dev_s *dev)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static void stm32serial_dmarxcallback(DMA_HANDLE handle, uint8_t status,
                                         FAR void *arg)
 {
@@ -2486,7 +2486,7 @@ void up_serialinit(void)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 void stm32serial_dmapoll(void)
 {
     irqstate_t flags;

--- a/arch/arm/src/stm32f0l0g0/stm32_uart.h
+++ b/arch/arm/src/stm32f0l0g0/stm32_uart.h
@@ -349,12 +349,12 @@
 
 /* Is DMA available on any (enabled) USART? */
 
-#undef SERIAL_HAVE_DMA
+#undef SERIAL_HAVE_RXDMA
 #if defined(CONFIG_USART1_RXDMA) || defined(CONFIG_USART2_RXDMA) || \
     defined(CONFIG_USART3_RXDMA) || defined(CONFIG_USART4_RXDMA)  || \
     defined(CONFIG_USART5_RXDMA)  || defined(CONFIG_USART6_RXDMA) || \
     defined(CONFIG_USART7_RXDMA)  || defined(CONFIG_USART8_RXDMA)
-#  define SERIAL_HAVE_DMA 1
+#  define SERIAL_HAVE_RXDMA 1
 #endif
 
 /* Is DMA used on the console USART? */
@@ -450,7 +450,7 @@ extern "C"
  *
  ************************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 void stm32_serial_dma_poll(void);
 #endif
 

--- a/arch/arm/src/stm32f7/Kconfig
+++ b/arch/arm/src/stm32f7/Kconfig
@@ -1738,6 +1738,13 @@ config USART1_RXDMA
 	---help---
 		In high data rate usage, Rx DMA may eliminate Rx overrun errors
 
+config USART1_TXDMA
+	bool "USART1 Tx DMA"
+	default n
+	depends on STM32F7_USART1 && STM32F7_DMA2
+	---help---
+		In high data rate usage, Rx DMA may reduce CPU Load
+
 config USART2_RS485
 	bool "RS-485 on USART2"
 	default n
@@ -1762,6 +1769,13 @@ config USART2_RXDMA
 	depends on STM32F7_USART2 && STM32F7_DMA1
 	---help---
 		In high data rate usage, Rx DMA may eliminate Rx overrun errors
+
+config USART2_TXDMA
+	bool "USART2 Tx DMA"
+	default n
+	depends on STM32F7_USART2 && STM32F7_DMA1
+	---help---
+		In high data rate usage, Rx DMA may reduce CPU Load
 
 config USART3_RS485
 	bool "RS-485 on USART3"
@@ -1788,6 +1802,13 @@ config USART3_RXDMA
 	---help---
 		In high data rate usage, Rx DMA may eliminate Rx overrun errors
 
+config USART3_TXDMA
+	bool "USART3 Tx DMA"
+	default n
+	depends on STM32F7_USART3 && STM32F7_DMA1
+	---help---
+		In high data rate usage, Rx DMA may reduce CPU Load
+
 config UART4_RS485
 	bool "RS-485 on UART4"
 	default n
@@ -1812,6 +1833,13 @@ config UART4_RXDMA
 	depends on STM32F7_UART4 && STM32F7_DMA1
 	---help---
 		In high data rate usage, Rx DMA may eliminate Rx overrun errors
+
+config UART4_TXDMA
+	bool "UART4 Tx DMA"
+	default n
+	depends on STM32F7_UART4 && STM32F7_DMA1
+	---help---
+		In high data rate usage, Rx DMA may reduce CPU Load
 
 config UART5_RS485
 	bool "RS-485 on UART5"
@@ -1838,6 +1866,13 @@ config UART5_RXDMA
 	---help---
 		In high data rate usage, Rx DMA may eliminate Rx overrun errors
 
+config UART5_TXDMA
+	bool "UART5 Tx DMA"
+	default n
+	depends on STM32F7_UART5 && STM32F7_DMA1
+	---help---
+		In high data rate usage, Rx DMA may reduce CPU Load
+
 config USART6_RS485
 	bool "RS-485 on USART6"
 	default n
@@ -1863,6 +1898,13 @@ config USART6_RXDMA
 	---help---
 		In high data rate usage, Rx DMA may eliminate Rx overrun errors
 
+config USART6_TXDMA
+	bool "USART6 Tx DMA"
+	default n
+	depends on STM32F7_USART6 && STM32F7_DMA2
+	---help---
+		In high data rate usage, Rx DMA may reduce CPU Load
+
 config UART7_RS485
 	bool "RS-485 on UART7"
 	default n
@@ -1884,9 +1926,16 @@ config UART7_RS485_DIR_POLARITY
 config UART7_RXDMA
 	bool "UART7 Rx DMA"
 	default n
-	depends on STM32F7_UART7 && STM32F7_DMA2
+	depends on STM32F7_UART7 && STM32F7_DMA1
 	---help---
 		In high data rate usage, Rx DMA may eliminate Rx overrun errors
+
+config UART7_TXDMA
+	bool "UART7 Tx DMA"
+	default n
+	depends on STM32F7_UART7 && STM32F7_DMA1
+	---help---
+		In high data rate usage, Rx DMA may reduce CPU Load
 
 config UART8_RS485
 	bool "RS-485 on UART8"
@@ -1909,9 +1958,16 @@ config UART8_RS485_DIR_POLARITY
 config UART8_RXDMA
 	bool "UART8 Rx DMA"
 	default n
-	depends on STM32F7_UART8 && STM32F7_DMA2
+	depends on STM32F7_UART8 && STM32F7_DMA1
 	---help---
 		In high data rate usage, Rx DMA may eliminate Rx overrun errors
+
+config UART8_TXDMA
+	bool "UART8 Tx DMA"
+	default n
+	depends on STM32F7_UART8 && STM32F7_DMA1
+	---help---
+		In high data rate usage, Rx DMA may reduce CPU Load
 
 config STM32F7_SERIAL_RXDMA_BUFFER_SIZE
 	int "Rx DMA buffer size"

--- a/arch/arm/src/stm32f7/stm32_serial.c
+++ b/arch/arm/src/stm32f7/stm32_serial.c
@@ -87,7 +87,7 @@
  * have also been selected.
  */
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 
 /* Verify that DMA has been enabled and the DMA channel has been defined.
  */
@@ -121,7 +121,7 @@
 #    error "RXDMA and RS-485 cannot be enabled at the same time for the same U[S]ART"
 #  endif
 
-/* There may be alternate DMA channels for each U[S]ART.  Logic in the
+/* There may be alternate DMA channels for USART 1 & 6.  Logic in the
  * board.h file should provide definitions to select among the alternatives.
  */
 
@@ -129,32 +129,8 @@
 #    error "USART1 DMA channel not defined (DMAMAP_USART1_RX)"
 #  endif
 
-#  if defined(CONFIG_USART2_RXDMA) && !defined(DMAMAP_USART2_RX)
-#    error "USART2 DMA channel not defined (DMAMAP_USART2_RX)"
-#  endif
-
-#  if defined(CONFIG_USART3_RXDMA) && !defined(DMAMAP_USART3_RX)
-#    error "USART3 DMA channel not defined (DMAMAP_USART3_RX)"
-#  endif
-
-#  if defined(CONFIG_UART4_RXDMA) && !defined(DMAMAP_UART4_RX)
-#    error "UART4 DMA channel not defined (DMAMAP_UART4_RX)"
-#  endif
-
-#  if defined(CONFIG_UART5_RXDMA) && !defined(DMAMAP_UART5_RX)
-#    error "UART5 DMA channel not defined (DMAMAP_UART5_RX)"
-#  endif
-
 #  if defined(CONFIG_USART6_RXDMA) && !defined(DMAMAP_USART6_RX)
 #    error "USART6 DMA channel not defined (DMAMAP_USART6_RX)"
-#  endif
-
-#  if defined(CONFIG_UART7_RXDMA) && !defined(DMAMAP_UART7_RX)
-#    error "UART7 DMA channel not defined (DMAMAP_UART7_RX)"
-#  endif
-
-#  if defined(CONFIG_UART8_RXDMA) && !defined(DMAMAP_UART8_RX)
-#    error "UART8 DMA channel not defined (DMAMAP_UART8_RX)"
 #  endif
 
 /* The DMA buffer size when using RX DMA to emulate a FIFO.
@@ -186,26 +162,186 @@
 
 /* DMA priority */
 
-#  ifndef CONFIG_USART_DMAPRIO
-#      define CONFIG_USART_DMAPRIO  DMA_SCR_PRIMED
+#  ifndef CONFIG_USART_RXDMAPRIO
+#      define CONFIG_USART_RXDMAPRIO  DMA_SCR_PRIMED
 #  endif
 
-#  if (CONFIG_USART_DMAPRIO & ~DMA_SCR_PL_MASK) != 0
-#    error "Illegal value for CONFIG_USART_DMAPRIO"
+#  if (CONFIG_USART_RXDMAPRIO & ~DMA_SCR_PL_MASK) != 0
+#    error "Illegal value for CONFIG_USART_RXDMAPRIO"
 #  endif
 
 /* DMA control words */
 
-#  define SERIAL_DMA_CONTROL_WORD      \
-              (DMA_SCR_DIR_P2M       | \
-               DMA_SCR_CIRC          | \
-               DMA_SCR_MINC          | \
-               DMA_SCR_PSIZE_8BITS   | \
-               DMA_SCR_MSIZE_8BITS   | \
-               CONFIG_USART_DMAPRIO  | \
-               DMA_SCR_PBURST_SINGLE | \
+#  define SERIAL_RXDMA_CONTROL_WORD   \
+              (DMA_SCR_DIR_P2M        | \
+               DMA_SCR_CIRC           | \
+               DMA_SCR_MINC           | \
+               DMA_SCR_PSIZE_8BITS    | \
+               DMA_SCR_MSIZE_8BITS    | \
+               CONFIG_USART_RXDMAPRIO | \
+               DMA_SCR_PBURST_SINGLE  | \
                DMA_SCR_MBURST_SINGLE)
-#endif /* SERIAL_HAVE_DMA */
+#endif /* SERIAL_HAVE_RXDMA */
+
+/* Verify that DMA has been enabled and the DMA channel has been defined.
+ */
+
+#if defined(CONFIG_USART1_TXDMA) || defined(CONFIG_USART6_TXDMA)
+#  ifndef CONFIG_STM32F7_DMA2
+#    error STM32 USART1/6 transmit DMA requires CONFIG_STM32F7_DMA2
+#  endif
+#endif
+
+#if defined(CONFIG_USART2_TXDMA) || defined(CONFIG_USART3_TXDMA) || \
+    defined(CONFIG_UART4_TXDMA) || defined(CONFIG_UART5_TXDMA) || \
+    defined(CONFIG_UART7_TXDMA) || defined(CONFIG_UART8_TXDMA)
+#  ifndef CONFIG_STM32F7_DMA1
+#    error STM32 USART2/3/4/5/7/8 transmit DMA requires CONFIG_STM32F7_DMA1
+#  endif
+#endif
+
+/* Currently RS-485 support cannot be enabled when TXDMA is in use due to lack
+ * of testing - RS-485 support was developed on STM32F1x
+ */
+
+#if (defined(CONFIG_USART1_TXDMA) && defined(CONFIG_USART1_RS485)) || \
+    (defined(CONFIG_USART2_TXDMA) && defined(CONFIG_USART2_RS485)) || \
+    (defined(CONFIG_USART3_TXDMA) && defined(CONFIG_USART3_RS485)) || \
+    (defined(CONFIG_UART4_TXDMA) && defined(CONFIG_UART4_RS485)) || \
+    (defined(CONFIG_UART5_TXDMA) && defined(CONFIG_UART5_RS485)) || \
+    (defined(CONFIG_USART6_TXDMA) && defined(CONFIG_USART6_RS485)) || \
+    (defined(CONFIG_UART7_TXDMA) && defined(CONFIG_UART7_RS485)) || \
+    (defined(CONFIG_UART8_TXDMA) && defined(CONFIG_UART8_RS485))
+#  error "TXDMA and RS-485 cannot be enabled at the same time for the same U[S]ART"
+#endif
+
+/* There may be alternate DMA channels for USART 1 & 6.  Logic in the
+ * board.h file should provide definitions to select among the alternatives.
+ */
+
+#  if defined(CONFIG_USART1_TXDMA) && !defined(DMAMAP_USART1_TX)
+#    error "USART1 DMA channel not defined (DMAMAP_USART1_TX)"
+#  endif
+
+#  if defined(CONFIG_USART6_TXDMA) && !defined(DMAMAP_USART6_TX)
+#    error "USART6 DMA channel not defined (DMAMAP_USART6_TX)"
+#  endif
+
+/* The DMA buffer size when using TX DMA.
+ *
+ * This TX buffer size should be an even multiple of the Cortex-M7 D-Cache line
+ * size, ARMV7M_DCACHE_LINESIZE, so that it can be individually invalidated.
+ *
+ * Should there be a Cortex-M7 without a D-Cache, ARMV7M_DCACHE_LINESIZE
+ * would be zero!
+ */
+
+#if !defined(ARMV7M_DCACHE_LINESIZE) || ARMV7M_DCACHE_LINESIZE == 0
+#  undef ARMV7M_DCACHE_LINESIZE
+#  define ARMV7M_DCACHE_LINESIZE 32
+#endif
+
+#define TXDMA_BUFFER_MASK   (ARMV7M_DCACHE_LINESIZE - 1)
+#define TXDMA_BUFFER_SIZE   ((CONFIG_STM32F7_SERIAL_RXDMA_BUFFER_SIZE \
+                              + RXDMA_BUFFER_MASK) & ~RXDMA_BUFFER_MASK)
+
+/* If built with CONFIG_ARMV7M_DCACHE Buffers need to be aligned and multiples
+ * of ARMV7M_DCACHE_LINESIZE
+ */
+
+#if defined(CONFIG_ARMV7M_DCACHE)
+#  define TXDMA_BUF_SIZE(b) (((b) + TXDMA_BUFFER_MASK) & ~TXDMA_BUFFER_MASK)
+#  define TXDMA_BUF_ALIGN   aligned_data(ARMV7M_DCACHE_LINESIZE);
+#else
+#  define TXDMA_BUF_SIZE(b)  (b)
+#  define TXDMA_BUF_ALIGN
+#endif
+
+#if !defined(CONFIG_USART1_TXDMA)
+#  define USART1_TXBUFSIZE_ADJUSTED  CONFIG_USART1_TXBUFSIZE
+#  define USART1_TXBUFSIZE_ALGN
+#else
+#  define USART1_TXBUFSIZE_ADJUSTED TXDMA_BUF_SIZE(CONFIG_USART1_TXBUFSIZE)
+#  define USART1_TXBUFSIZE_ALGN TXDMA_BUF_ALIGN
+#endif
+
+#if !defined(CONFIG_USART2_TXDMA)
+#  define USART2_TXBUFSIZE_ADJUSTED  CONFIG_USART2_TXBUFSIZE
+#  define USART2_TXBUFSIZE_ALGN
+#else
+#  define USART2_TXBUFSIZE_ADJUSTED TXDMA_BUF_SIZE(CONFIG_USART2_TXBUFSIZE)
+#  define USART2_TXBUFSIZE_ALGN TXDMA_BUF_ALIGN
+#endif
+
+#if !defined(CONFIG_USART3_TXDMA)
+#  define USART3_TXBUFSIZE_ADJUSTED  CONFIG_USART3_TXBUFSIZE
+#  define USART3_TXBUFSIZE_ALGN
+#else
+#  define USART3_TXBUFSIZE_ADJUSTED TXDMA_BUF_SIZE(CONFIG_USART3_TXBUFSIZE)
+#  define USART3_TXBUFSIZE_ALGN TXDMA_BUF_ALIGN
+#endif
+
+#if !defined(CONFIG_UART4_TXDMA)
+#  define UART4_TXBUFSIZE_ADJUSTED  CONFIG_UART4_TXBUFSIZE
+#  define UART4_TXBUFSIZE_ALGN
+#else
+#  define UART4_TXBUFSIZE_ADJUSTED TXDMA_BUF_SIZE(CONFIG_UART4_TXBUFSIZE)
+#  define UART4_TXBUFSIZE_ALGN TXDMA_BUF_ALIGN
+#endif
+
+#if !defined(CONFIG_UART5_TXDMA)
+#  define UART5_TXBUFSIZE_ADJUSTED  CONFIG_UART5_TXBUFSIZE
+#  define UART5_TXBUFSIZE_ALGN
+#else
+#  define UART5_TXBUFSIZE_ADJUSTED TXDMA_BUF_SIZE(CONFIG_UART5_TXBUFSIZE)
+#  define UART5_TXBUFSIZE_ALGN TXDMA_BUF_ALIGN
+#endif
+
+#if !defined(CONFIG_USART6_TXDMA)
+#  define USART6_TXBUFSIZE_ADJUSTED  CONFIG_USART6_TXBUFSIZE
+#  define USART6_TXBUFSIZE_ALGN
+#else
+#  define USART6_TXBUFSIZE_ADJUSTED TXDMA_BUF_SIZE(CONFIG_USART6_TXBUFSIZE)
+#  define USART6_TXBUFSIZE_ALGN TXDMA_BUF_ALIGN
+#endif
+
+#if !defined(CONFIG_UART7_TXDMA)
+#  define UART7_TXBUFSIZE_ADJUSTED  CONFIG_UART7_TXBUFSIZE
+#  define UART7_TXBUFSIZE_ALGN
+#else
+#  define UART7_TXBUFSIZE_ADJUSTED TXDMA_BUF_SIZE(CONFIG_UART7_TXBUFSIZE)
+#  define UART7_TXBUFSIZE_ALGN TXDMA_BUF_ALIGN
+#endif
+
+#if !defined(CONFIG_UART8_TXDMA)
+#  define UART8_TXBUFSIZE_ADJUSTED  CONFIG_UART8_TXBUFSIZE
+#  define UART8_TXBUFSIZE_ALGN
+#else
+#  define UART8_TXBUFSIZE_ADJUSTED TXDMA_BUF_SIZE(CONFIG_UART8_TXBUFSIZE)
+#  define UART8_TXBUFSIZE_ALGN TXDMA_BUF_ALIGN
+#endif
+
+#if SERIAL_HAVE_TXDMA
+/* DMA priority */
+
+#  ifndef CONFIG_USART_TXDMAPRIO
+#      define CONFIG_USART_TXDMAPRIO  DMA_SCR_PRIMED
+#  endif
+
+#  if (CONFIG_USART_TXDMAPRIO & ~DMA_SCR_PL_MASK) != 0
+#    error "Illegal value for CONFIG_USART_TXDMAPRIO"
+#  endif
+
+#  define SERIAL_TXDMA_CONTROL_WORD     \
+              (DMA_SCR_DIR_M2P        | \
+               DMA_SCR_MINC           | \
+               DMA_SCR_PSIZE_8BITS    | \
+               DMA_SCR_MSIZE_8BITS    | \
+               DMA_SCR_PBURST_SINGLE  | \
+               DMA_SCR_MBURST_SINGLE  | \
+               CONFIG_USART_TXDMAPRIO)
+
+#endif /* SERIAL_HAVE_TXDMA */
 
 /* Power management definitions */
 
@@ -215,6 +351,14 @@
 #if defined(CONFIG_PM)
 #  define PM_IDLE_DOMAIN             0 /* Revisit */
 #endif
+
+/* Since RX DMA or TX DMA or both may be enabled for a given U[S]ART.
+ * We need runtime detection in up_dma_setup and up_dma_shutdown
+ * We use the default struct default init value of 0 which maps to
+ * STM32_DMA_MAP(DMA1,DMA_STREAM0,DMA_CHAN0) which is not a U[S]ART.
+ */
+
+#define INVALID_SERIAL_DMA_CHANNEL 0
 
 /* Keep track if a Break was set
  *
@@ -350,13 +494,17 @@ struct up_dev_s
   const uint32_t    cts_gpio;   /* U[S]ART CTS GPIO pin configuration */
 #endif
 
-#ifdef SERIAL_HAVE_DMA
-  const unsigned int rxdma_channel; /* DMA channel assigned */
+  /* TX DMA state */
+
+#ifdef SERIAL_HAVE_TXDMA
+  const unsigned int txdma_channel; /* DMA channel assigned */
+  DMA_HANDLE        txdma;      /* currently-open trasnmit DMA stream */
 #endif
 
   /* RX DMA state */
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
+  const unsigned int rxdma_channel; /* DMA channel assigned */
   DMA_HANDLE        rxdma;      /* currently-open receive DMA stream */
   bool              rxenable;   /* DMA-based reception en/disable */
 #ifdef CONFIG_PM
@@ -378,6 +526,14 @@ struct up_dev_s
 #endif
 };
 
+#ifdef CONFIG_PM
+struct pm_config_s
+{
+  struct pm_callback_s pm_cb;
+  bool serial_suspended;
+};
+#endif
+
 /****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/
@@ -391,7 +547,7 @@ static int  up_attach(struct uart_dev_s *dev);
 static void up_detach(struct uart_dev_s *dev);
 static int  up_interrupt(int irq, void *context, FAR void *arg);
 static int  up_ioctl(struct file *filep, int cmd, unsigned long arg);
-#ifndef SERIAL_HAVE_ONLY_DMA
+#if !defined(SERIAL_HAVE_ONLY_DMA)
 static int  up_receive(struct uart_dev_s *dev, unsigned int *status);
 static void up_rxint(struct uart_dev_s *dev, bool enable);
 static bool up_rxavailable(struct uart_dev_s *dev);
@@ -404,9 +560,19 @@ static void up_send(struct uart_dev_s *dev, int ch);
 static void up_txint(struct uart_dev_s *dev, bool enable);
 static bool up_txready(struct uart_dev_s *dev);
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_TXDMA
+static void up_dma_send(struct uart_dev_s *dev);
+static void up_dma_txint(struct uart_dev_s *dev, bool enable);
+static void up_dma_txavailable(struct uart_dev_s *dev);
+static void up_dma_txcallback(DMA_HANDLE handle, uint8_t status, void *arg);
+#endif
+
+#if defined(SERIAL_HAVE_RXDMA) || defined(SERIAL_HAVE_TXDMA)
 static int  up_dma_setup(struct uart_dev_s *dev);
 static void up_dma_shutdown(struct uart_dev_s *dev);
+#endif
+
+#ifdef SERIAL_HAVE_RXDMA
 static int  up_dma_receive(struct uart_dev_s *dev, unsigned int *status);
 #ifdef CONFIG_PM
 static void up_dma_reenable(struct up_dev_s *priv);
@@ -430,7 +596,7 @@ static int  up_pm_prepare(struct pm_callback_s *cb, int domain,
  * Private Data
  ****************************************************************************/
 
-#ifndef SERIAL_HAVE_ONLY_DMA
+#if !defined(SERIAL_HAVE_ONLY_DMA)
 static const struct uart_ops_s g_uart_ops =
 {
   .setup          = up_setup,
@@ -451,8 +617,30 @@ static const struct uart_ops_s g_uart_ops =
 };
 #endif
 
-#ifdef SERIAL_HAVE_DMA
-static const struct uart_ops_s g_uart_dma_ops =
+#if defined(SERIAL_HAVE_RXDMA) && defined(SERIAL_HAVE_TXDMA)
+static const struct uart_ops_s g_uart_rxtxdma_ops =
+{
+  .setup          = up_dma_setup,
+  .shutdown       = up_dma_shutdown,
+  .attach         = up_attach,
+  .detach         = up_detach,
+  .ioctl          = up_ioctl,
+  .receive        = up_dma_receive,
+  .rxint          = up_dma_rxint,
+  .rxavailable    = up_dma_rxavailable,
+#ifdef CONFIG_SERIAL_IFLOWCONTROL
+  .rxflowcontrol  = up_rxflowcontrol,
+#endif
+  .send           = up_send,
+  .txint          = up_dma_txint,
+  .txready        = up_txready,
+  .txempty        = up_txready,
+  .dmatxavail     = up_dma_txavailable,
+  .dmasend        = up_dma_send,
+};
+#endif
+#if !defined(SERIAL_HAVE_ONLY_DMA) && defined(SERIAL_HAVE_RXDMA)
+static const struct uart_ops_s g_uart_rxdma_ops =
 {
   .setup          = up_dma_setup,
   .shutdown       = up_dma_shutdown,
@@ -472,7 +660,30 @@ static const struct uart_ops_s g_uart_dma_ops =
 };
 #endif
 
-/* DMA buffers.  DMA buffers must:
+#if !defined(SERIAL_HAVE_ONLY_DMA) && defined(SERIAL_HAVE_TXDMA)
+static const struct uart_ops_s g_uart_txdma_ops =
+{
+    .setup          = up_dma_setup,
+    .shutdown       = up_dma_shutdown,
+    .attach         = up_attach,
+    .detach         = up_detach,
+    .ioctl          = up_ioctl,
+    .receive        = up_receive,
+    .rxint          = up_rxint,
+    .rxavailable    = up_rxavailable,
+  #ifdef CONFIG_SERIAL_IFLOWCONTROL
+    .rxflowcontrol  = up_rxflowcontrol,
+  #endif
+    .send           = up_send,
+    .txint          = up_dma_txint,
+    .txready        = up_txready,
+    .txempty        = up_txready,
+    .dmatxavail     = up_dma_txavailable,
+    .dmasend        = up_dma_send,
+};
+#endif
+
+/* DMA buffers.  RX DMA buffers must:
  *
  * 1. Be a multiple of the D-Cache line size.  This requirement is assured
  *    by the definition of RXDMA buffer size above.
@@ -485,84 +696,92 @@ static const struct uart_ops_s g_uart_dma_ops =
 
 #ifdef CONFIG_USART1_RXDMA
 static char g_usart1rxfifo[RXDMA_BUFFER_SIZE]
-  __attribute__((aligned(ARMV7M_DCACHE_LINESIZE)));
+  aligned_data(ARMV7M_DCACHE_LINESIZE);
 #endif
 
 # ifdef CONFIG_USART2_RXDMA
 static char g_usart2rxfifo[RXDMA_BUFFER_SIZE]
-  __attribute__((aligned(ARMV7M_DCACHE_LINESIZE)));
+  aligned_data(ARMV7M_DCACHE_LINESIZE);
 #endif
 
 #ifdef CONFIG_USART3_RXDMA
 static char g_usart3rxfifo[RXDMA_BUFFER_SIZE]
-  __attribute__((aligned(ARMV7M_DCACHE_LINESIZE)));
+  aligned_data(ARMV7M_DCACHE_LINESIZE);
 #endif
 
 #ifdef CONFIG_UART4_RXDMA
 static char g_uart4rxfifo[RXDMA_BUFFER_SIZE]
-  __attribute__((aligned(ARMV7M_DCACHE_LINESIZE)));
+  aligned_data(ARMV7M_DCACHE_LINESIZE);
 #endif
 
 #ifdef CONFIG_UART5_RXDMA
 static char g_uart5rxfifo[RXDMA_BUFFER_SIZE]
-  __attribute__((aligned(ARMV7M_DCACHE_LINESIZE)));
+  aligned_data(ARMV7M_DCACHE_LINESIZE);
 #endif
 
 #ifdef CONFIG_USART6_RXDMA
 static char g_usart6rxfifo[RXDMA_BUFFER_SIZE]
-  __attribute__((aligned(ARMV7M_DCACHE_LINESIZE)));
+  aligned_data(ARMV7M_DCACHE_LINESIZE);
 #endif
 
 #ifdef CONFIG_UART7_RXDMA
 static char g_uart7rxfifo[RXDMA_BUFFER_SIZE]
-  __attribute__((aligned(ARMV7M_DCACHE_LINESIZE)));
+  aligned_data(ARMV7M_DCACHE_LINESIZE);
 #endif
 
 #ifdef CONFIG_UART8_RXDMA
 static char g_uart8rxfifo[RXDMA_BUFFER_SIZE]
-  __attribute__((aligned(ARMV7M_DCACHE_LINESIZE)));
+  aligned_data(ARMV7M_DCACHE_LINESIZE);
 #endif
 
 /* Receive/Transmit buffers */
 
 #ifdef CONFIG_STM32F7_USART1
 static char g_usart1rxbuffer[CONFIG_USART1_RXBUFSIZE];
-static char g_usart1txbuffer[CONFIG_USART1_TXBUFSIZE];
+static char g_usart1txbuffer[USART1_TXBUFSIZE_ADJUSTED] \
+  USART1_TXBUFSIZE_ALGN;
 #endif
 
 #ifdef CONFIG_STM32F7_USART2
 static char g_usart2rxbuffer[CONFIG_USART2_RXBUFSIZE];
-static char g_usart2txbuffer[CONFIG_USART2_TXBUFSIZE];
+static char g_usart2txbuffer[USART2_TXBUFSIZE_ADJUSTED] \
+  USART2_TXBUFSIZE_ALGN;
 #endif
 
 #ifdef CONFIG_STM32F7_USART3
 static char g_usart3rxbuffer[CONFIG_USART3_RXBUFSIZE];
-static char g_usart3txbuffer[CONFIG_USART3_TXBUFSIZE];
+static char g_usart3txbuffer[USART3_TXBUFSIZE_ADJUSTED] \
+  USART3_TXBUFSIZE_ALGN;
 #endif
 
 #ifdef CONFIG_STM32F7_UART4
 static char g_uart4rxbuffer[CONFIG_UART4_RXBUFSIZE];
-static char g_uart4txbuffer[CONFIG_UART4_TXBUFSIZE];
+static char g_uart4txbuffer[UART4_TXBUFSIZE_ADJUSTED] \
+  UART4_TXBUFSIZE_ALGN;
 #endif
 
 #ifdef CONFIG_STM32F7_UART5
 static char g_uart5rxbuffer[CONFIG_UART5_RXBUFSIZE];
-static char g_uart5txbuffer[CONFIG_UART5_TXBUFSIZE];
+static char g_uart5txbuffer[UART5_TXBUFSIZE_ADJUSTED] \
+  UART5_TXBUFSIZE_ALGN;
 #endif
 
 #ifdef CONFIG_STM32F7_USART6
 static char g_usart6rxbuffer[CONFIG_USART6_RXBUFSIZE];
-static char g_usart6txbuffer[CONFIG_USART6_TXBUFSIZE];
+static char g_usart6txbuffer[USART6_TXBUFSIZE_ADJUSTED] \
+  USART6_TXBUFSIZE_ALGN;
 #endif
 
 #ifdef CONFIG_STM32F7_UART7
 static char g_uart7rxbuffer[CONFIG_UART7_RXBUFSIZE];
-static char g_uart7txbuffer[CONFIG_UART7_TXBUFSIZE];
+static char g_uart7txbuffer[UART7_TXBUFSIZE_ADJUSTED] \
+  UART7_TXBUFSIZE_ALGN;
 #endif
 
 #ifdef CONFIG_STM32F7_UART8
 static char g_uart8rxbuffer[CONFIG_UART8_RXBUFSIZE];
-static char g_uart8txbuffer[CONFIG_UART8_TXBUFSIZE];
+static char g_uart8txbuffer[UART8_TXBUFSIZE_ADJUSTED] \
+  UART8_TXBUFSIZE_ALGN;
 #endif
 
 /* This describes the state of the STM32 USART1 ports. */
@@ -577,16 +796,20 @@ static struct up_dev_s g_usart1priv =
 #endif
       .recv      =
       {
-        .size    = CONFIG_USART1_RXBUFSIZE,
+        .size    = sizeof(g_usart1rxbuffer),
         .buffer  = g_usart1rxbuffer,
       },
       .xmit      =
       {
-        .size    = CONFIG_USART1_TXBUFSIZE,
+        .size    = sizeof(g_usart1txbuffer),
         .buffer  = g_usart1txbuffer,
       },
-#ifdef CONFIG_USART1_RXDMA
-      .ops       = &g_uart_dma_ops,
+#if defined(CONFIG_USART1_RXDMA) && defined(CONFIG_USART1_TXDMA)
+      .ops       = &g_uart_rxtxdma_ops,
+#elif defined(CONFIG_USART1_RXDMA) && !defined(CONFIG_USART1_TXDMA)
+      .ops       = &g_uart_rxdma_ops,
+#elif !defined(CONFIG_USART1_RXDMA) && defined(CONFIG_USART1_TXDMA)
+      .ops       = &g_uart_txdma_ops,
 #else
       .ops       = &g_uart_ops,
 #endif
@@ -609,6 +832,9 @@ static struct up_dev_s g_usart1priv =
 #if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_USART1_IFLOWCONTROL)
   .iflow         = true,
   .rts_gpio      = GPIO_USART1_RTS,
+#endif
+#ifdef CONFIG_USART1_TXDMA
+  .txdma_channel = DMAMAP_USART1_TX,
 #endif
 #ifdef CONFIG_USART1_RXDMA
   .rxdma_channel = DMAMAP_USART1_RX,
@@ -638,16 +864,20 @@ static struct up_dev_s g_usart2priv =
 #endif
       .recv      =
       {
-        .size    = CONFIG_USART2_RXBUFSIZE,
+        .size    = sizeof(g_usart2rxbuffer),
         .buffer  = g_usart2rxbuffer,
       },
       .xmit      =
       {
-        .size    = CONFIG_USART2_TXBUFSIZE,
+        .size    = sizeof(g_usart2txbuffer),
         .buffer  = g_usart2txbuffer,
       },
-#ifdef CONFIG_USART2_RXDMA
-      .ops       = &g_uart_dma_ops,
+#if defined(CONFIG_USART2_RXDMA) && defined(CONFIG_USART2_TXDMA)
+      .ops       = &g_uart_rxtxdma_ops,
+#elif defined(CONFIG_USART2_RXDMA) && !defined(CONFIG_USART2_TXDMA)
+      .ops       = &g_uart_rxdma_ops,
+#elif !defined(CONFIG_USART2_RXDMA) && defined(CONFIG_USART2_TXDMA)
+      .ops       = &g_uart_txdma_ops,
 #else
       .ops       = &g_uart_ops,
 #endif
@@ -670,6 +900,9 @@ static struct up_dev_s g_usart2priv =
 #if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_USART2_IFLOWCONTROL)
   .iflow         = true,
   .rts_gpio      = GPIO_USART2_RTS,
+#endif
+#ifdef CONFIG_USART2_TXDMA
+  .txdma_channel = DMAMAP_USART2_TX,
 #endif
 #ifdef CONFIG_USART2_RXDMA
   .rxdma_channel = DMAMAP_USART2_RX,
@@ -699,16 +932,20 @@ static struct up_dev_s g_usart3priv =
 #endif
       .recv      =
       {
-        .size    = CONFIG_USART3_RXBUFSIZE,
+        .size    = sizeof(g_usart3rxbuffer),
         .buffer  = g_usart3rxbuffer,
       },
       .xmit      =
       {
-        .size    = CONFIG_USART3_TXBUFSIZE,
+        .size    = sizeof(g_usart3txbuffer),
         .buffer  = g_usart3txbuffer,
       },
-#ifdef CONFIG_USART3_RXDMA
-      .ops       = &g_uart_dma_ops,
+#if defined(CONFIG_USART3_RXDMA) && defined(CONFIG_USART3_TXDMA)
+      .ops       = &g_uart_rxtxdma_ops,
+#elif defined(CONFIG_USART3_RXDMA) && !defined(CONFIG_USART3_TXDMA)
+      .ops       = &g_uart_rxdma_ops,
+#elif !defined(CONFIG_USART3_RXDMA) && defined(CONFIG_USART3_TXDMA)
+      .ops       = &g_uart_txdma_ops,
 #else
       .ops       = &g_uart_ops,
 #endif
@@ -731,6 +968,9 @@ static struct up_dev_s g_usart3priv =
 #if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_USART3_IFLOWCONTROL)
   .iflow         = true,
   .rts_gpio      = GPIO_USART3_RTS,
+#endif
+#ifdef CONFIG_USART3_TXDMA
+  .txdma_channel = DMAMAP_USART3_TX,
 #endif
 #ifdef CONFIG_USART3_RXDMA
   .rxdma_channel = DMAMAP_USART3_RX,
@@ -760,16 +1000,20 @@ static struct up_dev_s g_uart4priv =
 #endif
       .recv      =
       {
-        .size    = CONFIG_UART4_RXBUFSIZE,
+        .size    = sizeof(g_uart4rxbuffer),
         .buffer  = g_uart4rxbuffer,
       },
       .xmit      =
       {
-        .size    = CONFIG_UART4_TXBUFSIZE,
+        .size    = sizeof(g_uart4txbuffer),
         .buffer  = g_uart4txbuffer,
       },
-#ifdef CONFIG_UART4_RXDMA
-      .ops       = &g_uart_dma_ops,
+#if defined(CONFIG_UART4_RXDMA) && defined(CONFIG_UART4_TXDMA)
+      .ops       = &g_uart_rxtxdma_ops,
+#elif defined(CONFIG_UART4_RXDMA) && !defined(CONFIG_UART4_TXDMA)
+      .ops       = &g_uart_rxdma_ops,
+#elif !defined(CONFIG_UART4_RXDMA) && defined(CONFIG_UART4_TXDMA)
+      .ops       = &g_uart_txdma_ops,
 #else
       .ops       = &g_uart_ops,
 #endif
@@ -793,6 +1037,9 @@ static struct up_dev_s g_uart4priv =
   .usartbase     = STM32_UART4_BASE,
   .tx_gpio       = GPIO_UART4_TX,
   .rx_gpio       = GPIO_UART4_RX,
+#ifdef CONFIG_UART4_TXDMA
+  .txdma_channel = DMAMAP_UART4_TX,
+#endif
 #ifdef CONFIG_UART4_RXDMA
   .rxdma_channel = DMAMAP_UART4_RX,
   .rxfifo        = g_uart4rxfifo,
@@ -829,10 +1076,14 @@ static struct up_dev_s g_uart5priv =
         .size   = CONFIG_UART5_TXBUFSIZE,
         .buffer = g_uart5txbuffer,
       },
-#ifdef CONFIG_UART5_RXDMA
-      .ops      = &g_uart_dma_ops,
+#if defined(CONFIG_UART5_RXDMA) && defined(CONFIG_UART5_TXDMA)
+      .ops       = &g_uart_rxtxdma_ops,
+#elif defined(CONFIG_UART5_RXDMA) && !defined(CONFIG_UART5_TXDMA)
+      .ops       = &g_uart_rxdma_ops,
+#elif !defined(CONFIG_UART5_RXDMA) && defined(CONFIG_UART5_TXDMA)
+      .ops       = &g_uart_txdma_ops,
 #else
-      .ops      = &g_uart_ops,
+      .ops       = &g_uart_ops,
 #endif
       .priv     = &g_uart5priv,
     },
@@ -854,6 +1105,9 @@ static struct up_dev_s g_uart5priv =
   .usartbase      = STM32_UART5_BASE,
   .tx_gpio        = GPIO_UART5_TX,
   .rx_gpio        = GPIO_UART5_RX,
+#ifdef CONFIG_UART5_TXDMA
+  .txdma_channel = DMAMAP_UART5_TX,
+#endif
 #ifdef CONFIG_UART5_RXDMA
   .rxdma_channel = DMAMAP_UART5_RX,
   .rxfifo        = g_uart5rxfifo,
@@ -882,18 +1136,22 @@ static struct up_dev_s g_usart6priv =
 #endif
       .recv     =
       {
-        .size   = CONFIG_USART6_RXBUFSIZE,
+        .size   = sizeof(g_usart6rxbuffer),
         .buffer = g_usart6rxbuffer,
       },
       .xmit     =
       {
-        .size   = CONFIG_USART6_TXBUFSIZE,
+        .size   = sizeof(g_usart6txbuffer),
         .buffer = g_usart6txbuffer,
       },
-#ifdef CONFIG_USART6_RXDMA
-      .ops      = &g_uart_dma_ops,
+#if defined(CONFIG_USART6_RXDMA) && defined(CONFIG_USART6_TXDMA)
+      .ops       = &g_uart_rxtxdma_ops,
+#elif defined(CONFIG_USART6_RXDMA) && !defined(CONFIG_USART6_TXDMA)
+      .ops       = &g_uart_rxdma_ops,
+#elif !defined(CONFIG_USART6_RXDMA) && defined(CONFIG_USART6_TXDMA)
+      .ops       = &g_uart_txdma_ops,
 #else
-      .ops      = &g_uart_ops,
+      .ops       = &g_uart_ops,
 #endif
       .priv     = &g_usart6priv,
     },
@@ -914,6 +1172,9 @@ static struct up_dev_s g_usart6priv =
 #if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_USART6_IFLOWCONTROL)
   .iflow          = true,
   .rts_gpio       = GPIO_USART6_RTS,
+#endif
+#ifdef CONFIG_USART6_TXDMA
+  .txdma_channel = DMAMAP_USART6_TX,
 #endif
 #ifdef CONFIG_USART6_RXDMA
   .rxdma_channel = DMAMAP_USART6_RX,
@@ -943,18 +1204,22 @@ static struct up_dev_s g_uart7priv =
 #endif
       .recv     =
       {
-        .size   = CONFIG_UART7_RXBUFSIZE,
+        .size   = sizeof(g_uart7rxbuffer),
         .buffer = g_uart7rxbuffer,
       },
       .xmit     =
       {
-        .size   = CONFIG_UART7_TXBUFSIZE,
+        .size   = sizeof(g_uart7txbuffer),
         .buffer = g_uart7txbuffer,
       },
-#ifdef CONFIG_UART7_RXDMA
-      .ops      = &g_uart_dma_ops,
+#if defined(CONFIG_UART7_RXDMA) && defined(CONFIG_UART7_TXDMA)
+      .ops       = &g_uart_rxtxdma_ops,
+#elif defined(CONFIG_UART7_RXDMA) && !defined(CONFIG_UART7_TXDMA)
+      .ops       = &g_uart_rxdma_ops,
+#elif !defined(CONFIG_UART7_RXDMA) && defined(CONFIG_UART7_TXDMA)
+      .ops       = &g_uart_txdma_ops,
 #else
-      .ops      = &g_uart_ops,
+      .ops       = &g_uart_ops,
 #endif
       .priv     = &g_uart7priv,
     },
@@ -975,6 +1240,9 @@ static struct up_dev_s g_uart7priv =
 #if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_UART7_IFLOWCONTROL)
   .iflow          = true,
   .rts_gpio       = GPIO_UART7_RTS,
+#endif
+#ifdef CONFIG_UART7_TXDMA
+  .txdma_channel = DMAMAP_UART7_TX,
 #endif
 #ifdef CONFIG_UART7_RXDMA
   .rxdma_channel = DMAMAP_UART7_RX,
@@ -1004,18 +1272,22 @@ static struct up_dev_s g_uart8priv =
 #endif
       .recv     =
       {
-        .size   = CONFIG_UART8_RXBUFSIZE,
+        .size   = sizeof(g_uart8rxbuffer),
         .buffer = g_uart8rxbuffer,
       },
       .xmit     =
       {
-        .size   = CONFIG_UART8_TXBUFSIZE,
+        .size   = sizeof(g_uart8txbuffer),
         .buffer = g_uart8txbuffer,
       },
-#ifdef CONFIG_UART8_RXDMA
-      .ops      = &g_uart_dma_ops,
+#if defined(CONFIG_UART8_RXDMA) && defined(CONFIG_UART8_TXDMA)
+      .ops       = &g_uart_rxtxdma_ops,
+#elif defined(CONFIG_UART8_RXDMA) && !defined(CONFIG_UART8_TXDMA)
+      .ops       = &g_uart_rxdma_ops,
+#elif !defined(CONFIG_UART8_RXDMA) && defined(CONFIG_UART8_TXDMA)
+      .ops       = &g_uart_txdma_ops,
 #else
-      .ops      = &g_uart_ops,
+      .ops       = &g_uart_ops,
 #endif
       .priv     = &g_uart8priv,
     },
@@ -1036,6 +1308,9 @@ static struct up_dev_s g_uart8priv =
 #if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_UART8_IFLOWCONTROL)
   .iflow          = true,
   .rts_gpio       = GPIO_UART8_RTS,
+#endif
+#ifdef CONFIG_UART8_TXDMA
+  .txdma_channel = DMAMAP_UART8_TX,
 #endif
 #ifdef CONFIG_UART8_RXDMA
   .rxdma_channel = DMAMAP_UART8_RX,
@@ -1084,11 +1359,7 @@ static struct up_dev_s * const g_uart_devs[STM32_NSERIAL] =
 };
 
 #ifdef CONFIG_PM
-static struct
-{
-  struct pm_callback_s pm_cb;
-  bool serial_suspended;
-} g_serialpm =
+static struct pm_config_s g_serialpm =
 {
   .pm_cb.notify     = up_pm_notify,
   .pm_cb.prepare    = up_pm_prepare,
@@ -1113,7 +1384,8 @@ static inline uint32_t up_serialin(struct up_dev_s *priv, int offset)
  * Name: up_serialout
  ****************************************************************************/
 
-static inline void up_serialout(struct up_dev_s *priv, int offset, uint32_t value)
+static inline void up_serialout(struct up_dev_s *priv, int offset,
+                                uint32_t value)
 {
   putreg32(value, priv->usartbase + offset);
 }
@@ -1194,9 +1466,10 @@ static void up_disableusartint(struct up_dev_s *priv, uint16_t *ie)
       cr1 = up_serialin(priv, STM32_USART_CR1_OFFSET);
       cr3 = up_serialin(priv, STM32_USART_CR3_OFFSET);
 
-      /* Return the current interrupt mask value for the used interrupts.  Notice
-       * that this depends on the fact that none of the used interrupt enable bits
-       * overlap.  This logic would fail if we needed the break interrupt!
+      /* Return the current interrupt mask value for the used interrupts.
+       * Notice that this depends on the fact that none of the used interrupt
+       * enable bits overlap.  This logic would fail if we needed the break
+       * interrupt!
        */
 
       *ie = (cr1 & (USART_CR1_USED_INTS)) | (cr3 & USART_CR3_EIE);
@@ -1218,7 +1491,7 @@ static void up_disableusartint(struct up_dev_s *priv, uint16_t *ie)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static int up_dma_nextrx(struct up_dev_s *priv)
 {
   size_t dmaresidual;
@@ -1398,7 +1671,7 @@ static void up_setsuspend(struct uart_dev_s *dev, bool suspend)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   int passes;
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
   bool dmarestored = false;
 #endif
 
@@ -1437,7 +1710,7 @@ static void up_setsuspend(struct uart_dev_s *dev, bool suspend)
             }
         }
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
       if (priv->dev.ops == &g_uart_dma_ops && !priv->rxdmasusp)
         {
           /* Suspend Rx DMA. */
@@ -1449,7 +1722,7 @@ static void up_setsuspend(struct uart_dev_s *dev, bool suspend)
     }
   else
     {
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
       if (priv->dev.ops == &g_uart_dma_ops && priv->rxdmasusp)
         {
           /* Re-enable DMA. */
@@ -1475,7 +1748,7 @@ static void up_setsuspend(struct uart_dev_s *dev, bool suspend)
 #endif
     }
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
   if (dmarestored)
     {
       irqstate_t flags;
@@ -1745,12 +2018,11 @@ static int up_setup(struct uart_dev_s *dev)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#if defined(SERIAL_HAVE_RXDMA) || defined(SERIAL_HAVE_TXDMA)
 static int up_dma_setup(struct uart_dev_s *dev)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
   int result;
-  uint32_t regval;
 
   /* Do the basic UART setup first, unless we are the console */
 
@@ -1763,39 +2035,55 @@ static int up_dma_setup(struct uart_dev_s *dev)
         }
     }
 
-  /* Acquire the DMA channel.  This should always succeed. */
+#if defined(SERIAL_HAVE_TXDMA)
+  /* Acquire the Tx DMA channel.  This should always succeed. */
 
-  priv->rxdma = stm32_dmachannel(priv->rxdma_channel);
+  if (priv->txdma_channel != INVALID_SERIAL_DMA_CHANNEL)
+    {
+      priv->txdma = stm32_dmachannel(priv->txdma_channel);
 
-  /* Configure for circular DMA reception into the RX FIFO */
+      /* Enable receive Tx DMA for the UART */
 
-  stm32_dmasetup(priv->rxdma,
-                 priv->usartbase + STM32_USART_RDR_OFFSET,
-                 (uint32_t)priv->rxfifo,
-                 RXDMA_BUFFER_SIZE,
-                 SERIAL_DMA_CONTROL_WORD);
-
-  /* Reset our DMA shadow pointer and Rx data availability count to match
-   * the address just programmed above.
-   */
-
-  priv->rxdmanext = 0;
-#ifdef CONFIG_ARMV7M_DCACHE
-  priv->rxdmaavail = 0;
+      modifyreg32(priv->usartbase + STM32_USART_CR3_OFFSET, 0, USART_CR3_DMAT);
+    }
 #endif
 
-  /* Enable receive DMA for the UART */
+#if defined(SERIAL_HAVE_RXDMA)
+  /* Acquire the Rx DMA channel.  This should always succeed. */
 
-  regval  = up_serialin(priv, STM32_USART_CR3_OFFSET);
-  regval |= USART_CR3_DMAR;
-  up_serialout(priv, STM32_USART_CR3_OFFSET, regval);
+  if (priv->rxdma_channel != INVALID_SERIAL_DMA_CHANNEL)
+    {
+      priv->rxdma = stm32_dmachannel(priv->rxdma_channel);
 
-  /* Start the DMA channel, and arrange for callbacks at the half and
-   * full points in the FIFO.  This ensures that we have half a FIFO
-   * worth of time to claim bytes before they are overwritten.
-   */
+      /* Configure for circular DMA reception into the RX FIFO */
 
-  stm32_dmastart(priv->rxdma, up_dma_rxcallback, (void *)priv, true);
+      stm32_dmasetup(priv->rxdma,
+                     priv->usartbase + STM32_USART_RDR_OFFSET,
+                     (uint32_t)priv->rxfifo,
+                     RXDMA_BUFFER_SIZE,
+                     SERIAL_RXDMA_CONTROL_WORD);
+
+      /* Reset our DMA shadow pointer and Rx data availability count to match
+       * the address just programmed above.
+       */
+
+      priv->rxdmanext = 0;
+#ifdef CONFIG_ARMV7M_DCACHE
+      priv->rxdmaavail = 0;
+#endif
+
+      /* Enable receive Rx DMA for the UART */
+
+      modifyreg32(priv->usartbase + STM32_USART_CR3_OFFSET, 0, USART_CR3_DMAR);
+
+      /* Start the DMA channel, and arrange for callbacks at the half and
+       * full points in the FIFO.  This ensures that we have half a FIFO
+       * worth of time to claim bytes before they are overwritten.
+       */
+
+      stm32_dmastart(priv->rxdma, up_dma_rxcallback, (void *)priv, true);
+    }
+#endif
 
   return OK;
 }
@@ -1875,7 +2163,7 @@ static void up_shutdown(struct uart_dev_s *dev)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#if defined(SERIAL_HAVE_RXDMA) || defined(SERIAL_HAVE_TXDMA)
 static void up_dma_shutdown(struct uart_dev_s *dev)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
@@ -1884,14 +2172,33 @@ static void up_dma_shutdown(struct uart_dev_s *dev)
 
   up_shutdown(dev);
 
-  /* Stop the DMA channel */
+#if defined(SERIAL_HAVE_RXDMA)
+  /* Stop the RX DMA channel */
 
-  stm32_dmastop(priv->rxdma);
+  if (priv->rxdma_channel != INVALID_SERIAL_DMA_CHANNEL)
+    {
+      stm32_dmastop(priv->rxdma);
 
-  /* Release the DMA channel */
+      /* Release the RX DMA channel */
 
-  stm32_dmafree(priv->rxdma);
-  priv->rxdma = NULL;
+      stm32_dmafree(priv->rxdma);
+      priv->rxdma = NULL;
+    }
+#endif
+
+#if defined(SERIAL_HAVE_TXDMA)
+  /* Stop the TX DMA channel */
+
+  if (priv->txdma_channel != INVALID_SERIAL_DMA_CHANNEL)
+    {
+      stm32_dmastop(priv->txdma);
+
+      /* Release the TX DMA channel */
+
+      stm32_dmafree(priv->txdma);
+      priv->txdma = NULL;
+    }
+#endif
 }
 #endif
 
@@ -1906,7 +2213,8 @@ static void up_dma_shutdown(struct uart_dev_s *dev)
  *
  *   RX and TX interrupts are not enabled when by the attach method (unless the
  *   hardware supports multiple levels of interrupt enabling).  The RX and TX
- *   interrupts are not enabled until the txint() and rxint() methods are called.
+ *   interrupts are not enabled until the txint() and rxint() methods are
+ *   called.
  *
  ****************************************************************************/
 
@@ -1926,6 +2234,7 @@ static int up_attach(struct uart_dev_s *dev)
 
        up_enable_irq(priv->irq);
     }
+
   return ret;
 }
 
@@ -2002,9 +2311,9 @@ static int up_interrupt(int irq, void *context, FAR void *arg)
        * "           "      USART_ISR_ORE   Overrun Error Detected
        * USART_CR3_CTSIE    USART_ISR_CTS   CTS flag                        (not used)
        *
-       * NOTE: Some of these status bits must be cleared by explicitly writing zero
-       * to the SR register: USART_ISR_CTS, USART_ISR_LBD. Note of those are currently
-       * being used.
+       * NOTE: Some of these status bits must be cleared by explicitly writing
+       * zero to the SR register: USART_ISR_CTS, USART_ISR_LBD. Note of those
+       * are currently being used.
        */
 
 #ifdef HAVE_RS485
@@ -2024,10 +2333,12 @@ static int up_interrupt(int irq, void *context, FAR void *arg)
 
       /* Handle incoming, receive bytes. */
 
-      if ((priv->sr & USART_ISR_RXNE) != 0 && (priv->ie & USART_CR1_RXNEIE) != 0)
+      if ((priv->sr & USART_ISR_RXNE) != 0 &&
+          (priv->ie & USART_CR1_RXNEIE) != 0)
         {
           /* Received data ready... process incoming bytes.  NOTE the check for
-           * RXNEIE:  We cannot call uart_recvchards of RX interrupts are disabled.
+           * RXNEIE:  We cannot call uart_recvchards of RX interrupts are
+           * disabled.
            */
 
           uart_recvchars(&priv->dev);
@@ -2128,14 +2439,19 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
         if ((arg & SER_SINGLEWIRE_ENABLED) != 0)
           {
             uint32_t gpio_val = GPIO_OPENDRAIN;
-            gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLUP ? GPIO_PULLUP : GPIO_FLOAT;
-            gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLDOWN ? GPIO_PULLDOWN : GPIO_FLOAT;
-            stm32_configgpio((priv->tx_gpio & ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) | gpio_val);
+            gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) ==
+                         SER_SINGLEWIRE_PULLUP ? GPIO_PULLUP : GPIO_FLOAT;
+            gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) ==
+                         SER_SINGLEWIRE_PULLDOWN ? GPIO_PULLDOWN : GPIO_FLOAT;
+            stm32_configgpio((priv->tx_gpio &
+                             ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) | gpio_val);
             cr |= USART_CR3_HDSEL;
           }
         else
           {
-            stm32_configgpio((priv->tx_gpio & ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) | GPIO_PUSHPULL);
+            stm32_configgpio((priv->tx_gpio & ~(GPIO_PUPD_MASK |
+                                                GPIO_OPENDRAIN)) |
+                                                GPIO_PUSHPULL);
             cr &= ~USART_CR3_HDSEL;
           }
 
@@ -2426,7 +2742,7 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
  *
  ****************************************************************************/
 
-#ifndef SERIAL_HAVE_ONLY_DMA
+#ifndef SERIAL_HAVE_ONLY_RXDMA
 static int up_receive(struct uart_dev_s *dev, unsigned int *status)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
@@ -2455,7 +2771,7 @@ static int up_receive(struct uart_dev_s *dev, unsigned int *status)
  *
  ****************************************************************************/
 
-#ifndef SERIAL_HAVE_ONLY_DMA
+#ifndef SERIAL_HAVE_ONLY_RXDMA
 static void up_rxint(struct uart_dev_s *dev, bool enable)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
@@ -2481,8 +2797,8 @@ static void up_rxint(struct uart_dev_s *dev, bool enable)
   ie = priv->ie;
   if (enable)
     {
-      /* Receive an interrupt when their is anything in the Rx data register (or an Rx
-       * timeout occurs).
+      /* Receive an interrupt when their is anything in the Rx data register
+       * (or an Rx timeout occurs).
        */
 
 #ifndef CONFIG_SUPPRESS_SERIAL_INTS
@@ -2513,7 +2829,7 @@ static void up_rxint(struct uart_dev_s *dev, bool enable)
  *
  ****************************************************************************/
 
-#ifndef SERIAL_HAVE_ONLY_DMA
+#ifndef SERIAL_HAVE_ONLY_RXDMA
 static bool up_rxavailable(struct uart_dev_s *dev)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
@@ -2627,7 +2943,7 @@ static bool up_rxflowcontrol(struct uart_dev_s *dev,
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static int up_dma_receive(struct uart_dev_s *dev, unsigned int *status)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
@@ -2710,7 +3026,7 @@ static int up_dma_receive(struct uart_dev_s *dev, unsigned int *status)
  *
  ****************************************************************************/
 
-#if defined(SERIAL_HAVE_DMA) && defined(CONFIG_PM)
+#if defined(SERIAL_HAVE_RXDMA) && defined(CONFIG_PM)
 static void up_dma_reenable(struct up_dev_s *priv)
 {
   /* Configure for circular DMA reception into the RX FIFO */
@@ -2719,7 +3035,7 @@ static void up_dma_reenable(struct up_dev_s *priv)
                  priv->usartbase + STM32_USART_RDR_OFFSET,
                  (uint32_t)priv->rxfifo,
                  RXDMA_BUFFER_SIZE,
-                 SERIAL_DMA_CONTROL_WORD);
+                 SERIAL_RXDMA_CONTROL_WORD);
 
   /* Reset our DMA shadow pointer and Rx data availability count to match
    * the address just programmed above.
@@ -2751,7 +3067,7 @@ static void up_dma_reenable(struct up_dev_s *priv)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static void up_dma_rxint(struct uart_dev_s *dev, bool enable)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
@@ -2776,7 +3092,7 @@ static void up_dma_rxint(struct uart_dev_s *dev, bool enable)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static bool up_dma_rxavailable(struct uart_dev_s *dev)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
@@ -2786,6 +3102,106 @@ static bool up_dma_rxavailable(struct uart_dev_s *dev)
    */
 
   return (up_dma_nextrx(priv) != priv->rxdmanext);
+}
+#endif
+
+/****************************************************************************
+ * Name: up_dma_txcallback
+ *
+ * Description:
+ *   This function clears dma buffer at complete of DMA transfer and wakes up
+ *   threads waiting for space in buffer.
+ *
+ ****************************************************************************/
+
+#ifdef SERIAL_HAVE_TXDMA
+static void up_dma_txcallback(DMA_HANDLE handle, uint8_t status, void *arg)
+{
+  struct up_dev_s *priv = (struct up_dev_s *)arg;
+
+  /* Update 'nbytes' indicating number of bytes actually transferred by DMA.
+   * This is important to free TX buffer space by 'uart_xmitchars_done'.
+   */
+
+  if (status & DMA_SCR_HTIE)
+    {
+      priv->dev.dmatx.nbytes = priv->dev.dmatx.length / 2;
+    }
+  else if (status & DMA_SCR_TCIE)
+    {
+      priv->dev.dmatx.nbytes = priv->dev.dmatx.length;
+    }
+
+  /* Adjust the pointers */
+
+  uart_xmitchars_done(&priv->dev);
+
+  /* Kick off the next DMA to keep the channel as busy as possible */
+
+  uart_xmitchars_dma(&priv->dev);
+}
+#endif
+
+/****************************************************************************
+ * Name: up_dma_txavailable
+ *
+ * Description:
+ *        Informs DMA that Tx data is available and is ready for transfer.
+ *
+ ****************************************************************************/
+
+#ifdef SERIAL_HAVE_TXDMA
+static void up_dma_txavailable(struct uart_dev_s *dev)
+{
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
+
+  /* Only send when the DMA is idle */
+
+  if (stm32_dmaresidual(priv->txdma) == 0)
+    {
+      uart_xmitchars_dma(dev);
+    }
+}
+#endif
+
+/****************************************************************************
+ * Name: up_dma_send
+ *
+ * Description:
+ *   Called (usually) from the interrupt level to start DMA transfer.
+ *   (Re-)Configures DMA Stream updating buffer and buffer length.
+ *
+ ****************************************************************************/
+
+#ifdef SERIAL_HAVE_TXDMA
+static void up_dma_send(struct uart_dev_s *dev)
+{
+  struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
+
+  /* We need to stop DMA before reconfiguration */
+
+  stm32_dmastop(priv->txdma);
+
+  /* Wait until TX UART is ready for new transfer it should be */
+
+  while (!up_txready(dev));
+
+  /* Flush the contents of the TX buffer into physical memory */
+
+  up_clean_dcache((uintptr_t)dev->dmatx.buffer,
+                  (uintptr_t)dev->dmatx.buffer + dev->dmatx.length);
+
+  /* Make use of setup function to update buffer and its length for next transfer */
+
+  stm32_dmasetup(priv->txdma,
+                 priv->usartbase + STM32_USART_TDR_OFFSET,
+                 (uint32_t) dev->dmatx.buffer,
+                 (size_t) dev->dmatx.length,
+                 SERIAL_TXDMA_CONTROL_WORD);
+
+  /* Start transmission with the callback on DMA completion */
+
+  stm32_dmastart(priv->txdma, up_dma_txcallback, (void *)priv, false);
 }
 #endif
 
@@ -2810,6 +3226,28 @@ static void up_send(struct uart_dev_s *dev, int ch)
 
   up_serialout(priv, STM32_USART_TDR_OFFSET, (uint32_t)ch);
 }
+
+/****************************************************************************
+ * Name: up_dma_txint
+ *
+ * Description:
+ *   Call to enable or disable TX interrupts from the UART.
+ *
+ ****************************************************************************/
+
+#ifdef SERIAL_HAVE_TXDMA
+static void up_dma_txint(struct uart_dev_s *dev, bool enable)
+{
+  /* Nothing to do. */
+
+  /* In case of DMA transfer we do not want to make use of UART interrupts.
+   * Instead, we use DMA interrupts that are activated once during boot
+   * sequence. Furthermore we can use up_dma_txcallback() to handle staff at
+   * half DMA transfer or after transfer completion (depending configuration,
+   * see stm32_dmastart(...) ).
+   */
+}
+#endif
 
 /****************************************************************************
  * Name: up_txint
@@ -2901,7 +3339,7 @@ static bool up_txready(struct uart_dev_s *dev)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static void up_dma_rxcallback(DMA_HANDLE handle, uint8_t status, void *arg)
 {
   struct up_dev_s *priv = (struct up_dev_s *)arg;
@@ -2984,6 +3422,7 @@ static void up_pm_notify(struct pm_callback_s *cb, int domain,
         break;
 
       default:
+
         /* Should not get here */
 
         break;
@@ -3041,7 +3480,7 @@ static int up_pm_prepare(struct pm_callback_s *cb, int domain,
     case PM_STANDBY:
     case PM_SLEEP:
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
       /* Flush Rx DMA buffers before checking state of serial device
        * buffers.
        */
@@ -3084,6 +3523,7 @@ static int up_pm_prepare(struct pm_callback_s *cb, int domain,
             {
               return ERROR;
             }
+
           if (priv->dev.recv.head != priv->dev.recv.tail)
             {
               return ERROR;
@@ -3092,6 +3532,7 @@ static int up_pm_prepare(struct pm_callback_s *cb, int domain,
       break;
 
     default:
+
       /* Should not get here */
 
       break;
@@ -3161,6 +3602,15 @@ void up_serialinit(void)
   unsigned minor = 0;
 #ifdef CONFIG_PM
   int ret;
+#endif
+
+#if !defined(SERIAL_HAVE_ONLY_DMA)
+#  if defined(SERIAL_HAVE_RXDMA)
+  UNUSED(g_uart_rxdma_ops);
+#  endif
+#  if defined(SERIAL_HAVE_TXDMA)
+  UNUSED(g_uart_txdma_ops);
+#  endif
 #endif
 
 #ifdef CONFIG_PM
@@ -3233,7 +3683,7 @@ void up_serialinit(void)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 void stm32_serial_dma_poll(void)
 {
     irqstate_t flags;

--- a/arch/arm/src/stm32f7/stm32_uart.h
+++ b/arch/arm/src/stm32f7/stm32_uart.h
@@ -187,101 +187,173 @@
 
 #if !defined(HAVE_UART) || !defined(CONFIG_ARCH_DMA)
 #  undef CONFIG_USART1_RXDMA
+#  undef CONFIG_USART1_TXDMA
 #  undef CONFIG_USART2_RXDMA
+#  undef CONFIG_USART2_TXDMA
 #  undef CONFIG_USART3_RXDMA
+#  undef CONFIG_USART3_TXDMA
 #  undef CONFIG_UART4_RXDMA
+#  undef CONFIG_UART4_TXDMA
 #  undef CONFIG_UART5_RXDMA
+#  undef CONFIG_UART5_TXDMA
 #  undef CONFIG_USART6_RXDMA
+#  undef CONFIG_USART6_TXDMA
 #  undef CONFIG_UART7_RXDMA
+#  undef CONFIG_UART7_TXDMA
 #  undef CONFIG_UART8_RXDMA
+#  undef CONFIG_UART8_TXDMA
 #endif
 
 /* Disable the DMA configuration on all unused USARTs */
 
 #ifndef CONFIG_STM32F7_USART1
 #  undef CONFIG_USART1_RXDMA
+#  undef CONFIG_USART1_TXDMA
 #endif
 
 #ifndef CONFIG_STM32F7_USART2
 #  undef CONFIG_USART2_RXDMA
+#  undef CONFIG_USART2_TXDMA
 #endif
 
 #ifndef CONFIG_STM32F7_USART3
 #  undef CONFIG_USART3_RXDMA
+#  undef CONFIG_USART3_TXDMA
 #endif
 
 #ifndef CONFIG_STM32F7_UART4
 #  undef CONFIG_UART4_RXDMA
+#  undef CONFIG_UART4_TXDMA
 #endif
 
 #ifndef CONFIG_STM32F7_UART5
 #  undef CONFIG_UART5_RXDMA
+#  undef CONFIG_UART5_TXDMA
 #endif
 
 #ifndef CONFIG_STM32F7_USART6
 #  undef CONFIG_USART6_RXDMA
+#  undef CONFIG_USART6_TXDMA
 #endif
 
 #ifndef CONFIG_STM32F7_UART7
 #  undef CONFIG_UART7_RXDMA
+#  undef CONFIG_UART7_TXDMA
 #endif
 
 #ifndef CONFIG_STM32F7_UART8
 #  undef CONFIG_UART8_RXDMA
+#  undef CONFIG_UART8_TXDMA
 #endif
 
-/* Is DMA available on any (enabled) USART? */
+/* Is RX DMA available on any (enabled) USART? */
 
-#undef SERIAL_HAVE_DMA
+#undef SERIAL_HAVE_RXDMA
 #if defined(CONFIG_USART1_RXDMA) || defined(CONFIG_USART2_RXDMA) || \
     defined(CONFIG_USART3_RXDMA) || defined(CONFIG_UART4_RXDMA)  || \
     defined(CONFIG_UART5_RXDMA)  || defined(CONFIG_USART6_RXDMA) || \
     defined(CONFIG_UART7_RXDMA)  || defined(CONFIG_UART8_RXDMA)
-#  define SERIAL_HAVE_DMA 1
+#  define SERIAL_HAVE_RXDMA 1
 #endif
 
-/* Is DMA used on the console UART? */
+/* Is TX DMA available on any (enabled) USART? */
 
-#undef SERIAL_HAVE_CONSOLE_DMA
+#undef SERIAL_HAVE_TXDMA
+#if defined(CONFIG_USART1_TXDMA) || defined(CONFIG_USART2_TXDMA) || \
+    defined(CONFIG_USART3_TXDMA) || defined(CONFIG_UART4_TXDMA)  || \
+    defined(CONFIG_UART5_TXDMA)  || defined(CONFIG_USART6_TXDMA) || \
+    defined(CONFIG_UART7_TXDMA)  || defined(CONFIG_UART8_TXDMA)
+#  define SERIAL_HAVE_TXDMA 1
+#endif
+
+/* Is RX DMA used on the console UART? */
+
+#undef SERIAL_HAVE_CONSOLE_RXDMA
 #if defined(CONFIG_USART1_SERIAL_CONSOLE) && defined(CONFIG_USART1_RXDMA)
-#  define SERIAL_HAVE_CONSOLE_DMA 1
+#  define SERIAL_HAVE_CONSOLE_RXDMA 1
 #elif defined(CONFIG_USART2_SERIAL_CONSOLE) && defined(CONFIG_USART2_RXDMA)
-#  define SERIAL_HAVE_CONSOLE_DMA 1
+#  define SERIAL_HAVE_CONSOLE_RXDMA 1
 #elif defined(CONFIG_USART3_SERIAL_CONSOLE) && defined(CONFIG_USART3_RXDMA)
-#  define SERIAL_HAVE_CONSOLE_DMA 1
+#  define SERIAL_HAVE_CONSOLE_RXDMA 1
 #elif defined(CONFIG_UART4_SERIAL_CONSOLE) && defined(CONFIG_UART4_RXDMA)
-#  define SERIAL_HAVE_CONSOLE_DMA 1
+#  define SERIAL_HAVE_CONSOLE_RXDMA 1
 #elif defined(CONFIG_UART5_SERIAL_CONSOLE) && defined(CONFIG_UART5_RXDMA)
-#  define SERIAL_HAVE_CONSOLE_DMA 1
+#  define SERIAL_HAVE_CONSOLE_RXDMA 1
 #elif defined(CONFIG_USART6_SERIAL_CONSOLE) && defined(CONFIG_USART6_RXDMA)
-#  define SERIAL_HAVE_CONSOLE_DMA 1
+#  define SERIAL_HAVE_CONSOLE_RXDMA 1
 #elif defined(CONFIG_UART7_SERIAL_CONSOLE) && defined(CONFIG_UART7_RXDMA)
-#  define SERIAL_HAVE_CONSOLE_DMA 1
+#  define SERIAL_HAVE_CONSOLE_RXDMA 1
 #elif defined(CONFIG_UART8_SERIAL_CONSOLE) && defined(CONFIG_UART8_RXDMA)
-#  define SERIAL_HAVE_CONSOLE_DMA 1
+#  define SERIAL_HAVE_CONSOLE_RXDMA 1
 #endif
 
-/* Is DMA used on all (enabled) USARTs */
+/* Is TX DMA used on the console UART? */
 
-#define SERIAL_HAVE_ONLY_DMA 1
+#undef SERIAL_HAVE_CONSOLE_TXDMA
+#if defined(CONFIG_USART1_SERIAL_CONSOLE) && defined(CONFIG_USART1_TXDMA)
+#  define SERIAL_HAVE_CONSOLE_TXDMA 1
+#elif defined(CONFIG_USART2_SERIAL_CONSOLE) && defined(CONFIG_USART2_TXDMA)
+#  define SERIAL_HAVE_CONSOLE_TXDMA 1
+#elif defined(CONFIG_USART3_SERIAL_CONSOLE) && defined(CONFIG_USART3_TXDMA)
+#  define SERIAL_HAVE_CONSOLE_TXDMA 1
+#elif defined(CONFIG_UART4_SERIAL_CONSOLE) && defined(CONFIG_UART4_TXDMA)
+#  define SERIAL_HAVE_CONSOLE_TXDMA 1
+#elif defined(CONFIG_UART5_SERIAL_CONSOLE) && defined(CONFIG_UART5_TXDMA)
+#  define SERIAL_HAVE_CONSOLE_TXDMA 1
+#elif defined(CONFIG_USART6_SERIAL_CONSOLE) && defined(CONFIG_USART6_TXDMA)
+#  define SERIAL_HAVE_CONSOLE_TXDMA 1
+#elif defined(CONFIG_UART7_SERIAL_CONSOLE) && defined(CONFIG_UART7_TXDMA)
+#  define SERIAL_HAVE_CONSOLE_TXDMA 1
+#elif defined(CONFIG_UART8_SERIAL_CONSOLE) && defined(CONFIG_UART8_TXDMA)
+#  define SERIAL_HAVE_CONSOLE_TXDMA 1
+#endif
+
+/* Is RX DMA used on all (enabled) USARTs */
+
+#define SERIAL_HAVE_ONLY_RXDMA 1
 #if defined(CONFIG_STM32F7_USART1) && !defined(CONFIG_USART1_RXDMA)
-#  undef SERIAL_HAVE_ONLY_DMA
+#  undef SERIAL_HAVE_ONLY_RXDMA
 #elif defined(CONFIG_STM32F7_USART2) && !defined(CONFIG_USART2_RXDMA)
-#  undef SERIAL_HAVE_ONLY_DMA
+#  undef SERIAL_HAVE_ONLY_RXDMA
 #elif defined(CONFIG_STM32F7_USART3) && !defined(CONFIG_USART3_RXDMA)
-#  undef SERIAL_HAVE_ONLY_DMA
+#  undef SERIAL_HAVE_ONLY_RXDMA
 #elif defined(CONFIG_STM32F7_UART4) && !defined(CONFIG_UART4_RXDMA)
-#  undef SERIAL_HAVE_ONLY_DMA
+#  undef SERIAL_HAVE_ONLY_RXDMA
 #elif defined(CONFIG_STM32F7_UART5) && !defined(CONFIG_UART5_RXDMA)
-#  undef SERIAL_HAVE_ONLY_DMA
+#  undef SERIAL_HAVE_ONLY_RXDMA
 #elif defined(CONFIG_STM32F7_USART6) && !defined(CONFIG_USART6_RXDMA)
-#  undef SERIAL_HAVE_ONLY_DMA
+#  undef SERIAL_HAVE_ONLY_RXDMA
 #elif defined(CONFIG_STM32F7_UART7) && !defined(CONFIG_UART7_RXDMA)
-#  undef SERIAL_HAVE_ONLY_DMA
+#  undef SERIAL_HAVE_ONLY_RXDMA
 #elif defined(CONFIG_STM32F7_UART8) && !defined(CONFIG_UART8_RXDMA)
-#  undef SERIAL_HAVE_ONLY_DMA
+#  undef SERIAL_HAVE_ONLY_RXDMA
 #endif
 
+/* Is TX DMA used on all (enabled) USARTs */
+
+#define SERIAL_HAVE_ONLY_TXDMA 1
+#if defined(CONFIG_STM32F7_USART1) && !defined(CONFIG_USART1_TXDMA)
+#  undef SERIAL_HAVE_ONLY_TXDMA
+#elif defined(CONFIG_STM32F7_USART2) && !defined(CONFIG_USART2_TXDMA)
+#  undef SERIAL_HAVE_ONLY_TXDMA
+#elif defined(CONFIG_STM32F7_USART3) && !defined(CONFIG_USART3_TXDMA)
+#  undef SERIAL_HAVE_ONLY_TXDMA
+#elif defined(CONFIG_STM32F7_UART4) && !defined(CONFIG_UART4_TXDMA)
+#  undef SERIAL_HAVE_ONLY_TXDMA
+#elif defined(CONFIG_STM32F7_UART5) && !defined(CONFIG_UART5_TXDMA)
+#  undef SERIAL_HAVE_ONLY_TXDMA
+#elif defined(CONFIG_STM32F7_USART6) && !defined(CONFIG_USART6_TXDMA)
+#  undef SERIAL_HAVE_ONLY_TXDMA
+#elif defined(CONFIG_STM32F7_UART7) && !defined(CONFIG_UART7_TXDMA)
+#  undef SERIAL_HAVE_ONLY_TXDMA
+#elif defined(CONFIG_STM32F7_UART8) && !defined(CONFIG_UART8_TXDMA)
+#  undef SERIAL_HAVE_ONLY_TXDMA
+#endif
+
+#undef SERIAL_HAVE_ONLY_DMA
+#if defined(SERIAL_HAVE_ONLY_RXDMA) && defined(SERIAL_HAVE_ONLY_TXDMA)
+#define SERIAL_HAVE_ONLY_DMA
+#endif
 /* Is RS-485 used? */
 
 #if defined(CONFIG_USART1_RS485) || defined(CONFIG_USART2_RS485) || \
@@ -333,7 +405,7 @@ extern "C"
  *
  ************************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 void stm32_serial_dma_poll(void);
 #endif
 

--- a/arch/arm/src/stm32l4/stm32l4_serial.c
+++ b/arch/arm/src/stm32l4/stm32l4_serial.c
@@ -86,7 +86,7 @@
  *    5       X
  */
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 
 /* Verify that DMA has been enabled and the DMA channel has been defined.
  */
@@ -168,11 +168,11 @@
 
 /* DMA priority */
 
-#  ifndef CONFIG_USART_DMAPRIO
-#    define CONFIG_USART_DMAPRIO  DMA_CCR_PRIMED
+#  ifndef CONFIG_USART_RXDMAPRIO
+#    define CONFIG_USART_RXDMAPRIO  DMA_CCR_PRIMED
 #  endif
-#  if (CONFIG_USART_DMAPRIO & ~DMA_CCR_PL_MASK) != 0
-#    error "Illegal value for CONFIG_USART_DMAPRIO"
+#  if (CONFIG_USART_RXDMAPRIO & ~DMA_CCR_PL_MASK) != 0
+#    error "Illegal value for CONFIG_USART_RXDMAPRIO"
 #  endif
 
 /* DMA control words */
@@ -182,13 +182,13 @@
                DMA_CCR_MINC          | \
                DMA_CCR_PSIZE_8BITS   | \
                DMA_CCR_MSIZE_8BITS   | \
-               CONFIG_USART_DMAPRIO)
+               CONFIG_USART_RXDMAPRIO)
 #  ifdef CONFIG_SERIAL_IFLOWCONTROL
 #    define SERIAL_DMA_IFLOW_CONTROL_WORD \
               (DMA_CCR_MINC          | \
                DMA_CCR_PSIZE_8BITS   | \
                DMA_CCR_MSIZE_8BITS   | \
-               CONFIG_USART_DMAPRIO)
+               CONFIG_USART_RXDMAPRIO)
 #  endif
 
 #endif
@@ -283,13 +283,13 @@ struct stm32l4_serial_s
   const uint32_t    cts_gpio;  /* U[S]ART CTS GPIO pin configuration */
 #endif
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
   const unsigned int rxdma_channel; /* DMA channel assigned */
 #endif
 
   /* RX DMA state */
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
   DMA_HANDLE        rxdma;     /* currently-open receive DMA stream */
   bool              rxenable;  /* DMA-based reception en/disable */
 #ifdef CONFIG_PM
@@ -333,7 +333,7 @@ static void stm32l4serial_send(FAR struct uart_dev_s *dev, int ch);
 static void stm32l4serial_txint(FAR struct uart_dev_s *dev, bool enable);
 static bool stm32l4serial_txready(FAR struct uart_dev_s *dev);
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static int  stm32l4serial_dmasetup(FAR struct uart_dev_s *dev);
 static void stm32l4serial_dmashutdown(FAR struct uart_dev_s *dev);
 static int  stm32l4serial_dmareceive(FAR struct uart_dev_s *dev,
@@ -383,7 +383,7 @@ static const struct uart_ops_s g_uart_ops =
 };
 #endif
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static const struct uart_ops_s g_uart_dma_ops =
 {
   .setup          = stm32l4serial_dmasetup,
@@ -912,7 +912,7 @@ static void stm32l4serial_disableusartint(FAR struct stm32l4_serial_s *priv,
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static int stm32l4serial_dmanextrx(FAR struct stm32l4_serial_s *priv)
 {
   size_t dmaresidual;
@@ -1078,7 +1078,7 @@ static void stm32l4serial_setformat(FAR struct uart_dev_s *dev)
 static void stm32l4serial_setsuspend(struct uart_dev_s *dev, bool suspend)
 {
   FAR struct stm32l4_serial_s *priv = (struct stm32l4_serial_s *)dev->priv;
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
   bool dmarestored = false;
 #endif
 
@@ -1109,7 +1109,7 @@ static void stm32l4serial_setsuspend(struct uart_dev_s *dev, bool suspend)
 
       while ((stm32l4serial_getreg(priv, STM32L4_USART_ISR_OFFSET) & USART_ISR_TC) == 0);
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
       if (priv->dev.ops == &g_uart_dma_ops && !priv->rxdmasusp)
         {
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
@@ -1131,7 +1131,7 @@ static void stm32l4serial_setsuspend(struct uart_dev_s *dev, bool suspend)
     }
   else
     {
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
       if (priv->dev.ops == &g_uart_dma_ops && priv->rxdmasusp)
         {
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
@@ -1167,7 +1167,7 @@ static void stm32l4serial_setsuspend(struct uart_dev_s *dev, bool suspend)
 #endif
     }
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
   if (dmarestored)
     {
       irqstate_t flags;
@@ -1414,7 +1414,7 @@ static int stm32l4serial_setup(FAR struct uart_dev_s *dev)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static int stm32l4serial_dmasetup(FAR struct uart_dev_s *dev)
 {
   FAR struct stm32l4_serial_s *priv = (FAR struct stm32l4_serial_s *)dev->priv;
@@ -1572,7 +1572,7 @@ static void stm32l4serial_shutdown(FAR struct uart_dev_s *dev)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static void stm32l4serial_dmashutdown(FAR struct uart_dev_s *dev)
 {
   FAR struct stm32l4_serial_s *priv = (FAR struct stm32l4_serial_s *)dev->priv;
@@ -2325,7 +2325,7 @@ static bool stm32l4serial_rxflowcontrol(FAR struct uart_dev_s *dev,
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static int stm32l4serial_dmareceive(FAR struct uart_dev_s *dev,
                                     FAR unsigned int *status)
 {
@@ -2366,7 +2366,7 @@ static int stm32l4serial_dmareceive(FAR struct uart_dev_s *dev,
  *
  ****************************************************************************/
 
-#if defined(SERIAL_HAVE_DMA)
+#if defined(SERIAL_HAVE_RXDMA)
 static void stm32l4serial_dmareenable(FAR struct stm32l4_serial_s *priv)
 {
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
@@ -2435,7 +2435,7 @@ static void stm32l4serial_dmareenable(FAR struct stm32l4_serial_s *priv)
  *
  ****************************************************************************/
 
-#if defined(SERIAL_HAVE_DMA) && defined(CONFIG_SERIAL_IFLOWCONTROL)
+#if defined(SERIAL_HAVE_RXDMA) && defined(CONFIG_SERIAL_IFLOWCONTROL)
 static bool stm32l4serial_dmaiflowrestart(struct stm32l4_serial_s *priv)
 {
   if (!priv->rxenable)
@@ -2483,7 +2483,7 @@ static bool stm32l4serial_dmaiflowrestart(struct stm32l4_serial_s *priv)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static void stm32l4serial_dmarxint(FAR struct uart_dev_s *dev, bool enable)
 {
   FAR struct stm32l4_serial_s *priv = (FAR struct stm32l4_serial_s *)dev->priv;
@@ -2517,7 +2517,7 @@ static void stm32l4serial_dmarxint(FAR struct uart_dev_s *dev, bool enable)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static bool stm32l4serial_dmarxavailable(FAR struct uart_dev_s *dev)
 {
   FAR struct stm32l4_serial_s *priv = (FAR struct stm32l4_serial_s *)dev->priv;
@@ -2642,7 +2642,7 @@ static bool stm32l4serial_txready(FAR struct uart_dev_s *dev)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 static void stm32l4serial_dmarxcallback(DMA_HANDLE handle, uint8_t status,
                                         FAR void *arg)
 {
@@ -2798,7 +2798,7 @@ static int stm32l4serial_pmprepare(FAR struct pm_callback_s *cb, int domain,
     case PM_STANDBY:
     case PM_SLEEP:
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
       /* Flush Rx DMA buffers before checking state of serial device
        * buffers.
        */
@@ -2983,7 +2983,7 @@ void up_serialinit(void)
  *
  ****************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 void stm32l4_serial_dma_poll(void)
 {
     irqstate_t flags;

--- a/arch/arm/src/stm32l4/stm32l4_uart.h
+++ b/arch/arm/src/stm32l4/stm32l4_uart.h
@@ -187,11 +187,11 @@
 
 /* Is DMA available on any (enabled) USART? */
 
-#undef SERIAL_HAVE_DMA
+#undef SERIAL_HAVE_RXDMA
 #if defined(CONFIG_USART1_RXDMA) || defined(CONFIG_USART2_RXDMA) || \
     defined(CONFIG_USART3_RXDMA) || defined(CONFIG_UART4_RXDMA)  || \
     defined(CONFIG_UART5_RXDMA)
-#  define SERIAL_HAVE_DMA 1
+#  define SERIAL_HAVE_RXDMA 1
 #endif
 
 /* Is DMA used on the console UART? */
@@ -274,7 +274,7 @@ extern "C"
  *
  ************************************************************************************/
 
-#ifdef SERIAL_HAVE_DMA
+#ifdef SERIAL_HAVE_RXDMA
 void stm32l4_serial_dma_poll(void);
 #endif
 

--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -550,14 +550,14 @@ config UART_TXDMA
 	default n
 	select SERIAL_TXDMA
 	---help---
-		Enable DMA transfers on UART
+		Enable Tx DMA transfers on UART
 
 config UART_RXDMA
 	bool "UART Rx DMA support"
 	default n
 	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on UART
+		Enable Rx DMA transfers on UART
 
 endmenu
 

--- a/drivers/serial/Kconfig-lpuart
+++ b/drivers/serial/Kconfig-lpuart
@@ -133,12 +133,19 @@ config LPUART0_OFLOWCONTROL
 	---help---
 		Enable CTS flow control
 
-config LPUART0_DMA
-	bool "LPUART0 DMA support"
+config LPUART0_RXDMA
+	bool "LPUART0 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers
+		Enable Rx DMA transfers on LPUART0
+
+config LPUART0_TXDMA
+	bool "LPUART0 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on LPUART0
 
 endmenu
 
@@ -222,12 +229,19 @@ config LPUART1_OFLOWCONTROL
 	---help---
 		Enable CTS flow control
 
-config LPUART1_DMA
-	bool "LPUART1 DMA support"
+config LPUART1_RXDMA
+	bool "LPUART1 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers
+		Enable Rx DMA transfers on LPUART1
+
+config LPUART1_TXDMA
+	bool "LPUART1 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on LPUART1
 
 endmenu
 
@@ -313,12 +327,19 @@ config LPUART2_OFLOWCONTROL
 	---help---
 		Enable CTS flow control
 
-config LPUART2_DMA
-	bool "LPUART2 DMA support"
+config LPUART2_RXDMA
+	bool "LPUART2 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers
+		Enable Rx DMA transfers on LPUART2
+
+config LPUART2_TXDMA
+	bool "LPUART2 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on LPUART2
 
 endmenu
 
@@ -402,12 +423,19 @@ config LPUART3_OFLOWCONTROL
 	---help---
 		Enable CTS flow control
 
-config LPUART3_DMA
-	bool "LPUART3 DMA support"
+config LPUART3_RXDMA
+	bool "LPUART3 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers
+		Enable Rx DMA transfers on LPUART3
+
+config LPUART3_TXDMA
+	bool "LPUART3 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on LPUART3
 
 endmenu
 
@@ -491,12 +519,19 @@ config LPUART4_OFLOWCONTROL
 	---help---
 		Enable CTS flow control
 
-config LPUART4_DMA
-	bool "LPUART4 DMA support"
+config LPUART4_RXDMA
+	bool "LPUART4 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers
+		Enable Rx DMA transfers on LPUART4
+
+config LPUART4_TXDMA
+	bool "LPUART4 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on LPUART4
 
 endmenu
 
@@ -580,12 +615,19 @@ config LPUART5_OFLOWCONTROL
 	---help---
 		Enable CTS flow control
 
-config LPUART5_DMA
-	bool "LPUART5 DMA support"
+config LPUART5_RXDMA
+	bool "LPUART5 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers
+		Enable Rx DMA transfers on LPUART5
+
+config LPUART5_TXDMA
+	bool "LPUART5 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on LPUART5
 
 endmenu
 
@@ -669,12 +711,19 @@ config LPUART6_OFLOWCONTROL
 	---help---
 		Enable CTS flow control
 
-config LPUART6_DMA
-	bool "LPUART6 DMA support"
+config LPUART6_RXDMA
+	bool "LPUART6 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers
+		Enable Rx DMA transfers on LPUART6
+
+config LPUART6_TXDMA
+	bool "LPUART6 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on LPUART6
 
 endmenu
 
@@ -758,12 +807,19 @@ config LPUART7_OFLOWCONTROL
 	---help---
 		Enable CTS flow control
 
-config LPUART7_DMA
-	bool "LPUART7 DMA support"
+config LPUART7_RXDMA
+	bool "LPUART7 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers
+		Enable Rx DMA transfers on LPUART7
+
+config LPUART7_TXDMA
+	bool "LPUART7 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on LPUART7
 
 endmenu
 
@@ -847,11 +903,18 @@ config LPUART8_OFLOWCONTROL
 	---help---
 		Enable CTS flow control
 
-config LPUART8_DMA
-	bool "LPUART8 DMA support"
+config LPUART8_RXDMA
+	bool "LPUART8 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers
+		Enable Rx DMA transfers on LPUART8
+
+config LPUART8_TXDMA
+	bool "LPUART8 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on LPUART8
 
 endmenu

--- a/drivers/serial/Kconfig-uart
+++ b/drivers/serial/Kconfig-uart
@@ -109,12 +109,19 @@ config UART0_OFLOWCONTROL
 	---help---
 		Enable UART0 CTS flow control
 
-config UART0_DMA
-	bool "UART0 DMA support"
+config UART0_RXDMA
+	bool "UART0 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on UART0
+		Enable Rx DMA transfers on UART0
+
+config UART0_TXDMA
+	bool "UART0 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on UART0
 
 endmenu
 
@@ -174,12 +181,19 @@ config UART1_OFLOWCONTROL
 	---help---
 		Enable UART1 CTS flow control
 
-config UART1_DMA
-	bool "UART1 DMA support"
+config UART1_RXDMA
+	bool "UART1 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on UART1
+		Enable Rx DMA transfers on UART1
+
+config UART1_TXDMA
+	bool "UART1 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on UART1
 
 endmenu
 
@@ -239,12 +253,19 @@ config UART2_OFLOWCONTROL
 	---help---
 		Enable UART2 CTS flow control
 
-config UART2_DMA
-	bool "UART2 DMA support"
+config UART2_RXDMA
+	bool "UART2 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on UART2
+		Enable Rx DMA transfers on UART2
+
+config UART2_TXDMA
+	bool "UART2 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on UART2
 
 endmenu
 
@@ -304,12 +325,19 @@ config UART3_OFLOWCONTROL
 	---help---
 		Enable UART3 CTS flow control
 
-config UART3_DMA
-	bool "UART3 DMA support"
+config UART3_RXDMA
+	bool "UART3 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on UART3
+		Enable Rx DMA transfers on UART3
+
+config UART3_TXDMA
+	bool "UART3 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on UART3
 
 endmenu
 
@@ -369,12 +397,19 @@ config UART4_OFLOWCONTROL
 	---help---
 		Enable UART4 CTS flow control
 
-config UART4_DMA
-	bool "UART4 DMA support"
+config UART4_RXDMA
+	bool "UART4 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on UART4
+		Enable Rx DMA transfers on UART4
+
+config UART4_TXDMA
+	bool "UART4 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on UART4
 
 endmenu
 
@@ -434,12 +469,19 @@ config UART5_OFLOWCONTROL
 	---help---
 		Enable UART5 CTS flow control
 
-config UART5_DMA
-	bool "UART5 DMA support"
+config UART5_RXDMA
+	bool "UART5 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on UART5
+		Enable Rx DMA transfers on UART5
+
+config UART5_TXDMA
+	bool "UART5 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on UART5
 
 endmenu
 
@@ -499,12 +541,19 @@ config UART6_OFLOWCONTROL
 	---help---
 		Enable UART6 CTS flow control
 
-config UART6_DMA
-	bool "UART6 DMA support"
+config UART6_RXDMA
+	bool "UART6 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on UART6
+		Enable Rx DMA transfers on UART6
+
+config UART6_TXDMA
+	bool "UART6 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on UART6
 
 endmenu
 
@@ -564,12 +613,19 @@ config UART7_OFLOWCONTROL
 	---help---
 		Enable UART7 CTS flow control
 
-config UART7_DMA
-	bool "UART7 DMA support"
+config UART7_RXDMA
+	bool "UART7 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on UART7
+		Enable Rx DMA transfers on UART7
+
+config UART7_TXDMA
+	bool "UART7 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on UART7
 
 endmenu
 
@@ -629,11 +685,18 @@ config UART8_OFLOWCONTROL
 	---help---
 		Enable UART8 CTS flow control
 
-config UART8_DMA
-	bool "UART8 DMA support"
+config UART8_RXDMA
+	bool "UART8 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on UART8
+		Enable Rx DMA transfers on UART8
+
+config UART8_TXDMA
+	bool "UART8 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on UART8
 
 endmenu

--- a/drivers/serial/Kconfig-usart
+++ b/drivers/serial/Kconfig-usart
@@ -109,12 +109,19 @@ config USART0_OFLOWCONTROL
 	---help---
 		Enable USART0 CTS flow control
 
-config USART0_DMA
-	bool "USART0 DMA support"
+config USART0_RXDMA
+	bool "USART0 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on USART0
+		Enable Rx DMA transfers on USART0
+
+config USART0_TXDMA
+	bool "USART0 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on USART0
 
 endmenu
 
@@ -174,12 +181,19 @@ config USART1_OFLOWCONTROL
 	---help---
 		Enable USART1 CTS flow control
 
-config USART1_DMA
-	bool "USART1 DMA support"
+config USART1_RXDMA
+	bool "USART1 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on USART1
+		Enable Rx DMA transfers on USART1
+
+config USART1_TXDMA
+	bool "USART1 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on USART1
 
 endmenu
 
@@ -239,12 +253,19 @@ config USART2_OFLOWCONTROL
 	---help---
 		Enable USART2 CTS flow control
 
-config USART2_DMA
-	bool "USART2 DMA support"
+config USART2_RXDMA
+	bool "USART2 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on USART2
+		Enable Rx DMA transfers on USART2
+
+config USART2_TXDMA
+	bool "USART2 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on USART2
 endmenu
 
 menu "USART3 Configuration"
@@ -303,12 +324,19 @@ config USART3_OFLOWCONTROL
 	---help---
 		Enable USART3 CTS flow control
 
-config USART3_DMA
-	bool "USART3 DMA support"
+config USART3_RXDMA
+	bool "USART3 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on USART3
+		Enable Rx DMA transfers on USART3
+
+config USART3_TXDMA
+	bool "USART3 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on USART3
 
 endmenu
 
@@ -368,12 +396,19 @@ config USART4_OFLOWCONTROL
 	---help---
 		Enable USART4 CTS flow control
 
-config USART4_DMA
-	bool "USART4 DMA support"
+config USART4_RXDMA
+	bool "USART4 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on USART4
+		Enable Rx DMA transfers on USART4
+
+config USART4_TXDMA
+	bool "USART4 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on USART4
 
 endmenu
 
@@ -433,12 +468,19 @@ config USART5_OFLOWCONTROL
 	---help---
 		Enable USART5 CTS flow control
 
-config USART5_DMA
-	bool "USART5 DMA support"
+config USART5_RXDMA
+	bool "USART5 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on USART5
+		Enable Rx DMA transfers on USART5
+
+config USART5_TXDMA
+	bool "USART5 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on USART5
 
 endmenu
 
@@ -498,12 +540,19 @@ config USART6_OFLOWCONTROL
 	---help---
 		Enable USART6 CTS flow control
 
-config USART6_DMA
-	bool "USART6 DMA support"
+config USART6_RXDMA
+	bool "USART6 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on USART6
+		Enable Rx DMA transfers on USART6
+
+config USART6_TXDMA
+	bool "USART6 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on USART6
 
 endmenu
 
@@ -563,12 +612,19 @@ config USART7_OFLOWCONTROL
 	---help---
 		Enable USART7 CTS flow control
 
-config USART7_DMA
-	bool "USART7 DMA support"
+config USART7_RXDMA
+	bool "USART7 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on USART7
+		Enable Rx DMA transfers on USART7
+
+config USART7_TXDMA
+	bool "USART7 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on USART7
 
 endmenu
 
@@ -628,12 +684,19 @@ config USART8_OFLOWCONTROL
 	---help---
 		Enable USART8 CTS flow control
 
-config USART8_DMA
-	bool "USART8 DMA support"
+config USART8_RXDMA
+	bool "USART8 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on USART8
+		Enable Rx DMA transfers on USART8
+
+config USART8_TXDMA
+	bool "USART8 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on USART8
 
 endmenu
 
@@ -693,11 +756,18 @@ config USART9_OFLOWCONTROL
 	---help---
 		Enable USART9 CTS flow control
 
-config USART9_DMA
-	bool "USART9 DMA support"
+config USART9_RXDMA
+	bool "USART9 Rx DMA support"
 	default n
-	select SERIAL_DMA
+	select SERIAL_RXDMA
 	---help---
-		Enable DMA transfers on USART9
+		Enable Rx DMA transfers on USART9
+
+config USART9_TXDMA
+	bool "USART9 Tx DMA support"
+	default n
+	select SERIAL_TXDMA
+	---help---
+		Enable Tx DMA transfers on USART9
 
 endmenu


### PR DESCRIPTION
[BACKPORT] arch/arm/src/stm32f0l0g0/stm32_serial_v1.c:  CONFIG_USART_DMAPRIO->CONFIG_USART_RXDMAPRIO

[BACKPORT] arch/arm/src/stm32l4/stm32l4_serial.c: CONFIG_USART_DMAPRIO->CONFIG_USART_RXDMAPRIO.

[BACKPORT] arch/arm/src/stm32f0l0g0/stm32_serial_v1.c: SERIAL_HAVE_DMA->SERIAL_HAVE_RXDMA.

[BACKPORT] arch/arm/src/stm32l4/stm32l4_serial.c: SERIAL_HAVE_DMA->SERIAL_HAVE_RXDMA.

[BACKPORT] arch/arm/src/stm32/stm32_hciuart.c:  CONFIG_STM32_HCIUART_DMAPRIO->CONFIG_STM32_HCIUART_RXDMAPRIO.

[BACKPORT] arch/arm/src/stm32/stm32_serial.c:  SERIAL_HAVE_DMA->SERIAL_HAVE_RXDMA.

[BACKPORT] arch/arm/src/stm32f7/stm32_serial.c:  CONFIG_USART_DMAPRIO->CONFIG_USART_RXDMAPRIO.

[BACKPORT] arch/arm/src/stm32f7/stm32_serial.c:  Add Tx U[S]ART DMA.

[BACKPORT] arch/arm/src/stm32f7/stm32_serial.c:  Serial nxsyle fixes (sans long table lines).

[BACKPORT] Merged in david_s5/nuttx-5/David-Sidrane/archarmsrcstm32f7stm32_serialc-fix-typo-1575381167793 (pull request #1087)

arch/arm/src/stm32f7/stm32_serial.c:  Fix typo in UART7

Approved-by: Gregory Nutt <gnutt@nuttx.org>