### PR TITLE
[BACKPORT] Revert "arch/arm/src/stm32f7/stm32_flash.c: Add flash block mapping support for progmem."

### DIFF
--- a/arch/arm/src/stm32f7/Kconfig
+++ b/arch/arm/src/stm32f7/Kconfig
@@ -1125,20 +1125,6 @@ config STM32F7_PROGMEM
 		Add progmem support, start block and end block options are provided to 
 		obtain an uniform flash memory mapping.
 
-if STM32F7_PROGMEM
-
-config STM32F7_PROGMEM_STARTBLOCK
-	int "First mapped progmem block"
-	default 0
-	range 0 64
-
-config STM32F7_PROGMEM_LASTBLOCK
-	int "Last mapped progmem block"
-	default -1
-	range -1 64
-
-endif # STM32F7_PROGMEM
-
 menu "STM32 Peripheral Support"
 
 # These "hidden" settings determine is a peripheral option is available for the

--- a/arch/arm/src/stm32f7/stm32_flash.c
+++ b/arch/arm/src/stm32f7/stm32_flash.c
@@ -73,32 +73,19 @@
 #define FLASH_OPTKEY2      0x4c5d6e7f
 #define FLASH_ERASEDVALUE  0xff
 
-#if CONFIG_STM32F7_PROGMEM_STARTBLOCK < 0 || \
-    CONFIG_STM32F7_PROGMEM_STARTBLOCK >= STM32_FLASH_NPAGES
-#  error "Invalid CONFIG_STM32F7_PROGMEM_STARTBLOCK"
-#endif
-
-#if CONFIG_STM32F7_PROGMEM_LASTBLOCK < 0
-#  undef CONFIG_STM32F7_PROGMEM_LASTBLOCK
-#  define CONFIG_STM32F7_PROGMEM_LASTBLOCK (STM32_FLASH_NPAGES-1)
-#endif
-
-#define PROGMEM_NBLOCKS \
-  (CONFIG_STM32F7_PROGMEM_LASTBLOCK - CONFIG_STM32F7_PROGMEM_STARTBLOCK + 1)
-
-#define PAGESIZE 256
-
 /****************************************************************************
  * Private Data
  ****************************************************************************/
 
 static sem_t g_sem = SEM_INITIALIZER(1);
 
