### PR TITLE
stm32f7: ethernet: fix the 'bitwise comparison always evaluates to false' error

### DIFF
--- a/arch/arm/src/stm32f7/stm32_ethernet.c
+++ b/arch/arm/src/stm32f7/stm32_ethernet.c
@@ -3435,7 +3435,7 @@ static int stm32_phyinit(struct stm32_ethmac_s *priv)
    */
 
 #else
-  if ((phyval & CONFIG_STM32F7_PHYSR_MODE) == CONFIG_STM32F7_PHYSR_FULLDUPLEX)
+  if ((phyval & CONFIG_STM32F7_PHYSR_MODE) != !CONFIG_STM32F7_PHYSR_FULLDUPLEX)
     {
       priv->fduplex = 1;
     }


### PR DESCRIPTION
PX4 CI building with GCC 9 was complaining about an error regarding this bitwise comparison. It doesn't look good to me as we basically do a double negation, but like this it doesn't complain.

https://github.com/PX4/Firmware/pull/14691/checks?check_run_id=595172297#step:6:553