### PR TITLE
S32K1XX FlexCAN fix & EEEPROM driver

### DIFF
--- a/arch/arm/src/kinetis/kinetis_flexcan.c
+++ b/arch/arm/src/kinetis/kinetis_flexcan.c
@@ -410,7 +410,7 @@ uint32_t kinetis_bitratetotimeseg(struct flexcan_timeseg *timeseg,
   const int32_t TSEG1MAX = (can_fd ? TSEG1_FD_MAX : TSEG1_MAX);
   const int32_t TSEG2MAX = (can_fd ? TSEG2_FD_MAX : TSEG2_MAX);
   const int32_t SEGMAX = (can_fd ? SEG_FD_MAX : SEG_MAX);
-  const int32_t NUMTQMAX = (can_fd ? NUMTQ_FD_MAX : NUMTQMAX);
+  const int32_t NUMTQMAX = (can_fd ? NUMTQ_FD_MAX : NUMTQ_MAX);
 
   for (tmppresdiv = 0; tmppresdiv < PRESDIV_MAX; tmppresdiv++)
     {
@@ -511,8 +511,7 @@ static uint32_t kinetis_waitmcr_change(uint32_t base,
 
 static void kinetis_receive(FAR struct kinetis_driver_s *priv,
                             uint32_t flags);
-static void kinetis_txdone(FAR struct kinetis_driver_s *priv,
-                           uint32_t flags);
+static void kinetis_txdone(FAR void *arg);
 
 static int  kinetis_flexcan_interrupt(int irq, FAR void *context,
                                       FAR void *arg);
@@ -602,6 +601,16 @@ static int kinetis_transmit(FAR struct kinetis_driver_s *priv)
   /* Attempt to write frame */
 
   uint32_t mbi = 0;
+  uint32_t mb_bit;
+  uint32_t regval;
+#ifdef CONFIG_NET_CAN_CANFD
+  uint32_t *frame_data_word;
+  uint32_t i;
+#endif
+#ifdef CONFIG_NET_CAN_RAW_TX_DEADLINE
+  int32_t timeout;
+#endif
+
   if ((getreg32(priv->base + KINETIS_CAN_ESR2_OFFSET) &
       (CAN_ESR2_IMB | CAN_ESR2_VPS)) ==
       (CAN_ESR2_IMB | CAN_ESR2_VPS))
@@ -611,7 +620,7 @@ static int kinetis_transmit(FAR struct kinetis_driver_s *priv)
       mbi -= RXMBCOUNT;
     }
 
-  uint32_t mb_bit = 1 << (RXMBCOUNT + mbi);
+  mb_bit = 1 << (RXMBCOUNT + mbi);
 
   while (mbi < TXMBCOUNT)
     {
@@ -632,7 +641,6 @@ static int kinetis_transmit(FAR struct kinetis_driver_s *priv)
     }
 
 #ifdef CONFIG_NET_CAN_RAW_TX_DEADLINE
-  int32_t timeout = 0;
   struct timespec ts;
   clock_systimespec(&ts);
 
@@ -665,6 +673,7 @@ static int kinetis_transmit(FAR struct kinetis_driver_s *priv)
         {
           priv->txmb[mbi].deadline.tv_sec = 0;
           priv->txmb[mbi].deadline.tv_usec = 0;
+          timeout = -1;
         }
     }
 #endif
@@ -718,9 +727,9 @@ static int kinetis_transmit(FAR struct kinetis_driver_s *priv)
 
       cs.dlc = len_to_can_dlc[frame->len];
 
-      uint32_t *frame_data_word = (uint32_t *)&frame->data[0];
+      frame_data_word = (uint32_t *)&frame->data[0];
 
-      for (int i = 0; i < (frame->len + 4 - 1) / 4; i++)
+      for (i = 0; i < (frame->len + 4 - 1) / 4; i++)
         {
           mb->data[i].w00 = __builtin_bswap32(frame_data_word[i]);
         }
@@ -729,7 +738,6 @@ static int kinetis_transmit(FAR struct kinetis_driver_s *priv)
 
   mb->cs = cs; /* Go. */
 
-  uint32_t regval;
   regval = getreg32(priv->base + KINETIS_CAN_IMASK1_OFFSET);
   regval |= mb_bit;
   putreg32(regval, priv->base + KINETIS_CAN_IMASK1_OFFSET);
@@ -833,6 +841,10 @@ static void kinetis_receive(FAR struct kinetis_driver_s *priv,
 {
   uint32_t mb_index;
   struct mb_s *rf;
+#ifdef CONFIG_NET_CAN_CANFD
+  uint32_t *frame_data_word;
+  uint32_t i;
+#endif
 
   while ((mb_index = arm_lsb(flags)) != 32)
     {
@@ -862,9 +874,9 @@ static void kinetis_receive(FAR struct kinetis_driver_s *priv,
 
           frame->len = can_dlc_to_len[rf->cs.dlc];
 
-          uint32_t *frame_data_word = (uint32_t *)&frame->data[0];
+          frame_data_word = (uint32_t *)&frame->data[0];
 
-          for (int i = 0; i < (frame->len + 4 - 1) / 4; i++)
+          for (i = 0; i < (frame->len + 4 - 1) / 4; i++)
             {
               frame_data_word[i] = __builtin_bswap32(rf->data[i].w00);
             }
@@ -938,7 +950,7 @@ static void kinetis_receive(FAR struct kinetis_driver_s *priv,
 
       /* Reread interrupt flags and process them in this loop */
 
-      if(flags == 0)
+      if (flags == 0)
         {
           flags  = getreg32(priv->base + KINETIS_CAN_IFLAG1_OFFSET);
           flags &= IFLAG1_RX;
@@ -960,20 +972,26 @@ static void kinetis_receive(FAR struct kinetis_driver_s *priv,
  *
  * Assumptions:
  *   Global interrupts are disabled by the watchdog logic.
- *   The network is locked.
+ *   We are not in an interrupt context so that we can lock the network.
  *
  ****************************************************************************/
 
-static void kinetis_txdone(FAR struct kinetis_driver_s *priv, uint32_t flags)
+static void kinetis_txdone(FAR void *arg)
 {
-  #warning Missing logic
+  FAR struct kinetis_driver_s *priv = (FAR struct kinetis_driver_s *)arg;
+  uint32_t flags;
+  uint32_t mbi;
+  uint32_t mb_bit;
 
-  /* FIXME First Process Error aborts */
+  flags  = getreg32(priv->base + KINETIS_CAN_IFLAG1_OFFSET);
+  flags &= IFLAG1_TX;
+
+  /* TODO First Process Error aborts */
 
   /* Process TX completions */
 
-  uint32_t mb_bit = 1 << RXMBCOUNT;
-  for (uint32_t mbi = 0; flags && mbi < TXMBCOUNT; mbi++)
+  mb_bit = 1 << RXMBCOUNT;
+  for (mbi = 0; flags && mbi < TXMBCOUNT; mbi++)
     {
       if (flags & mb_bit)
         {
@@ -996,7 +1014,9 @@ static void kinetis_txdone(FAR struct kinetis_driver_s *priv, uint32_t flags)
    * new XMIT data
    */
 
+  net_lock();
   devif_poll(&priv->dev, kinetis_txpoll);
+  net_unlock();
 }
 
 /****************************************************************************
@@ -1022,27 +1042,39 @@ static void kinetis_txdone(FAR struct kinetis_driver_s *priv, uint32_t flags)
 static int kinetis_flexcan_interrupt(int irq, FAR void *context,
                                      FAR void *arg)
 {
- FAR struct kinetis_driver_s *priv = (struct kinetis_driver_s *)arg;
+  FAR struct kinetis_driver_s *priv = (struct kinetis_driver_s *)arg;
 
-  if(irq == priv->config->mb_irq) {
-    uint32_t flags;
-    flags  = getreg32(priv->base + KINETIS_CAN_IFLAG1_OFFSET);
-    flags &= IFLAG1_RX;
+  if (irq == priv->config->mb_irq)
+    {
+      uint32_t flags;
+      flags  = getreg32(priv->base + KINETIS_CAN_IFLAG1_OFFSET);
+      flags &= IFLAG1_RX;
 
-    if (flags)
-      {
-        kinetis_receive(priv, flags);
-      }
+      if (flags)
+        {
+          /* Process immediately since scheduling a workqueue is too slow
+           * which causes us to drop CAN frames
+           */
 
-    flags  = getreg32(priv->base + KINETIS_CAN_IFLAG1_OFFSET);
-    flags &= IFLAG1_TX;
+          kinetis_receive(priv, flags);
+        }
 
-    if (flags)
-      {
-        kinetis_txdone(priv, flags);
-      }
+      flags  = getreg32(priv->base + KINETIS_CAN_IFLAG1_OFFSET);
+      flags &= IFLAG1_TX;
 
-  }
+      if (flags)
+        {
+          /* Disable further TX MB CAN interrupts. here can be no race
+           * condition here.
+           */
+
+          flags  = getreg32(priv->base + KINETIS_CAN_IMASK1_OFFSET);
+          flags &= ~(IFLAG1_TX);
+          putreg32(flags, priv->base + KINETIS_CAN_IMASK1_OFFSET);
+          work_queue(CANWORK, &priv->irqwork, kinetis_txdone, priv, 0);
+        }
+    }
+
   return OK;
 }
 
@@ -1066,6 +1098,7 @@ static int kinetis_flexcan_interrupt(int irq, FAR void *context,
 static void kinetis_txtimeout_work(FAR void *arg)
 {
   FAR struct kinetis_driver_s *priv = (FAR struct kinetis_driver_s *)arg;
+  uint32_t mbi;
 
   struct timespec ts;
   struct timeval *now = (struct timeval *)&ts;
@@ -1076,7 +1109,7 @@ static void kinetis_txtimeout_work(FAR void *arg)
    * transmit function transmitted a new frame
    */
 
-  for (int mbi = 0; mbi < TXMBCOUNT; mbi++)
+  for (mbi = 0; mbi < TXMBCOUNT; mbi++)
     {
       if (priv->txmb[mbi].deadline.tv_sec != 0
           && (now->tv_sec > priv->txmb[mbi].deadline.tv_sec
@@ -1165,8 +1198,10 @@ static void kinetis_setfreeze(uint32_t base, uint32_t freeze)
 static uint32_t kinetis_waitmcr_change(uint32_t base, uint32_t mask,
                                        uint32_t target_state)
 {
-  const unsigned timeout = 1000;
-  for (unsigned wait_ack = 0; wait_ack < timeout; wait_ack++)
+  const uint32_t timeout = 1000;
+  uint32_t wait_ack;
+
+  for (wait_ack = 0; wait_ack < timeout; wait_ack++)
     {
       const bool state = (getreg32(base + KINETIS_CAN_MCR_OFFSET) & mask)
           != 0;
@@ -1499,21 +1534,21 @@ static int kinetis_initialize(struct kinetis_driver_s *priv)
   regval  = getreg32(priv->base + KINETIS_CAN_CTRL1_OFFSET);
   regval |= CAN_CTRL1_PRESDIV(priv->arbi_timing.presdiv) | /* Prescaler divisor factor */
             CAN_CTRL1_PROPSEG(priv->arbi_timing.propseg) | /* Propagation segment */
-            CAN_CTRL1_PSEG1(priv->arbi_timing.pseg1) |   /* Phase buffer segment 1 */
-            CAN_CTRL1_PSEG2(priv->arbi_timing.pseg2) |   /* Phase buffer segment 2 */
-            CAN_CTRL1_RJW(1);      /* Resynchronization jump width */
+            CAN_CTRL1_PSEG1(priv->arbi_timing.pseg1) |     /* Phase buffer segment 1 */
+            CAN_CTRL1_PSEG2(priv->arbi_timing.pseg2) |     /* Phase buffer segment 2 */
+            CAN_CTRL1_RJW(1);                              /* Resynchronization jump width */
   putreg32(regval, priv->base + KINETIS_CAN_CTRL1_OFFSET);
 
 #else
   regval  = getreg32(priv->base + KINETIS_CAN_CBT_OFFSET);
-  regval |= CAN_CBT_BTF |         /* Enable extended bit timing
-                                   * configurations for CAN-FD for setting up
-                                   * separately nominal and data phase */
+            regval |= CAN_CBT_BTF |                       /* Enable extended bit timing
+                                                           * configurations for CAN-FD for setting up
+                                                           * separately nominal and data phase */
             CAN_CBT_EPRESDIV(priv->arbi_timing.presdiv) | /* Prescaler divisor factor */
             CAN_CBT_EPROPSEG(priv->arbi_timing.propseg) | /* Propagation segment */
-            CAN_CBT_EPSEG1(priv->arbi_timing.pseg1) |   /* Phase buffer segment 1 */
-            CAN_CBT_EPSEG2(priv->arbi_timing.pseg2) |   /* Phase buffer segment 2 */
-            CAN_CBT_ERJW(1);      /* Resynchronization jump width */
+            CAN_CBT_EPSEG1(priv->arbi_timing.pseg1) |     /* Phase buffer segment 1 */
+            CAN_CBT_EPSEG2(priv->arbi_timing.pseg2) |     /* Phase buffer segment 2 */
+            CAN_CBT_ERJW(1);                              /* Resynchronization jump width */
   putreg32(regval, priv->base + KINETIS_CAN_CBT_OFFSET);
 
   /* Enable CAN FD feature */
@@ -1524,11 +1559,11 @@ static int kinetis_initialize(struct kinetis_driver_s *priv)
 
   regval  = getreg32(priv->base + KINETIS_CAN_FDCBT_OFFSET);
   regval |= CAN_FDCBT_FPRESDIV(priv->data_timing.presdiv) |  /* Prescaler divisor factor of 1 */
-            CAN_FDCBT_FPROPSEG(priv->data_timing.propseg) | /* Propagation
-                                                             * segment (only register that doesn't add 1) */
-            CAN_FDCBT_FPSEG1(priv->data_timing.pseg1) |    /* Phase buffer segment 1 */
-            CAN_FDCBT_FPSEG2(priv->data_timing.pseg2) |    /* Phase buffer segment 2 */
-            CAN_FDCBT_FRJW(priv->data_timing.pseg2);       /* Resynchorinzation jump width same as PSEG2 */
+            CAN_FDCBT_FPROPSEG(priv->data_timing.propseg) |  /* Propagation
+                                                              * segment (only register that doesn't add 1) */
+            CAN_FDCBT_FPSEG1(priv->data_timing.pseg1) |      /* Phase buffer segment 1 */
+            CAN_FDCBT_FPSEG2(priv->data_timing.pseg2) |      /* Phase buffer segment 2 */
+            CAN_FDCBT_FRJW(priv->data_timing.pseg2);         /* Resynchorinzation jump width same as PSEG2 */
   putreg32(regval, priv->base + KINETIS_CAN_FDCBT_OFFSET);
 
   /* Additional CAN-FD configurations */
@@ -1683,6 +1718,9 @@ int kinetis_caninitialize(int intf)
   struct kinetis_driver_s *priv;
   int ret;
   uint32_t regval;
+#ifdef TX_TIMEOUT_WQ
+  uint32_t i;
+#endif
 
   switch (intf)
     {
@@ -1832,7 +1870,7 @@ int kinetis_caninitialize(int intf)
   priv->dev.d_private = (void *)priv;      /* Used to recover private state from dev */
 
 #ifdef TX_TIMEOUT_WQ
-  for (int i = 0; i < TXMBCOUNT; i++)
+  for (i = 0; i < TXMBCOUNT; i++)
     {
       priv->txtimeout[i] = wd_create();    /* Create TX timeout timer */
     }

--- a/arch/arm/src/s32k1xx/Kconfig
+++ b/arch/arm/src/s32k1xx/Kconfig
@@ -255,6 +255,13 @@ config S32K1XX_PROGMEM
         Use the FlexNVM 32/64 KB of d-flash memory as a
 		Memory-Technology-Device (MTD).
 
+config S32K1XX_EEEPROM
+	bool "Emulated EEPROM"
+	default n
+    ---help---
+       Enables Emulated EEPROM function which uses the FlexRAM and FlexNVM
+       memory to emulate non-volatile memory. The EEEPROM wil be registered 
+       as a ramdisk block device
 
 endmenu # S32K1XX Peripheral Selection
 

--- a/arch/arm/src/s32k1xx/Make.defs
+++ b/arch/arm/src/s32k1xx/Make.defs
@@ -102,6 +102,10 @@ ifeq ($(CONFIG_S32K1XX_PROGMEM),y)
 CHIP_CSRCS += s32k1xx_progmem.c
 endif
 
+ifeq ($(CONFIG_S32K1XX_EEEPROM),y)
+CHIP_CSRCS += s32k1xx_eeeprom.c
+endif 
+
 # Source files specific to the ARM CPU family and to the S32K1xx chip family
 
 ifeq ($(CONFIG_ARCH_CHIP_S32K11X),y)

--- a/arch/arm/src/s32k1xx/hardware/s32k1xx_ftfc.h
+++ b/arch/arm/src/s32k1xx/hardware/s32k1xx_ftfc.h
@@ -140,4 +140,6 @@
 #define S32K1XX_FTFC_PROGRAM_PARTITION                   0x80 /* PGMPART */
 #define S32K1XX_FTFC_SET_FLEXRAM_FUNCTION                0x81 /* SETRAM */
 
+#define S32K1XX_FTFC_EEEPROM_BASE                        0x14000000
+
 #endif /* __ARCH_ARM_SRC_S32K1XX_HARDWARE_S32K1XX_FTFC_H */

--- a/arch/arm/src/s32k1xx/s32k1xx_eeeprom.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_eeeprom.c
@@ -1,0 +1,479 @@
+/******************************************************************************
+ * arch/arm/src/s32k1xx/s32k1xx_eeeprom.c
+ *
+ *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
+ *   Author:  Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/******************************************************************************
+ * Included Files
+ ******************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <sys/ioctl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <assert.h>
+#include <errno.h>
+
+#include "up_arch.h"
+
+#include "hardware/s32k1xx_ftfc.h"
+#include "hardware/s32k1xx_sim.h"
+
+#include "s32k1xx_config.h"
+#include "s32k1xx_eeeprom.h"
+
+#include "up_internal.h"
+
+#include <arch/board/board.h> /* Include last:  has dependencies */
+
+#include <nuttx/kmalloc.h>
+#include <nuttx/fs/fs.h>
+
+/******************************************************************************
+ * Private Types
+ ******************************************************************************/
+
+struct eeed_struct_s
+{
+  uint32_t eeed_nsectors;         /* Number of sectors on device */
+  uint16_t eeed_sectsize;         /* The size of one sector */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  uint8_t eeed_crefs;             /* Open reference count */
+#endif
+  FAR uint8_t *eeed_buffer;       /* FlexRAM memory */
+};
+
+/******************************************************************************
+ * Private Function Prototypes
+ ******************************************************************************/
+
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+static int     eeed_open(FAR struct inode *inode);
+static int     eeed_close(FAR struct inode *inode);
+#endif
+
+static ssize_t eeed_read(FAR struct inode *inode, FAR unsigned char *buffer,
+                 size_t start_sector, unsigned int nsectors);
+static ssize_t eeed_write(FAR struct inode *inode,
+                 FAR const unsigned char *buffer, size_t start_sector,
+                 unsigned int nsectors);
+
+static int     eeed_geometry(FAR struct inode *inode,
+                 FAR struct geometry *geometry);
+static int     eeed_ioctl(FAR struct inode *inode, int cmd,
+                 unsigned long arg);
+
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+static int     eeed_unlink(FAR struct inode *inode);
+#endif
+
+/******************************************************************************
+ * Private Data
+ ******************************************************************************/
+
+static const struct block_operations g_bops =
+{
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  eeed_open,     /* open     */
+  eeed_close,    /* close    */
+#else
+  0,           /* open     */
+  0,           /* close    */
+#endif
+  eeed_read,     /* read     */
+  eeed_write,    /* write    */
+  eeed_geometry, /* geometry */
+  eeed_ioctl,    /* ioctl    */
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+  eeed_unlink    /* unlink   */
+#endif
+};
+
+/******************************************************************************
+ * Private Functions
+ ******************************************************************************/
+
+static inline void wait_ftfc_ready()
+{
+  while ((getreg8(S32K1XX_FTFC_FSTAT) & FTTC_FSTAT_CCIF) == 0)
+    {
+      /* Busy */
+    }
+}
+
+static uint32_t execute_ftfc_command()
+{
+  uint8_t regval;
+  uint32_t retval = 0;
+
+  /* Clear CCIF to launch command */
+
+  regval = getreg8(S32K1XX_FTFC_FSTAT);
+  regval |= FTTC_FSTAT_CCIF;
+  putreg8(regval, S32K1XX_FTFC_FSTAT);
+
+  wait_ftfc_ready();
+
+  retval = getreg8(S32K1XX_FTFC_FSTAT);
+
+  if (retval & (FTTC_FSTAT_MGSTAT0 | FTTC_FSTAT_FPVIOL |
+                FTTC_FSTAT_ACCERR | FTTC_FSTAT_RDCOLERR))
+    {
+      return retval; /* Error has occured */
+    }
+
+  return retval;
+}
+
+/******************************************************************************
+ * Name: eeed_open
+ *
+ * Description: Open the block device
+ *
+ ******************************************************************************/
+
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+static int eeed_open(FAR struct inode *inode)
+{
+  FAR struct eeed_struct_s *dev;
+
+  DEBUGASSERT(inode && inode->i_private);
+  dev = (FAR struct eeed_struct_s *)inode->i_private;
+
+  /* Increment the open reference count */
+
+  dev->eeed_crefs++;
+  DEBUGASSERT(dev->eeed_crefs > 0);
+
+  finfo("eeed_crefs: %d\n", dev->eeed_crefs);
+  return OK;
+}
+#endif
+
+/******************************************************************************
+ * Name: eeed_close
+ *
+ * Description: close the block device
+ *
+ ******************************************************************************/
+
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+static int eeed_close(FAR struct inode *inode)
+{
+  FAR struct eeed_struct_s *dev;
+
+  DEBUGASSERT(inode && inode->i_private);
+  dev = (FAR struct eeed_struct_s *)inode->i_private;
+
+  /* Increment the open reference count */
+
+  DEBUGASSERT(dev->eeed_crefs > 0);
+  dev->eeed_crefs--;
+  finfo("eeed_crefs: %d\n", dev->eeed_crefs);
+
+  return OK;
+}
+#endif
+
+/******************************************************************************
+ * Name: eeed_read
+ *
+ * Description:  Read the specified number of sectors
+ *
+ ******************************************************************************/
+
+static ssize_t eeed_read(FAR struct inode *inode, unsigned char *buffer,
+                       size_t start_sector, unsigned int nsectors)
+{
+  FAR struct eeed_struct_s *dev;
+
+  DEBUGASSERT(inode && inode->i_private);
+  dev = (FAR struct eeed_struct_s *)inode->i_private;
+
+  finfo("sector: %d nsectors: %d sectorsize: %d\n",
+        start_sector, dev->eeed_sectsize, nsectors);
+
+  if (start_sector < dev->eeed_nsectors &&
+      start_sector + nsectors <= dev->eeed_nsectors)
+    {
+       finfo("Transfer %d bytes from %p\n",
+             nsectors * dev->eeed_sectsize,
+             &dev->eeed_buffer[start_sector * dev->eeed_sectsize]);
+
+       wait_ftfc_ready();
+
+       memcpy(buffer,
+             &dev->eeed_buffer[start_sector * dev->eeed_sectsize],
+             nsectors * dev->eeed_sectsize);
+      return nsectors;
+    }
+
+  return -EINVAL;
+}
+
+/******************************************************************************
+ * Name: eeed_write
+ *
+ * Description: Write the specified number of sectors
+ *
+ ******************************************************************************/
+
+static ssize_t eeed_write(FAR struct inode *inode, const unsigned char *buffer,
+                        size_t start_sector, unsigned int nsectors)
+{
+  struct eeed_struct_s *dev;
+
+  DEBUGASSERT(inode && inode->i_private);
+  dev = (struct eeed_struct_s *)inode->i_private;
+
+  finfo("sector: %d nsectors: %d sectorsize: %d\n",
+        start_sector, dev->eeed_sectsize, nsectors);
+
+  if (start_sector < dev->eeed_nsectors &&
+           start_sector + nsectors <= dev->eeed_nsectors)
+    {
+      finfo("Transfer %d bytes to %p\n",
+             nsectors * dev->eeed_sectsize,
+             &dev->eeed_buffer[start_sector * dev->eeed_sectsize]);
+
+      FAR uint32_t *dest = (FAR uint32_t *)&dev->eeed_buffer
+                           [start_sector * dev->eeed_sectsize];
+
+      uint32_t *src = (uint32_t *)buffer;
+
+      for (int i = 0; i < nsectors; i++)
+        {
+          wait_ftfc_ready();
+          *dest = *src;
+          dest++;
+          src++;
+        }
+
+      return nsectors;
+    }
+
+  return -EFBIG;
+}
+
+/******************************************************************************
+ * Name: eeed_geometry
+ *
+ * Description: Return device geometry
+ *
+ ******************************************************************************/
+
+static int eeed_geometry(FAR struct inode *inode, struct geometry *geometry)
+{
+  struct eeed_struct_s *dev;
+
+  finfo("Entry\n");
+
+  DEBUGASSERT(inode);
+  if (geometry)
+    {
+      dev = (struct eeed_struct_s *)inode->i_private;
+      geometry->geo_available     = true;
+      geometry->geo_mediachanged  = false;
+      geometry->geo_writeenabled  = true;
+      geometry->geo_nsectors      = dev->eeed_nsectors;
+      geometry->geo_sectorsize    = dev->eeed_sectsize;
+
+      finfo("available: true mediachanged: false writeenabled: %s\n",
+            geometry->geo_writeenabled ? "true" : "false");
+      finfo("nsectors: %d sectorsize: %d\n",
+            geometry->geo_nsectors, geometry->geo_sectorsize);
+
+      return OK;
+    }
+
+  return -EINVAL;
+}
+
+/******************************************************************************
+ * Name: eeed_ioctl
+ *
+ * Description:
+ *   Return device geometry
+ *
+ ******************************************************************************/
+
+static int eeed_ioctl(FAR struct inode *inode, int cmd, unsigned long arg)
+{
+  FAR struct eeed_struct_s *dev;
+  FAR void **ppv = (void**)((uintptr_t)arg);
+
+  finfo("Entry\n");
+
+  /* Only one ioctl command is supported */
+
+  DEBUGASSERT(inode && inode->i_private);
+  if (cmd == BIOC_XIPBASE && ppv)
+    {
+      dev  = (FAR struct eeed_struct_s *)inode->i_private;
+      *ppv = (FAR void *)dev->eeed_buffer;
+
+      finfo("ppv: %p\n", *ppv);
+      return OK;
+    }
+
+  return -ENOTTY;
+}
+
+/******************************************************************************
+ * Name: eeed_unlink
+ *
+ * Description:
+ *   The block driver has been unlinked.
+ *
+ ******************************************************************************/
+
+#ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS
+static int eeed_unlink(FAR struct inode *inode)
+{
+  FAR struct eeed_struct_s *dev;
+
+  DEBUGASSERT(inode && inode->i_private);
+  dev = (FAR struct eeed_struct_s *)inode->i_private;
+
+  /* And free the block driver itself */
+
+  kmm_free(dev);
+
+  return OK;
+}
+#endif
+
+/******************************************************************************
+ * Public Functions
+ ******************************************************************************/
+
+/******************************************************************************
+ * Name: s32k1xx_eeeprom_register
+ *
+ * Description:
+ *   Non-standard function to register a eeeprom
+ *
+ * Input Parameters:
+ *   minor:         Selects suffix of device named /dev/eeepromN, N={1,2,3...}
+ *   size:          The size of eeprom in bytes
+ *
+ * Returned Value:
+ *   Zero on success; a negated errno value on failure.
+ *
+ ******************************************************************************/
+
+int s32k1xx_eeeprom_register(int minor, uint32_t size)
+{
+  struct eeed_struct_s *dev;
+  char devname[16];
+  int ret = -ENOMEM;
+
+  /* Allocate a eeeprom device structure */
+
+  dev = (struct eeed_struct_s *)kmm_zalloc(sizeof(struct eeed_struct_s));
+  if (dev)
+    {
+      /* Initialize the eeeprom device structure */
+
+      dev->eeed_nsectors     = size / 4;     /* Number of sectors on device */
+      dev->eeed_sectsize     = 4;            /* The size of one sector */
+      dev->eeed_buffer       = (FAR uint8_t *)S32K1XX_FTFC_EEEPROM_BASE;
+
+      /* Create a eeeprom device name */
+
+      snprintf(devname, 16, "/dev/eeeprom%d", minor);
+
+      /* Inode private data is a reference to the eeeprom device structure */
+
+      ret = register_blockdriver(devname, &g_bops, 0, dev);
+      if (ret < 0)
+        {
+          ferr("register_blockdriver failed: %d\n", -ret);
+          kmm_free(dev);
+        }
+    }
+
+  return ret;
+}
+
+/******************************************************************************
+ * Name: s32k1xx_eeeprom_init
+ *
+ * Description:
+ *   Init FTFC flash controller to run in Enhanced EEPROM mode
+ *
+ *
+ ******************************************************************************/
+
+void s32k1xx_eeeprom_init()
+{
+  uint32_t regval;
+
+  regval = getreg32(S32K1XX_SIM_FCFG1);
+
+  /* If the FlexNVM memory has not been partitioned */
+
+  if (((regval & SIM_FCFG1_DEPART_MASK) >> SIM_FCFG1_DEPART_SHIFT) == 0xf)
+    {
+      /* Setup D-flash partitioning for use with EEEPROM */
+
+      putreg8(S32K1XX_FTFC_PROGRAM_PARTITION, S32K1XX_FTFC_FCCOB0); /* Command */
+
+      putreg8(0x0, S32K1XX_FTFC_FCCOB1); /* CSEc key size */
+      putreg8(0x0, S32K1XX_FTFC_FCCOB2); /* uSFE */
+      putreg8(0x0, S32K1XX_FTFC_FCCOB3); /* Load FlexRAM EEE */
+      putreg8(0x2, S32K1XX_FTFC_FCCOB4); /* EEE Partition code (4KB) */
+      putreg8(0x8, S32K1XX_FTFC_FCCOB5); /* DE  Partition code (64KB FlexNVM as
+                                          * EEEPROM backup
+                                          */
+
+      execute_ftfc_command();
+    }
+
+  /* Enable FlexRAM for use with EEPROM */
+
+  putreg8(S32K1XX_FTFC_SET_FLEXRAM_FUNCTION, S32K1XX_FTFC_FCCOB0); /* Command */
+
+  putreg8(0x0, S32K1XX_FTFC_FCCOB1); /* FlexRAM used for EEEPROM */
+
+  execute_ftfc_command();
+
+  /* Wait for Emulated EEPROM to be ready */
+
+  while ((getreg8(S32K1XX_FTFC_FCNFG) & FTTC_FCNFG_EEERDY) == 0)
+    {
+      /* Busy */
+    }
+}

--- a/arch/arm/src/s32k1xx/s32k1xx_eeeprom.h
+++ b/arch/arm/src/s32k1xx/s32k1xx_eeeprom.h
@@ -1,0 +1,88 @@
+/******************************************************************************
+ * arch/arm/src/s32k1xx/s32k1xx_eeeprom.h
+ *
+ *   Copyright (C) 2019 Gregory Nutt. All rights reserved.
+ *   Author:  Gregory Nutt <gnutt@nuttx.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name NuttX nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_S32K1XX_EEEPROM_H
+#define __ARCH_ARM_SRC_S32K1XX_EEEPROM_H
+
+/******************************************************************************
+ * Included Files
+ ******************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/compiler.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "up_internal.h"
+#include "s32k1xx_config.h"
+
+/******************************************************************************
+ * Pre-processor Definitions
+ ******************************************************************************/
+
+/******************************************************************************
+ * Public Function Prototypes
+ ******************************************************************************/
+
+/******************************************************************************
+ * Name: s32k1xx_eeeprom_init
+ *
+ * Description:
+ *   Init FTFC flash controller to run in Enhanced EEPROM mode
+ *
+ *
+ ******************************************************************************/
+
+void s32k1xx_eeeprom_init(void);
+
+/******************************************************************************
+ * Name: s32k1xx_eeeprom_register
+ *
+ * Description:
+ *   Non-standard function to register a eeeprom
+ *
+ * Input Parameters:
+ *   minor:         Selects suffix of device named /dev/eeepromN, N={1,2,3...}
+ *   size:          The size of eeprom in bytes
+ *
+ * Returned Value:
+ *   Zero on success; a negated errno value on failure.
+ *
+ ******************************************************************************/
+
+int s32k1xx_eeeprom_register(int minor, uint32_t size);
+#endif /* __ARCH_ARM_SRC_S32K1XX_EEEPROM_H */

--- a/arch/arm/src/s32k1xx/s32k1xx_start.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_start.c
@@ -361,6 +361,10 @@ void __start(void)
   s32k1xx_progmem_init();
 #endif
 
+#ifdef CONFIG_S32K1XX_EEEPROM
+  s32k1xx_eeeprom_init();
+#endif
+
   /* For the case of the separate user-/kernel-space build, perform whatever
    * platform specific initialization of the user memory is required.
    * Normally this just means initializing the user space .data and .bss

--- a/net/can/can_getsockopt.c
+++ b/net/can/can_getsockopt.c
@@ -165,6 +165,7 @@ int can_getsockopt(FAR struct socket *psock, int option,
           }
         break;
 
+#ifdef CONFIG_NET_CAN_CANFD
       case CAN_RAW_FD_FRAMES:
         if (*value_len < sizeof(conn->fd_frames))
           {
@@ -183,6 +184,7 @@ int can_getsockopt(FAR struct socket *psock, int option,
             ret                = OK;
           }
         break;
+#endif
 
       case CAN_RAW_JOIN_FILTERS:
         break;

--- a/net/can/can_recvfrom.c
+++ b/net/can/can_recvfrom.c
@@ -436,7 +436,14 @@ static uint16_t can_recvfrom_eventhandler(FAR struct net_driver_s *dev,
           if (!conn->fd_frames)
 #endif
             {
+#if defined(CONFIG_NET_TIMESTAMP)
+              if ((conn->psock->s_timestamp && (dev->d_len >
+                  sizeof(struct can_frame) + sizeof(struct timeval)))
+                  || (!conn->psock->s_timestamp && (dev->d_len >
+                   sizeof(struct can_frame))))
+#else
               if (dev->d_len > sizeof(struct can_frame))
+#endif
                 {
                   /* DO WE NEED TO CLEAR FLAGS?? */
 

--- a/net/can/can_recvfrom.c
+++ b/net/can/can_recvfrom.c
@@ -288,11 +288,11 @@ static inline int can_readahead(struct can_recvfrom_s *pstate)
         }
 
       /* do not pass frames with DLC > 8 to a legacy socket */
-
+#if defined(CONFIG_NET_CANPROTO_OPTIONS) && defined(CONFIG_NET_CAN_CANFD)
       if (!conn->fd_frames)
+#endif
         {
-          struct canfd_frame *cfd = (struct canfd_frame *)pstate->pr_buffer;
-          if (cfd->len > CAN_MAX_DLEN)
+          if (recvlen > sizeof(struct can_frame))
             {
               return 0;
             }
@@ -381,7 +381,8 @@ static inline int can_readahead_timestamp(struct can_conn_s *conn,
 #ifdef CONFIG_NET_CANPROTO_OPTIONS
 static int can_recv_filter(struct can_conn_s *conn, canid_t id)
 {
-  for (int i = 0; i < conn->filter_count; i++)
+  uint32_t i;
+  for (i = 0; i < conn->filter_count; i++)
     {
       if (conn->filters[i].can_id & CAN_INV_FILTER)
         {
@@ -431,11 +432,11 @@ static uint16_t can_recvfrom_eventhandler(FAR struct net_driver_s *dev,
 #endif
 
           /* do not pass frames with DLC > 8 to a legacy socket */
-
+#if defined(CONFIG_NET_CANPROTO_OPTIONS) && defined(CONFIG_NET_CAN_CANFD)
           if (!conn->fd_frames)
+#endif
             {
-              struct canfd_frame *cfd = (struct canfd_frame *)dev->d_appdata;
-              if (cfd->len > CAN_MAX_DLEN)
+              if (dev->d_len > sizeof(struct can_frame))
                 {
                   /* DO WE NEED TO CLEAR FLAGS?? */
 
@@ -457,7 +458,9 @@ static uint16_t can_recvfrom_eventhandler(FAR struct net_driver_s *dev,
                 }
               else
                 {
-                  /* We still have to consume the data otherwise IOB gets full */
+                  /* We still have to consume the data
+                   * otherwise IOB gets full
+                   */
 
                   uint8_t dummy_buf[sizeof(struct timeval)];
                   can_readahead_timestamp(conn, (uint8_t *)&dummy_buf);

--- a/net/can/can_setsockopt.c
+++ b/net/can/can_setsockopt.c
@@ -140,6 +140,7 @@ int can_setsockopt(FAR struct socket *psock, int option,
 
         break;
 
+#ifdef CONFIG_NET_CAN_CANFD
       case CAN_RAW_FD_FRAMES:
         if (value_len != sizeof(conn->fd_frames))
           {
@@ -149,6 +150,7 @@ int can_setsockopt(FAR struct socket *psock, int option,
           conn->fd_frames = *(FAR int32_t *)value;
 
           break;
+#endif
 
       case CAN_RAW_JOIN_FILTERS:
         break;


### PR DESCRIPTION
This PR includes contains some fixes for the FlexCAN driver:
- Bitrate calculation fix
- FlexCAN TX done and transmit race condition

Furthermore it includes the Enhanced EEPROM (4kb) block device driver which allows PX4 to store it's parameters on.