### PR TITLE
Fixed hard fault in FlexCAN drivers

### DIFF
--- a/arch/arm/src/kinetis/kinetis_flexcan.c
+++ b/arch/arm/src/kinetis/kinetis_flexcan.c
@@ -354,24 +354,25 @@ static uint8_t g_rx_pool[sizeof(struct can_frame)*POOL_SIZE];
  ****************************************************************************/
 
 /****************************************************************************
- * Name: arm_clz
+ * Name: arm_lsb
  *
  * Description:
- *   Access to CLZ instructions
+ *   Calculate position of lsb that's equal to 1
  *
  * Input Parameters:
- *   value - The value to perform the Count Leading Zeros operation on
+ *   value - The value to perform the operation on
  *
  * Returned Value:
- *   None
+ *   location of lsb which is equal to 1, returns 32 when value is 0
  *
  ****************************************************************************/
 
-static inline uint32_t arm_clz(unsigned int value)
+static inline uint32_t arm_lsb(unsigned int value)
 {
   uint32_t ret;
-
-  __asm__ __volatile__ ("clz %0, %1" : "=r"(ret) : "r"(value));
+  volatile uint32_t rvalue = value;
+  __asm__ __volatile__ ("rbit %1,%0" : "=r" (rvalue) : "r" (rvalue));
+  __asm__ __volatile__ ("clz %0, %1" : "=r"(ret) : "r"(rvalue));
   return ret;
 }
 
@@ -420,7 +421,9 @@ uint32_t kinetis_bitratetotimeseg(struct flexcan_timeseg *timeseg,
           continue;
         }
 
-      /* The number of time quanta in 1 bit time must be lower than the one supported */
+      /* The number of time quanta in 1 bit time must be
+       * lower than the one supported
+       */
 
       if ((CLK_FREQ / ((tmppresdiv + 1) * numtq) == timeseg->bitrate)
           && (numtq >= 8) && (numtq < NUMTQMAX))