-static const size_t page_sizes[STM32_FLASH_NPAGES] = STM32_FLASH_SIZES;
-
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
+static void up_waste(void)
+{
+}
 
 static void sem_lock(void)
 {
@@ -128,6 +115,7 @@ static void flash_unlock(void)
 {
   while (getreg32(STM32_FLASH_SR) & FLASH_SR_BSY)
     {
+      up_waste();
     }
 
   if (getreg32(STM32_FLASH_CR) & FLASH_CR_LOCK)
@@ -142,39 +130,6 @@ static void flash_unlock(void)
 static void flash_lock(void)
 {
   modifyreg32(STM32_FLASH_CR, 0, FLASH_CR_LOCK);
-}
-
-static uint32_t flash_size(void)
-{
-  static uint32_t size;
-  int i;
-
-  if (size == 0)
-    {
-      for (i = 0; i < PROGMEM_NBLOCKS; i++)
-        {
-          size += page_sizes[CONFIG_STM32F7_PROGMEM_STARTBLOCK + i];
-        }
-    }
-
-  return size;
-}
-
-static uint32_t flash_base(void)
-{
-  static uint32_t base;
-  int i;
-
-  if (base == 0)
-    {
-      base = STM32_FLASH_BASE;
-      for (i = 0; i < CONFIG_STM32F7_PROGMEM_STARTBLOCK; i++)
-        {
-          base += page_sizes[i];
-        }
-    }
-
-  return base;
 }
 
 /****************************************************************************
@@ -203,29 +158,27 @@ void stm32_flash_lock(void)
  *
  ****************************************************************************/
 
-int stm32_flash_writeprotect(size_t block, bool enabled)
+int stm32_flash_writeprotect(size_t page, bool enabled)
 {
   uint32_t reg;
   uint32_t val;
 
-  if (block >= PROGMEM_NBLOCKS)
+  if (page >= STM32_FLASH_NPAGES)
     {
       return -EFAULT;
     }
 
-  block = block + CONFIG_STM32F7_PROGMEM_STARTBLOCK;
-
   /* Select the register that contains the bit to be changed */
 
-  if (block < 12)
+  if (page < 12)
     {
       reg = STM32_FLASH_OPTCR;
     }
-#if defined(CONFIG_STM32F7_FLASH_CONFIG_I)
+#if defined(CONFIG_STM32_FLASH_CONFIG_I)
   else
     {
       reg = STM32_FLASH_OPTCR1;
-      block -= 12;
+      page -= 12;
     }
 #else
   else
@@ -242,11 +195,11 @@ int stm32_flash_writeprotect(size_t block, bool enabled)
 
   if (enabled)
     {
-      val &= ~(1 << (16 + block));
+      val &= ~(1 << (16 + page));
     }
   else
     {
-      val |=  (1 << (16 + block));
+      val |=  (1 << (16 + page));
     }
 
   /* Unlock options */
@@ -266,6 +219,7 @@ int stm32_flash_writeprotect(size_t block, bool enabled)
 
   while (getreg32(STM32_FLASH_SR) & FLASH_SR_BSY)
     {
+      up_waste();
     }
 
   /* Re-lock options */
@@ -276,57 +230,75 @@ int stm32_flash_writeprotect(size_t block, bool enabled)
 
 size_t up_progmem_pagesize(size_t page)
 {
-  return PAGESIZE;
+  static const size_t page_sizes[STM32_FLASH_NPAGES] = STM32_FLASH_SIZES;
+
+  if (page >= sizeof(page_sizes) / sizeof(*page_sizes))
+    {
+      return 0;
+    }
+  else
+    {
+      return page_sizes[page];
+    }
 }
 
 ssize_t up_progmem_getpage(size_t addr)
 {
-  if (addr >= flash_base())
+  size_t page_end = 0;
+  size_t i;
+
+  if (addr >= STM32_FLASH_BASE)
     {
-      addr -= flash_base();
+      addr -= STM32_FLASH_BASE;
     }
 
-  if (addr >= flash_size())
+  if (addr >= STM32_FLASH_SIZE)
     {
       return -EFAULT;
     }
 
-  return addr / PAGESIZE;
+  for (i = 0; i < STM32_FLASH_NPAGES; ++i)
+    {
+      page_end += up_progmem_pagesize(i);
+      if (page_end > addr)
+        {
+          return i;
+        }
+    }
+
+  return -EFAULT;
 }
 
 size_t up_progmem_getaddress(size_t page)
 {
-  size_t base_address = flash_base();
+  size_t base_address = STM32_FLASH_BASE;
+  size_t i;
 
-  if (page >= flash_size() / PAGESIZE)
+  if (page >= STM32_FLASH_NPAGES)
     {
       return SIZE_MAX;
     }
 
-  base_address += PAGESIZE * page;
+  for (i = 0; i < page; ++i)
+    {
+      base_address += up_progmem_pagesize(i);
+    }
 
   return base_address;
 }
 
 size_t up_progmem_neraseblocks(void)
 {
-  return PROGMEM_NBLOCKS;
+  return STM32_FLASH_NPAGES;
 }
 
 bool up_progmem_isuniform(void)
 {
-  size_t size = up_progmem_pagesize(0);
-  int i;
-
-  for (i = 1; i < PROGMEM_NBLOCKS; i++)
-    {
-      if (up_progmem_pagesize(i) != size)
-        {
-          return false;
-        }
-    }
-
+#ifdef STM32_FLASH_PAGESIZE
   return true;
+#else
+  return false;
+#endif
 }
 
 ssize_t up_progmem_ispageerased(size_t page)
@@ -335,7 +307,7 @@ ssize_t up_progmem_ispageerased(size_t page)
   size_t count;
   size_t bwritten = 0;
 
-  if (page >= flash_size() / PAGESIZE)
+  if (page >= STM32_FLASH_NPAGES)
     {
       return -EFAULT;
     }
@@ -356,7 +328,7 @@ ssize_t up_progmem_ispageerased(size_t page)
 
 ssize_t up_progmem_eraseblock(size_t block)
 {
-  if (block >= PROGMEM_NBLOCKS)
+  if (block >= STM32_FLASH_NPAGES)
     {
       return -EFAULT;
     }
@@ -368,13 +340,10 @@ ssize_t up_progmem_eraseblock(size_t block)
   flash_unlock();
 
   modifyreg32(STM32_FLASH_CR, 0, FLASH_CR_SER);
-  modifyreg32(STM32_FLASH_CR, FLASH_CR_SNB_MASK,
-      FLASH_CR_SNB((block + CONFIG_STM32F7_PROGMEM_STARTBLOCK)));
+  modifyreg32(STM32_FLASH_CR, FLASH_CR_SNB_MASK, FLASH_CR_SNB(block));
   modifyreg32(STM32_FLASH_CR, 0, FLASH_CR_STRT);
 
-  while (getreg32(STM32_FLASH_SR) & FLASH_SR_BSY)
-    {
-    }
+  while (getreg32(STM32_FLASH_SR) & FLASH_SR_BSY) up_waste();
 
   modifyreg32(STM32_FLASH_CR, FLASH_CR_SER, 0);
   sem_unlock();
@@ -391,20 +360,6 @@ ssize_t up_progmem_eraseblock(size_t block)
     }
 }
 
-size_t up_progmem_erasesize(size_t block)
-{
-  block = block + CONFIG_STM32F7_PROGMEM_STARTBLOCK;
-
-  if (block >= sizeof(page_sizes) / sizeof(*page_sizes))
-    {
-      return 0;
-    }
-  else
-    {
-      return page_sizes[block];
-    }
-}
-
 ssize_t up_progmem_write(size_t addr, const void *buf, size_t count)
 {
   uint8_t *byte = (uint8_t *)buf;
@@ -416,7 +371,7 @@ ssize_t up_progmem_write(size_t addr, const void *buf, size_t count)
   if (addr >= STM32_FLASH_BASE &&
       addr + count <= STM32_FLASH_BASE + STM32_FLASH_SIZE)
     {
-      flash_base = up_progmem_getaddress(0);
+      flash_base = STM32_FLASH_BASE;
     }
   else if (addr >= STM32_OPT_BASE &&
            addr + count <= STM32_OPT_BASE + STM32_OPT_SIZE)
@@ -455,9 +410,7 @@ ssize_t up_progmem_write(size_t addr, const void *buf, size_t count)
 
       ARM_DSB();
 
-      while (getreg32(STM32_FLASH_SR) & FLASH_SR_BSY)
-        {
-        }
+      while (getreg32(STM32_FLASH_SR) & FLASH_SR_BSY) up_waste();
 
       /* Verify */
 


### PR DESCRIPTION
This reverts commit 29164c5706490b74a84d44ba0f79cd588fd3e910.

From https://github.com/apache/incubator-nuttx/pull/562.

Required for flash-based params on F7.