### PR TITLE
[BACKPORT] Allows network monitoring (in apps repo) using polling

### DIFF
--- a/arch/arm/src/stm32f7/Kconfig
+++ b/arch/arm/src/stm32f7/Kconfig
@@ -1144,6 +1144,10 @@ config STM32F7_HAVE_ETHRNET
 	bool
 	default n
 
+config STM32F7_HAVE_PHY_POLLED
+	bool
+	default n
+
 config STM32F7_HAVE_RNG
 	bool
 	default n
@@ -1402,6 +1406,7 @@ config STM32F7_ETHMAC
 	depends on STM32F7_HAVE_ETHRNET
 	select NETDEVICES
 	select ARCH_HAVE_PHY
+	select STM32F7_HAVE_PHY_POLLED
 
 config STM32F7_FMC
 	bool "FMC"
@@ -5267,6 +5272,16 @@ config STM32F7_PHYINIT
 		STM32F7_PHYINIT is defined in the configuration then the board specific logic must
 		provide stm32_phyinitialize();  The STM32 Ethernet driver will call this function
 		one time before it first uses the PHY.
+
+config STM32F7_PHY_POLLING
+	bool "Support network monitoring by poling the PHY"
+	default n
+	depends on STM32F7_HAVE_PHY_POLLED
+	select ARCH_PHY_POLLED
+	---help---
+		Some boards may not have an interrupt connected to the PHY.
+		This option allows the network monitor to be used by polling the
+		the PHY for status.
 
 config STM32F7_MII
 	bool "Use MII interface"

--- a/net/Kconfig
+++ b/net/Kconfig
@@ -15,6 +15,10 @@ config ARCH_PHY_INTERRUPT
 	bool
 	default n
 
+config ARCH_PHY_POLLED
+	bool
+	default n
+
 config ARCH_HAVE_NETDEV_STATISTICS
 	bool
 	default n


### PR DESCRIPTION
## Summary

This is a BACKPORT of

### Low level Net Monitor Polling 

  Not all boards have an interrupt line from the phy to the Soc. This commit allows the phy to be polled for
   link status.

   This may not work on all MAC/PHY combination that have mutually exclusive link management and operating
   modes. The STM32F7 and LAN8742AI do not have such a  limitation.

## Impact

None all  configurations have Kconfig knobs. 

## Testing

PX4 FMUV5X