@@ -828,13 +831,12 @@ static int kinetis_txpoll(struct net_driver_s *dev)
 static void kinetis_receive(FAR struct kinetis_driver_s *priv,
                             uint32_t flags)
 {
-  uint32_t regval;
   uint32_t mb_index;
   struct mb_s *rf;
 
-  while ((mb_index = arm_clz(flags)) != 32)
+  while ((mb_index = arm_lsb(flags)) != 32)
     {
-      rf = &priv->rx[31 - mb_index];
+      rf = &priv->rx[mb_index];
 
       /* Read the frame contents */
 
@@ -869,9 +871,8 @@ static void kinetis_receive(FAR struct kinetis_driver_s *priv,
 
           /* Clear MB interrupt flag */
 
-          regval  = getreg32(priv->base + KINETIS_CAN_IFLAG1_OFFSET);
-          regval |= (0x80000000 >> mb_index);
-          putreg32(regval, priv->base + KINETIS_CAN_IFLAG1_OFFSET);
+          putreg32(1 << mb_index,
+                   priv->base + KINETIS_CAN_IFLAG1_OFFSET);
 
           /* Copy the buffer pointer to priv->dev..  Set amount of data
            * in priv->dev.d_len
@@ -907,9 +908,8 @@ static void kinetis_receive(FAR struct kinetis_driver_s *priv,
 
           /* Clear MB interrupt flag */
 
-          regval  = getreg32(priv->base + KINETIS_CAN_IFLAG1_OFFSET);
-          regval |= (1 << mb_index);
-          putreg32(regval, priv->base + KINETIS_CAN_IFLAG1_OFFSET);
+          putreg32(1 << mb_index,
+                   priv->base + KINETIS_CAN_IFLAG1_OFFSET);
 
           /* Copy the buffer pointer to priv->dev..  Set amount of data
            * in priv->dev.d_len
@@ -934,10 +934,15 @@ static void kinetis_receive(FAR struct kinetis_driver_s *priv,
 
       priv->dev.d_buf = (uint8_t *)priv->txdesc;
 
-      /* Reread interrupt flags and process them in this loop wh */
+      flags &= ~(1 << mb_index);
 
-      flags  = getreg32(priv->base + KINETIS_CAN_IFLAG1_OFFSET);
-      flags &= IFLAG1_RX;
+      /* Reread interrupt flags and process them in this loop */
+
+      if(flags == 0)
+        {
+          flags  = getreg32(priv->base + KINETIS_CAN_IFLAG1_OFFSET);
+          flags &= IFLAG1_RX;
+        }
     }
 }
 
@@ -1017,24 +1022,27 @@ static void kinetis_txdone(FAR struct kinetis_driver_s *priv, uint32_t flags)
 static int kinetis_flexcan_interrupt(int irq, FAR void *context,
                                      FAR void *arg)
 {
-  FAR struct kinetis_driver_s *priv = (struct kinetis_driver_s *)arg;
-  uint32_t flags;
-  flags  = getreg32(priv->base + KINETIS_CAN_IFLAG1_OFFSET);
-  flags &= IFLAG1_RX;
+ FAR struct kinetis_driver_s *priv = (struct kinetis_driver_s *)arg;
 
-  if (flags)
-    {
-      kinetis_receive(priv, flags);
-    }
+  if(irq == priv->config->mb_irq) {
+    uint32_t flags;
+    flags  = getreg32(priv->base + KINETIS_CAN_IFLAG1_OFFSET);
+    flags &= IFLAG1_RX;
 
-  flags  = getreg32(priv->base + KINETIS_CAN_IFLAG1_OFFSET);
-  flags &= IFLAG1_TX;
+    if (flags)
+      {
+        kinetis_receive(priv, flags);
+      }
 
-  if (flags)
-    {
-      kinetis_txdone(priv, flags);
-    }
+    flags  = getreg32(priv->base + KINETIS_CAN_IFLAG1_OFFSET);
+    flags &= IFLAG1_TX;
 
+    if (flags)
+      {
+        kinetis_txdone(priv, flags);
+      }
+
+  }
   return OK;
 }
 

--- a/arch/arm/src/s32k1xx/Kconfig
+++ b/arch/arm/src/s32k1xx/Kconfig
@@ -245,6 +245,15 @@ config S32K1XX_LPUART2
 config S32K1XX_RTC
 	bool "RTC"
 	default n
+	
+config S32K1XX_PROGMEM
+    bool PROGMEM
+    default n
+    select ARCH_HAVE_PROGMEM
+    depends on (ARCH_CHIP_S32K11X || (ARCH_CHIP_S32K14X && !ARCH_CHIP_S32K148) )
+    ---help---
+        Use the FlexNVM 32/64 KB of d-flash memory as a
+		Memory-Technology-Device (MTD).
 
 
 endmenu # S32K1XX Peripheral Selection
@@ -597,5 +606,19 @@ config FLEXCAN2_DATA_SAMPLEP
 	default 90
 	
 endmenu # S32K1XX_FLEXCAN0
+
+menu "PROGMEM Configuration"
+	depends on S32K1XX_PROGMEM
+	
+config PROGMEM_SIZE
+	int "Progmem size (KB)"
+	default 64 if ARCH_CHIP_S32K14X
+	default 32 if ARCH_CHIP_S32K11X
+	
+config PROGMEM_SMARTFS_AUTOMOUNT
+	bool "Automount SmartFS partition"
+	depends on (MTD_SMART && FS_SMARTFS)
+	default y
+endmenu
 
 endif # ARCH_CHIP_S32K1XX

--- a/arch/arm/src/s32k1xx/Make.defs
+++ b/arch/arm/src/s32k1xx/Make.defs
@@ -98,6 +98,10 @@ ifeq ($(CONFIG_S32K1XX_RTC),y)
 CHIP_CSRCS += s32k1xx_rtc.c
 endif
 
+ifeq ($(CONFIG_S32K1XX_PROGMEM),y)
+CHIP_CSRCS += s32k1xx_progmem.c
+endif
+
 # Source files specific to the ARM CPU family and to the S32K1xx chip family
 
 ifeq ($(CONFIG_ARCH_CHIP_S32K11X),y)

--- a/arch/arm/src/s32k1xx/hardware/s32k1xx_ftfc.h
+++ b/arch/arm/src/s32k1xx/hardware/s32k1xx_ftfc.h
@@ -1,0 +1,143 @@
+/*****************************************************************************************************
+ * arch/arm/src/s32k1xx/chip/s32k1xx_ftfc.h
+ *
+ *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
+ *   Author: Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ *****************************************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_S32K1XX_HARDWARE_S32K1XX_FTFC_H
+#define __ARCH_ARM_SRC_S32K1XX_HARDWARE_S32K1XX_FTFC_H
+
+/*****************************************************************************************************
+ * Included Files
+ *****************************************************************************************************/
+
+#include <nuttx/config.h>
+#include <hardware/s32k1xx_memorymap.h>
+
+/*****************************************************************************************************
+ * Pre-processor Definitions
+ *****************************************************************************************************/
+
+/* FTFC Register Offsets *****************************************************************************/
+
+/* FTFC Register Offsets *****************************************************************************/
+
+#define S32K1XX_FTFC_FSTAT_OFFSET	                     0x0000
+#define S32K1XX_FTFC_FCNFG_OFFSET	                     0x0001
+#define S32K1XX_FTFC_FSEC_OFFSET	                     0x0002
+#define S32K1XX_FTFC_FOPT_OFFSET	                     0x0003
+#define S32K1XX_FTFC_FCCOB3_OFFSET	                     0x0004
+#define S32K1XX_FTFC_FCCOB2_OFFSET	                     0x0005
+#define S32K1XX_FTFC_FCCOB1_OFFSET	                     0x0006
+#define S32K1XX_FTFC_FCCOB0_OFFSET	                     0x0007
+#define S32K1XX_FTFC_FCCOB7_OFFSET	                     0x0008
+#define S32K1XX_FTFC_FCCOB6_OFFSET	                     0x0009
+#define S32K1XX_FTFC_FCCOB5_OFFSET	                     0x000a
+#define S32K1XX_FTFC_FCCOB4_OFFSET	                     0x000b
+#define S32K1XX_FTFC_FCCOBB_OFFSET	                     0x000c
+#define S32K1XX_FTFC_FCCOBA_OFFSET	                     0x000d
+#define S32K1XX_FTFC_FCCOB9_OFFSET	                     0x000e
+#define S32K1XX_FTFC_FCCOB8_OFFSET	                     0x000f
+#define S32K1XX_FTFC_FPROT3_OFFSET	                     0x0010
+#define S32K1XX_FTFC_FPROT2_OFFSET	                     0x0011
+#define S32K1XX_FTFC_FPROT1_OFFSET	                     0x0012
+#define S32K1XX_FTFC_FPROT0_OFFSET	                     0x0013
+#define S32K1XX_FTFC_FEPROT_OFFSET	                     0x0016
+#define S32K1XX_FTFC_FDPROT_OFFSET	                     0x0017
+#define S32K1XX_FTFC_FCSESTAT_OFFSET                     0x002c
+#define S32K1XX_FTFC_FERSTAT_OFFSET	                     0x002e
+#define S32K1XX_FTFC_FERCNFG_OFFSET	                     0x002f
+
+/* FTFC Register Addresses ***************************************************************************/
+
+#define S32K1XX_FTFC_FSTAT                               (S32K1XX_FTFC_BASE + S32K1XX_FTFC_FSTAT_OFFSET)
+#define S32K1XX_FTFC_FCNFG                               (S32K1XX_FTFC_BASE + S32K1XX_FTFC_FCNFG_OFFSET)
+#define S32K1XX_FTFC_FSEC                                (S32K1XX_FTFC_BASE + S32K1XX_FTFC_FSEC_OFFSET)
+#define S32K1XX_FTFC_FOPT                                (S32K1XX_FTFC_BASE + S32K1XX_FTFC_FOPT_OFFSET)
+#define S32K1XX_FTFC_FCCOB3                              (S32K1XX_FTFC_BASE + S32K1XX_FTFC_FCCOB3_OFFSET)
+#define S32K1XX_FTFC_FCCOB2                              (S32K1XX_FTFC_BASE + S32K1XX_FTFC_FCCOB2_OFFSET)
+#define S32K1XX_FTFC_FCCOB1                              (S32K1XX_FTFC_BASE + S32K1XX_FTFC_FCCOB1_OFFSET)
+#define S32K1XX_FTFC_FCCOB0                              (S32K1XX_FTFC_BASE + S32K1XX_FTFC_FCCOB0_OFFSET)
+#define S32K1XX_FTFC_FCCOB7                              (S32K1XX_FTFC_BASE + S32K1XX_FTFC_FCCOB7_OFFSET)
+#define S32K1XX_FTFC_FCCOB6                              (S32K1XX_FTFC_BASE + S32K1XX_FTFC_FCCOB6_OFFSET)
+#define S32K1XX_FTFC_FCCOB5                              (S32K1XX_FTFC_BASE + S32K1XX_FTFC_FCCOB5_OFFSET)
+#define S32K1XX_FTFC_FCCOB4                              (S32K1XX_FTFC_BASE + S32K1XX_FTFC_FCCOB4_OFFSET)
+#define S32K1XX_FTFC_FCCOBB                              (S32K1XX_FTFC_BASE + S32K1XX_FTFC_FCCOBB_OFFSET)
+#define S32K1XX_FTFC_FCCOBA                              (S32K1XX_FTFC_BASE + S32K1XX_FTFC_FCCOBA_OFFSET)
+#define S32K1XX_FTFC_FCCOB9                              (S32K1XX_FTFC_BASE + S32K1XX_FTFC_FCCOB9_OFFSET)
+#define S32K1XX_FTFC_FCCOB8                              (S32K1XX_FTFC_BASE + S32K1XX_FTFC_FCCOB8_OFFSET)
+#define S32K1XX_FTFC_FPROT3                              (S32K1XX_FTFC_BASE + S32K1XX_FTFC_FPROT3_OFFSET)
+#define S32K1XX_FTFC_FPROT2                              (S32K1XX_FTFC_BASE + S32K1XX_FTFC_FPROT2_OFFSET)
+#define S32K1XX_FTFC_FPROT1                              (S32K1XX_FTFC_BASE + S32K1XX_FTFC_FPROT1_OFFSET)
+#define S32K1XX_FTFC_FPROT0                              (S32K1XX_FTFC_BASE + S32K1XX_FTFC_FPROT0_OFFSET)
+#define S32K1XX_FTFC_FEPROT                              (S32K1XX_FTFC_BASE + S32K1XX_FTFC_FEPROT_OFFSET)
+#define S32K1XX_FTFC_FDPROT                              (S32K1XX_FTFC_BASE + S32K1XX_FTFC_FDPROT_OFFSET)
+#define S32K1XX_FTFC_FCSESTAT                            (S32K1XX_FTFC_BASE + S32K1XX_FTFC_FCSESTAT_OFFSET)
+#define S32K1XX_FTFC_FERSTAT                             (S32K1XX_FTFC_BASE + S32K1XX_FTFC_FERSTAT_OFFSET)
+#define S32K1XX_FTFC_FERCNFG                             (S32K1XX_FTFC_BASE + S32K1XX_FTFC_FERCNFG_OFFSET)
+
+/* FTFC Register Bitfield Definitions ****************************************************************/
+
+#define FTTC_FSTAT_MGSTAT0                               (1 << 0)
+#define FTTC_FSTAT_FPVIOL                                (1 << 4)
+#define FTTC_FSTAT_ACCERR                                (1 << 5)
+#define FTTC_FSTAT_RDCOLERR                              (1 << 6)
+#define FTTC_FSTAT_CCIF                                  (1 << 7)
+
+#define FTTC_FCNFG_EEERDY                                (1 << 0)
+#define FTTC_FCNFG_RAMRDY                                (1 << 1)
+
+/* Flash controller command numbers ******************************************************************/
+
+#define S32K1XX_FTFC_VERIFY_BLOCK                        0x00 /* RD1BLK*/
+#define S32K1XX_FTFC_VERIFY_SECTION                      0x01 /* RD1SEC*/
+#define S32K1XX_FTFC_PROGRAM_CHECK                       0x02 /* PGMCHK*/
+#define S32K1XX_FTFC_READ_RESOURCE                       0x03 /* RDRSRC*/
+#define S32K1XX_FTFC_PROGRAM_LONGWORD                    0x06 /* PGM4*/
+#define S32K1XX_FTFC_PROGRAM_PHRASE                      0x07 /* PGM8*/
+#define S32K1XX_FTFC_ERASE_BLOCK                         0x08 /* ERSBLK*/
+#define S32K1XX_FTFC_ERASE_SECTOR                        0x09 /* ERSSCR*/
+#define S32K1XX_FTFC_PROGRAM_SECTION                     0x0B /* PGMSEC*/
+#define S32K1XX_FTFC_GENERATE_CRC                        0x0C /* CRCGEN*/
+#define S32K1XX_FTFC_VERIFY_ALL_BLOCK                    0x40 /* RD1ALL*/
+#define S32K1XX_FTFC_READ_ONCE                           0x41 /* RDONCE or RDINDEX*/
+#define S32K1XX_FTFC_PROGRAM_ONCE                        0x43 /* PGMONCE or PGMINDEX*/
+#define S32K1XX_FTFC_ERASE_ALL_BLOCK                     0x44 /* ERSALL*/
+#define S32K1XX_FTFC_SECURITY_BY_PASS                    0x45 /* VFYKEY*/
+#define S32K1XX_FTFC_SWAP_CONTROL                        0x46 /* SWAP*/
+#define S32K1XX_FTFC_ERASE_ALL_BLOCK_UNSECURE            0x49 /* ERSALLU*/
+#define S32K1XX_FTFC_VERIFY_ALL_EXECUTE_ONLY_SEGMENT     0x4A /* RD1XA*/
+#define S32K1XX_FTFC_ERASE_ALL_EXECUTE_ONLY_SEGMENT      0x4B /* ERSXA*/
+#define S32K1XX_FTFC_PROGRAM_PARTITION                   0x80 /* PGMPART */
+#define S32K1XX_FTFC_SET_FLEXRAM_FUNCTION                0x81 /* SETRAM */
+
+#endif /* __ARCH_ARM_SRC_S32K1XX_HARDWARE_S32K1XX_FTFC_H */

--- a/arch/arm/src/s32k1xx/s32k1xx_progmem.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_progmem.c
@@ -1,0 +1,481 @@
+/******************************************************************************
+ * arch/arm/src/s32k1xx/s32k1xx_progmem.c
+ *
+ *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
+ *   Author:  Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Included Files
+ ******************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <assert.h>
+#include <errno.h>
+
+#include "up_arch.h"
+
+#include "hardware/s32k1xx_ftfc.h"
+
+#include "s32k1xx_config.h"
+#include "s32k1xx_progmem.h"
+
+#include "up_internal.h"
+
+#include <arch/board/board.h> /* Include last:  has dependencies */
+
+/******************************************************************************
+ * Pre-processor Definitions
+ ******************************************************************************/
+#ifdef CONFIG_MTD_SMART
+# ifndef CONFIG_MTD_SMART_ENABLE_CRC
+#  error SmartFS CRC has to be enbabled with this driver
+# endif
+#endif
+
+/******************************************************************************
+ * Private Data
+ ******************************************************************************/
+
+union fccob_flash_addr
+{
+    uint32_t addr;
+    struct
+    {
+        uint8_t fccob3;
+        uint8_t fccob2;
+        uint8_t fccob1;
+        uint8_t pad;
+    } fccobs;
+};
+
+/******************************************************************************
+ * Private Functions
+ ******************************************************************************/
+
+static inline void wait_ftfc_ready()
+{
+  while ((getreg8(S32K1XX_FTFC_FSTAT) & FTTC_FSTAT_CCIF) == 0)
+    {
+      /* Busy */
+    }
+}
+
+static uint32_t execute_ftfc_command()
+{
+  uint8_t regval;
+  uint32_t retval = 0;
+
+  /* Clear CCIF to launch command */
+
+  regval = getreg8(S32K1XX_FTFC_FSTAT);
+  regval |= FTTC_FSTAT_CCIF;
+  putreg8(regval, S32K1XX_FTFC_FSTAT);
+
+  wait_ftfc_ready();
+
+  retval = getreg8(S32K1XX_FTFC_FSTAT);
+
+  if (retval & (FTTC_FSTAT_MGSTAT0 | FTTC_FSTAT_FPVIOL |
+                FTTC_FSTAT_ACCERR | FTTC_FSTAT_RDCOLERR))
+    {
+      return retval; /* Error has occured */
+    }
+
+  return retval;
+}
+
+/******************************************************************************
+ * Public Functions
+ ******************************************************************************/
+
+/******************************************************************************
+ * Name: up_progmem_neraseblocks
+ *
+ * Description:
+ *   Return number of erase blocks
+ *
+ ******************************************************************************/
+
+size_t up_progmem_neraseblocks(void)
+{
+  return S32K1XX_PROGMEM_SECTOR_COUNT;
+}
+
+/******************************************************************************
+ * Name: up_progmem_isuniform
+ *
+ * Description:
+ *   Is program memory uniform or page size differs?
+ *
+ ******************************************************************************/
+
+bool up_progmem_isuniform(void)
+{
+  return true;
+}
+
+/******************************************************************************
+ * Name: up_progmem_pagesize
+ *
+ * Description:
+ *   Return read/write page size
+ *
+ ******************************************************************************/
+
+size_t up_progmem_pagesize(size_t page)
+{
+  return (size_t)S32K1XX_PROGMEM_PAGE_SIZE;
+}
+
+/******************************************************************************
+ * Name: up_progmem_erasesize
+ *
+ * Description:
+ *   Return erase block size
+ *
+ ******************************************************************************/
+
+size_t up_progmem_erasesize(size_t block)
+{
+  return (size_t)S32K1XX_PROGMEM_BLOCK_SECTOR_SIZE;
+}
+
+/******************************************************************************
+ * Name: up_progmem_getpage
+ *
+ * Description:
+ *   Address to read/write page conversion
+ *
+ * Input Parameters:
+ *   addr - Address with or without flash offset (absolute or aligned to page0)
+ *
+ * Returned Value:
+ *   Page or negative value on error.  The following errors are reported
+ *   (errno is not set!):
+ *
+ *     -EFAULT: On invalid address
+ *
+ ******************************************************************************/
+
+ssize_t up_progmem_getpage(size_t addr)
+{
+  if (addr >= S32K1XX_PROGMEM_START_ADDR)
+    {
+      addr -= S32K1XX_PROGMEM_START_ADDR;
+    }
+
+  return (size_t)(addr / S32K1XX_PROGMEM_PAGE_SIZE);
+}
+
+/******************************************************************************
+ * Name: up_progmem_getaddress
+ *
+ * Description:
+ *   Read/write page to address conversion
+ *
+ * Input Parameters:
+ *   page - page index
+ *
+ * Returned Value:
+ *   Base address of given page, SIZE_MAX if page index is not valid.
+ *
+ ******************************************************************************/
+
+size_t up_progmem_getaddress(size_t page)
+{
+  return (size_t)(S32K1XX_PROGMEM_START_ADDR
+           + (page * S32K1XX_PROGMEM_PAGE_SIZE));
+}
+
+/******************************************************************************
+ * Name: up_progmem_eraseblock
+ *
+ * Description:
+ *   Erase selected block.
+ *
+ * Input Parameters:
+ *   block - The erase block index to be erased.
+ *
+ * Returned Value:
+ *   block size or negative value on error.  The following errors are reported
+ *   (errno is not set!):
+ *
+ *     -EFAULT: On invalid page
+ *     -EIO:    On unsuccessful erase
+ *     -EROFS:  On access to write protected area
+ *     -EACCES: Insufficient permissions (read/write protected)
+ *     -EPERM:  If operation is not permitted due to some other constraints
+ *              (i.e. some internal block is not running etc.)
+ *
+ ******************************************************************************/
+
+ssize_t up_progmem_eraseblock(size_t block)
+{
+  union fccob_flash_addr dest;
+
+  dest.addr = (block * S32K1XX_PROGMEM_BLOCK_SECTOR_SIZE) + 0x800000
+      - S32K1XX_PROGMEM_START_ADDR;
+
+  wait_ftfc_ready();
+
+  /* Clear FSTAT error bits */
+
+  putreg8(FTTC_FSTAT_FPVIOL | FTTC_FSTAT_ACCERR | FTTC_FSTAT_RDCOLERR,
+           S32K1XX_FTFC_FSTAT);
+
+  putreg8(S32K1XX_FTFC_ERASE_SECTOR, S32K1XX_FTFC_FCCOB0);
+
+  putreg8(dest.fccobs.fccob1, S32K1XX_FTFC_FCCOB1);
+  putreg8(dest.fccobs.fccob2, S32K1XX_FTFC_FCCOB2);
+  putreg8(dest.fccobs.fccob3, S32K1XX_FTFC_FCCOB3);
+
+  if (execute_ftfc_command() & (FTTC_FSTAT_MGSTAT0 | FTTC_FSTAT_FPVIOL |
+      FTTC_FSTAT_ACCERR | FTTC_FSTAT_RDCOLERR))
+    {
+      return -EIO; /* Error has occured */
+    }
+
+#ifdef FTFC_VERIFY_CHECK
+  wait_ftfc_ready();
+
+  putreg8(FTTC_FSTAT_FPVIOL | FTTC_FSTAT_ACCERR | FTTC_FSTAT_RDCOLERR,
+           S32K1XX_FTFC_FSTAT);
+
+  putreg8(S32K1XX_FTFC_VERIFY_SECTION, S32K1XX_FTFC_FCCOB0);
+
+  putreg8(dest.fccobs.fccob1, S32K1XX_FTFC_FCCOB1);
+  putreg8(dest.fccobs.fccob2, S32K1XX_FTFC_FCCOB2);
+  putreg8(dest.fccobs.fccob3, S32K1XX_FTFC_FCCOB3);
+  putreg8(1, S32K1XX_FTFC_FCCOB4); /* 2048 / 8 = 256 */
+  putreg8(0, S32K1XX_FTFC_FCCOB5);
+  putreg8(1, S32K1XX_FTFC_FCCOB6);
+
+  if (execute_ftfc_command() & (FTTC_FSTAT_MGSTAT0 | FTTC_FSTAT_FPVIOL |
+      FTTC_FSTAT_ACCERR | FTTC_FSTAT_RDCOLERR))
+    {
+      return -EIO; /* Error has occured */
+    }
+#endif
+
+  return (ssize_t)S32K1XX_PROGMEM_BLOCK_SECTOR_SIZE;
+}
+
+/******************************************************************************
+ * Name: up_progmem_ispageerased
+ *
+ * Description:
+ *   Checks whether page is erased
+ *
+ * Input Parameters:
+ *   page - The erase page index to be checked.
+ *
+ * Returned Value:
+ *   Returns number of bytes NOT erased or negative value on error. If it
+ *   returns zero then complete page is erased.
+ *
+ *   The following errors are reported:
+ *     -EFAULT: On invalid page
+ *
+ ******************************************************************************/
+
+ssize_t up_progmem_ispageerased(size_t page)
+{
+  const uint8_t *p;
+  int i;
+
+  if (page >= S32K1XX_PROGMEM_PAGE_COUNT)
+    {
+      return -EFAULT;
+    }
+
+  p = (const uint8_t *)up_progmem_getaddress(page);
+
+  for (i = 0; i < S32K1XX_PROGMEM_PAGE_SIZE; i++)
+    {
+      if (p[i] != 0xff)
+        {
+          break;
+        }
+    }
+
+  return (ssize_t)(S32K1XX_PROGMEM_PAGE_SIZE - i);
+}
+
+/******************************************************************************
+ * Name: up_progmem_write
+ *
+ * Description:
+ *   Program data at given address
+ *
+ *   Note: this function is not limited to single page and nor it requires
+ *   the address be aligned inside the page boundaries.
+ *
+ * Input Parameters:
+ *   addr  - Address with or without flash offset
+ *   buf   - Pointer to buffer
+ *   count - Number of bytes to write
+ *
+ * Returned Value:
+ *   Bytes written or negative value on error.  The following errors are
+ *   reported (errno is not set!)
+ *
+ *     EINVAL: If count is not aligned with the flash boundaries (i.e.
+ *             some MCU's require per half-word or even word access)
+ *     EFAULT: On invalid address
+ *     EIO:    On unsuccessful write
+ *     EROFS:  On access to write protected area
+ *     EACCES: Insufficient permissions (read/write protected)
+ *     EPERM:  If operation is not permitted due to some other constraints
+ *             (i.e. some internal block is not running etc.)
+ *
+ ******************************************************************************/
+
+ssize_t up_progmem_write(size_t addr, FAR const void *buf, size_t count)
+{
+  union fccob_flash_addr dest;
+  uint32_t temp;
+  uint32_t i;
+  uint32_t j;
+  uint8_t *src;
+
+  if (addr >= S32K1XX_PROGMEM_START_ADDR)
+    {
+      addr -= S32K1XX_PROGMEM_START_ADDR;
+    }
+
+  if (count % S32K1XX_PROGMEM_DFLASH_WRITE_UNIT_SIZE != 0)
+    {
+      return -EINVAL;
+    }
+
+#ifdef SMART_FS_DOUBLE_WRITE_WORKAROUND
+  if (*(uint32_t *)addr == *(uint32_t *)buf
+      && *(uint32_t *)addr + 4 == *(uint32_t *)buf + 4)
+    {
+      return count;
+    }
+#endif
+
+  src = (uint8_t *)buf;
+  dest.addr = addr + 0x800000;
+
+  for (i = 0; i < count / S32K1XX_PROGMEM_DFLASH_WRITE_UNIT_SIZE ; i++)
+    {
+      wait_ftfc_ready();
+
+      /* Clear FSTAT error bits */
+
+      putreg8(FTTC_FSTAT_FPVIOL | FTTC_FSTAT_ACCERR | FTTC_FSTAT_RDCOLERR,
+               S32K1XX_FTFC_FSTAT);
+
+      putreg8(S32K1XX_FTFC_PROGRAM_PHRASE, S32K1XX_FTFC_FCCOB0);
+
+      putreg8(dest.fccobs.fccob1, S32K1XX_FTFC_FCCOB1);
+      putreg8(dest.fccobs.fccob2, S32K1XX_FTFC_FCCOB2);
+      putreg8(dest.fccobs.fccob3, S32K1XX_FTFC_FCCOB3);
+
+      for (j = 0; j < S32K1XX_PROGMEM_DFLASH_WRITE_UNIT_SIZE; j++)
+        {
+          temp = S32K1XX_FTFC_BASE + j + 0x8;
+          *(volatile uint8_t *)(temp) = src[j];
+        }
+
+      if (execute_ftfc_command() & (FTTC_FSTAT_MGSTAT0 | FTTC_FSTAT_FPVIOL |
+          FTTC_FSTAT_ACCERR | FTTC_FSTAT_RDCOLERR))
+        {
+          return -EIO; /* Error has occured */
+        }
+
+      dest.addr = dest.addr + S32K1XX_PROGMEM_DFLASH_WRITE_UNIT_SIZE;
+      src = src + S32K1XX_PROGMEM_DFLASH_WRITE_UNIT_SIZE;
+    }
+
+#ifdef FTFC_VERIFY_CHECK
+  src = (uint8_t *)buf;
+  dest.addr = addr + 0x800000;
+
+  for (i = 0; i < count / S32K1XX_PROGMEM_DFLASH_WRITE_UNIT_SIZE ; i++)
+    {
+      wait_ftfc_ready();
+
+      /* Clear FSTAT error bits */
+
+      putreg8(FTTC_FSTAT_FPVIOL | FTTC_FSTAT_ACCERR | FTTC_FSTAT_RDCOLERR,
+               S32K1XX_FTFC_FSTAT);
+
+      putreg8(S32K1XX_FTFC_PROGRAM_CHECK, S32K1XX_FTFC_FCCOB0);
+
+      putreg8(dest.fccobs.fccob1, S32K1XX_FTFC_FCCOB1);
+      putreg8(dest.fccobs.fccob2, S32K1XX_FTFC_FCCOB2);
+      putreg8(dest.fccobs.fccob3, S32K1XX_FTFC_FCCOB3);
+      putreg8(1, S32K1XX_FTFC_FCCOB4); /* Margin level 1 */
+
+      for (j = 0; j < S32K1XX_PROGMEM_DFLASH_WRITE_UNIT_SIZE; j++)
+        {
+          temp = S32K1XX_FTFC_BASE + j + 0xc;
+          *(uint8_t *)(temp) = src[j];
+        }
+
+      if (execute_ftfc_command() & (FTTC_FSTAT_MGSTAT0 | FTTC_FSTAT_FPVIOL |
+          FTTC_FSTAT_ACCERR | FTTC_FSTAT_RDCOLERR))
+        {
+          return count; /* Error has occured */
+        }
+
+       dest.addr = dest.addr + S32K1XX_PROGMEM_DFLASH_WRITE_UNIT_SIZE;
+       src = src + S32K1XX_PROGMEM_DFLASH_WRITE_UNIT_SIZE;
+    }
+#endif
+
+  return count;
+}
+
+void s32k1xx_progmem_init()
+{
+  /* Disable D-Flash Cache */
+
+  putreg32(0xc706b030, S32K1XX_MSCM_BASE + 0x404);
+
+  /* Setup D-flash partitioning */
+
+  putreg8(S32K1XX_FTFC_PROGRAM_PARTITION, S32K1XX_FTFC_FCCOB0); /* Command */
+
+  putreg8(0x0, S32K1XX_FTFC_FCCOB1); /* CSEc key size */
+  putreg8(0x0, S32K1XX_FTFC_FCCOB2); /* uSFE */
+  putreg8(0x0, S32K1XX_FTFC_FCCOB3); /* Disable FlexRAM EEE */
+  putreg8(0xf, S32K1XX_FTFC_FCCOB4); /* EEE Partition code */
+  putreg8(0x0, S32K1XX_FTFC_FCCOB5); /* DE  Partition code */
+
+  execute_ftfc_command();
+}

--- a/arch/arm/src/s32k1xx/s32k1xx_progmem.h
+++ b/arch/arm/src/s32k1xx/s32k1xx_progmem.h
@@ -1,0 +1,95 @@
+/******************************************************************************
+ * arch/arm/src/s32k1xx/s32k1xx_progmem.h
+ *
+ *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
+ *   Author:  Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_S32K1XX_PROGMEM_H
+#define __ARCH_ARM_SRC_S32K1XX_PROGMEM_H
+
+/******************************************************************************
+ * Included Files
+ ******************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/compiler.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "up_internal.h"
+#include "s32k1xx_config.h"
+
+/******************************************************************************
+ * Pre-processor Definitions
+ ******************************************************************************/
+
+#define DFLASH_SIZE CONFIG_PROGMEM_SIZE
+
+#if (DFLASH_SIZE % 2) == 1
+# error "Progmem size has to be a multiple of 2"
+#endif
+
+#if defined(CONFIG_ARCH_CHIP_S32K14X) && (DFLASH_SIZE > 64)
+# error "Progmem size is bigger than FlexNVM size"
+#endif
+
+#if defined(CONFIG_ARCH_CHIP_S32K11X) && (DFLASH_SIZE > 32)
+# error "Progmem size is bigger than FlexNVM size"
+#endif
+
+/* Base address of the flash segment used for progmem. */
+
+#define S32K1XX_PROGMEM_START_ADDR            0x10000000
+
+#define S32K1XX_PROGMEM_BLOCK_COUNT           1
+
+#define S32K1XX_PROGMEM_BLOCK_SIZE            DFLASH_SIZE * 1024
+
+#define S32K1XX_PROGMEM_BLOCK_SECTOR_SIZE     2048
+
+#define S32K1XX_PROGMEM_PAGE_SIZE             8
+
+#define S32K1XX_PROGMEM_SECTOR_COUNT          S32K1XX_PROGMEM_BLOCK_SIZE / S32K1XX_PROGMEM_BLOCK_SECTOR_SIZE
+
+#define S32K1XX_PROGMEM_PAGE_COUNT            (S32K1XX_PROGMEM_BLOCK_SIZE / S32K1XX_PROGMEM_PAGE_SIZE)
+
+#define S32K1XX_PROGMEM_DFLASH_WRITE_UNIT_SIZE 8
+
+/******************************************************************************
+ * Public Function Prototypes
+ ******************************************************************************/
+
+void s32k1xx_progmem_init();
+
+#endif /* __ARCH_ARM_SRC_S32K1XX_PROGMEM_H */

--- a/arch/arm/src/s32k1xx/s32k1xx_start.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_start.c
@@ -65,6 +65,10 @@
 #include "hardware/s32k1xx_mpu.h"
 #endif
 
+#ifdef CONFIG_S32K1XX_PROGMEM
+#include "s32k1xx_progmem.h"
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -352,6 +356,10 @@ void __start(void)
   s32k1xx_earlyserialinit();
 #endif
   showprogress('E');
+
+#ifdef CONFIG_S32K1XX_PROGMEM
+  s32k1xx_progmem_init();
+#endif
 
   /* For the case of the separate user-/kernel-space build, perform whatever
    * platform specific initialization of the user memory is required.

--- a/boards/arm/s32k1xx/rddrone-uavcan144/src/s32k1xx_bringup.c
+++ b/boards/arm/s32k1xx/rddrone-uavcan144/src/s32k1xx_bringup.c
@@ -143,5 +143,29 @@ int s32k1xx_bringup(void)
 #endif
 #endif
 
+#ifdef CONFIG_S32K1XX_PROGMEM
+  FAR struct mtd_dev_s *mtd;
+  int minor = 0;
+
+  mtd = progmem_initialize();
+  if (!mtd)
+    {
+      syslog(LOG_ERR, "ERROR: progmem_initialize failed\n");
+    }
+
+#if defined(CONFIG_FS_SMARTFS)
+  ret = smart_initialize(0, mtd, NULL);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to init the SMART FS layer: %d\n", ret);
+      return ret;
+    }
+
+# if defined(CONFIG_PROGMEM_SMARTFS_AUTOMOUNT)
+  mount("/dev/smart0", "/mnt", "smartfs", 0, NULL);
+# endif
+#endif
+#endif
+
   return ret;
 }

--- a/boards/arm/s32k1xx/rddrone-uavcan146/src/s32k1xx_bringup.c
+++ b/boards/arm/s32k1xx/rddrone-uavcan146/src/s32k1xx_bringup.c
@@ -140,5 +140,29 @@ int s32k1xx_bringup(void)
 #endif
 #endif
 
+#ifdef CONFIG_S32K1XX_PROGMEM
+  FAR struct mtd_dev_s *mtd;
+  int minor = 0;
+
+  mtd = progmem_initialize();
+  if (!mtd)
+    {
+      syslog(LOG_ERR, "ERROR: progmem_initialize failed\n");
+    }
+
+#if defined(CONFIG_FS_SMARTFS)
+  ret = smart_initialize(0, mtd, NULL);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to init the SMART FS layer: %d\n", ret);
+      return ret;
+    }
+
+# if defined(CONFIG_PROGMEM_SMARTFS_AUTOMOUNT)
+  mount("/dev/smart0", "/mnt", "smartfs", 0, NULL);
+# endif
+#endif
+#endif
+
   return ret;
 }

--- a/boards/arm/s32k1xx/s32k118evb/src/s32k1xx_bringup.c
+++ b/boards/arm/s32k1xx/s32k118evb/src/s32k1xx_bringup.c
@@ -105,5 +105,29 @@ int s32k1xx_bringup(void)
     }
 #endif
 
+#ifdef CONFIG_S32K1XX_PROGMEM
+  FAR struct mtd_dev_s *mtd;
+  int minor = 0;
+
+  mtd = progmem_initialize();
+  if (!mtd)
+    {
+      syslog(LOG_ERR, "ERROR: progmem_initialize failed\n");
+    }
+
+#if defined(CONFIG_FS_SMARTFS)
+  ret = smart_initialize(0, mtd, NULL);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to init the SMART FS layer: %d\n", ret);
+      return ret;
+    }
+
+# if defined(CONFIG_PROGMEM_SMARTFS_AUTOMOUNT)
+  mount("/dev/smart0", "/mnt", "smartfs", 0, NULL);
+# endif
+#endif
+#endif
+
   return ret;
 }

--- a/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_bringup.c
+++ b/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_bringup.c
@@ -137,5 +137,29 @@ int s32k1xx_bringup(void)
     }
 #endif
 
+#ifdef CONFIG_S32K1XX_PROGMEM
+  FAR struct mtd_dev_s *mtd;
+  int minor = 0;
+
+  mtd = progmem_initialize();
+  if (!mtd)
+    {
+      syslog(LOG_ERR, "ERROR: progmem_initialize failed\n");
+    }
+
+#if defined(CONFIG_FS_SMARTFS)
+  ret = smart_initialize(0, mtd, NULL);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to init the SMART FS layer: %d\n", ret);
+      return ret;
+    }
+
+# if defined(CONFIG_PROGMEM_SMARTFS_AUTOMOUNT)
+  mount("/dev/smart0", "/mnt", "smartfs", 0, NULL);
+# endif
+#endif
+#endif
+
   return ret;
 }

--- a/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_bringup.c
+++ b/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_bringup.c
@@ -137,5 +137,29 @@ int s32k1xx_bringup(void)
     }
 #endif
 
+#ifdef CONFIG_S32K1XX_PROGMEM
+  FAR struct mtd_dev_s *mtd;
+  int minor = 0;
+
+  mtd = progmem_initialize();
+  if (!mtd)
+    {
+      syslog(LOG_ERR, "ERROR: progmem_initialize failed\n");
+    }
+
+#if defined(CONFIG_FS_SMARTFS)
+  ret = smart_initialize(0, mtd, NULL);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to init the SMART FS layer: %d\n", ret);
+      return ret;
+    }
+
+# if defined(CONFIG_PROGMEM_SMARTFS_AUTOMOUNT)
+  mount("/dev/smart0", "/mnt", "smartfs", 0, NULL);
+# endif
+#endif
+#endif
+
   return ret;
 }

--- a/include/nuttx/net/net.h
+++ b/include/nuttx/net/net.h
@@ -377,6 +377,25 @@ void net_initialize(void);
 int net_lock(void);
 
 /****************************************************************************
+ * Name: net_trylock
+ *
+ * Description:
+ *   Try to take the network lock only when it is currently not locked.
+ *   Otherwise, it locks the semaphore.  In either
+ *   case, the call returns without blocking.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is returned on
+ *   failured (probably -EAGAIN).
+ *
+ ****************************************************************************/
+
+int net_trylock(void);
+
+/****************************************************************************
  * Name: net_unlock
  *
  * Description:

--- a/net/can/can_input.c
+++ b/net/can/can_input.c
@@ -147,7 +147,7 @@ const uint8_t len_to_can_dlc[65] =
  *          place.
  *
  * Assumptions:
- *   The network is locked.
+ *   This function can be called from an interrupt.
  *
  ****************************************************************************/
 

--- a/net/utils/net_lock.c
+++ b/net/utils/net_lock.c
@@ -170,6 +170,57 @@ int net_lock(void)
 }
 
 /****************************************************************************
+ * Name: net_trylock
+ *
+ * Description:
+ *   Try to take the network lock only when it is currently not locked.
+ *   Otherwise, it locks the semaphore.  In either
+ *   case, the call returns without blocking.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; a negated errno value is returned on
+ *   failured (probably -EAGAIN).
+ *
+ ****************************************************************************/
+
+int net_trylock(void)
+{
+#ifdef CONFIG_SMP
+  irqstate_t flags = enter_critical_section();
+#endif
+  pid_t me = getpid();
+  int ret = OK;
+
+  /* Does this thread already hold the semaphore? */
+
+  if (g_holder == me)
+    {
+      /* Yes.. just increment the reference count */
+
+      g_count++;
+    }
+  else
+    {
+        ret = nxsem_trywait(&g_netlock);
+        if (ret >= 0)
+          {
+            /* Now this thread holds the semaphore */
+
+            g_holder = me;
+            g_count  = 1;
+          }
+    }
+
+#ifdef CONFIG_SMP
+  leave_critical_section(flags);
+#endif
+  return ret;
+}
+
+/****************************************************************************
  * Name: net_unlock
  *
  * Description:


### PR DESCRIPTION
In some cases we had some weird race condition in the NuttX scheduler caused by the interrupt handler of the FlexCAN driver. Apparently it's a bad thing to call net_lock in the interrupt context. 

This patch introduces net_trylock and copies the CAN frame in the read-ahead buffer when it didn't acquire the lock thus we don't get a hard fault anymore.