### PR TITLE
Fix mistakes done by PR #96

### DIFF
--- a/net/socket/Make.defs
+++ b/net/socket/Make.defs
@@ -37,8 +37,8 @@
 
 SOCK_CSRCS += bind.c connect.c getsockname.c getpeername.c
 SOCK_CSRCS += recv.c recvfrom.c send.c sendto.c
-SOCK_CSRCS += socket.c net_sockets.c net_close.c net_dup.c
-SOCK_CSRCS += net_dup2.c net_sockif.c net_poll.c net_vfcntl.c
+SOCK_CSRCS += socket.c net_sockets.c net_close.c net_dupsd.c
+SOCK_CSRCS += net_dupsd2.c net_sockif.c net_clone.c net_poll.c net_vfcntl.c
 SOCK_CSRCS += net_fstat.c
 
 # TCP/IP support


### PR DESCRIPTION
While backporting SocketCAN #96 this make.defs caused a net_dup.o compile error.
This PR fixes that error