### PR TITLE
DO NOT MERGE For testing

### DIFF
--- a/arch/arm/src/stm32f7/Kconfig
+++ b/arch/arm/src/stm32f7/Kconfig
@@ -2582,10 +2582,24 @@ endchoice #"RTC clock source"
 
 if STM32F7_RTC_LSECLOCK
 
+config STM32F7_RTC_AUTO_LSECLOCK_START_DRV_CAPABILITY
+	bool "Automaticaly boost the LSE oscillator drive capability level until it starts-up"
+	default n
+	---help---
+		This will cycle through the values from low to high. To avoid
+		damaging the the crystal. We want to use the lowest setting that gets
+		the OSC running. See app note AN2867
+
+			0 = Low drive capability (default)
+			1 = Medium high drive capability
+			2 = Medium low drive capability
+			3 = High drive capability
+
 config STM32F7_RTC_LSECLOCK_START_DRV_CAPABILITY
 	int "LSE oscillator drive capability level at LSE start-up"
 	default 0
 	range 0 3
+	depends on !STM32F7_RTC_AUTO_LSECLOCK_START_DRV_CAPABILITY
 	---help---
 		0 = Low drive capability (default)
 		1 = Medium high drive capability
@@ -2596,6 +2610,7 @@ config STM32F7_RTC_LSECLOCK_RUN_DRV_CAPABILITY
 	int "LSE oscillator drive capability level after LSE start-up"
 	default 0
 	range 0 3
+	depends on !STM32F7_RTC_AUTO_LSECLOCK_START_DRV_CAPABILITY
 	---help---
 		0 = Low drive capability (default)
 		1 = Medium high drive capability

--- a/arch/arm/src/stm32f7/stm32_lse.c
+++ b/arch/arm/src/stm32f7/stm32_lse.c
@@ -1,9 +1,9 @@
 /****************************************************************************
  * arch/arm/src/stm32f7/stm32_lse.c
  *
- *   Copyright (C) 2017 Gregory Nutt. All rights reserved.
+ *   Copyright (C) 2017, 2021 Gregory Nutt. All rights reserved.
  *   Authors: Gregory Nutt <gnutt@nuttx.org>
- *            David Sidrane <david_s5@nscdg.com>
+ *            David Sidrane <david.sidrane@nscdg.com>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -49,6 +49,8 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#define LSERDY_TIMEOUT (500 * CONFIG_BOARD_LOOPSPERMSEC)
+
 #ifdef CONFIG_STM32F7_RTC_LSECLOCK_START_DRV_CAPABILITY
 # if CONFIG_STM32F7_RTC_LSECLOCK_START_DRV_CAPABILITY < 0 || \
      CONFIG_STM32F7_RTC_LSECLOCK_START_DRV_CAPABILITY > 3
@@ -64,6 +66,18 @@
 #endif
 
 /****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const uint32_t drives[4] =
+{
+    RCC_BDCR_LSEDRV_LOW,
+    RCC_BDCR_LSEDRV_MEDLO,
+    RCC_BDCR_LSEDRV_MEDHI,
+    RCC_BDCR_LSEDRV_HIGH
+};
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -77,7 +91,11 @@
 
 void stm32_rcc_enablelse(void)
 {
-  uint32_t regval;
+  uint32_t         regval;
+  volatile int32_t timeout;
+#ifdef CONFIG_STM32F7_RTC_AUTO_LSECLOCK_START_DRV_CAPABILITY
+  volatile int32_t drive = 0;
+#endif
 
   /* Check if the External Low-Speed (LSE) oscillator is already running. */
 
@@ -100,27 +118,55 @@ void stm32_rcc_enablelse(void)
       regval |= RCC_BDCR_LSEON;
 
 #ifdef CONFIG_STM32F7_RTC_LSECLOCK_START_DRV_CAPABILITY
-      /* Set start-up drive capability for LSE oscillator. */
+      /* Set start-up drive capability for LSE oscillator. With the
+       * enable on.
+       */
 
-      regval &= ~RCC_BDCR_LSEDRV_MASK;
-      regval |= CONFIG_STM32F7_RTC_LSECLOCK_START_DRV_CAPABILITY <<
-                RCC_BDCR_LSEDRV_SHIFT;
+      regval &= ~(RCC_BDCR_LSEDRV_MASK);
+      regval |= drives[CONFIG_STM32F7_RTC_LSECLOCK_START_DRV_CAPABILITY];
 #endif
 
-      putreg32(regval, STM32_RCC_BDCR);
+#ifdef CONFIG_STM32F7_RTC_AUTO_LSECLOCK_START_DRV_CAPABILITY
+      do
+        {
+          regval &= ~(RCC_BDCR_LSEDRV_MASK);
+          regval |= drives[drive++];
+#endif
 
-      /* Wait for the LSE clock to be ready */
+          putreg32(regval, STM32_RCC_BDCR);
 
-      while (((regval = getreg32(STM32_RCC_BDCR)) & RCC_BDCR_LSERDY) == 0);
+          /* Wait for the LSE clock to be ready (or until a timeout elapsed)
+           */
 
+          for (timeout = LSERDY_TIMEOUT; timeout > 0; timeout--)
+            {
+              /* Check if the LSERDY flag is the set in the BDCR */
+
+              regval = getreg32(STM32_RCC_BDCR);
+
+              if (regval & RCC_BDCR_LSERDY)
+                {
+                  /* If so, then break-out with timeout > 0 */
+
+                  break;
+                }
+            }
+
+#ifdef CONFIG_STM32F7_RTC_AUTO_LSECLOCK_START_DRV_CAPABILITY
+          if (timeout != 0)
+            {
+              break;
+            }
+        }
+      while (drive < sizeof(drives) / sizeof(drives[0]));
+#endif
 #if defined(CONFIG_STM32F7_RTC_LSECLOCK_RUN_DRV_CAPABILITY) && \
     CONFIG_STM32F7_RTC_LSECLOCK_START_DRV_CAPABILITY != \
     CONFIG_STM32F7_RTC_LSECLOCK_RUN_DRV_CAPABILITY
       /* Set running drive capability for LSE oscillator. */
 
       regval &= ~RCC_BDCR_LSEDRV_MASK;
-      regval |= CONFIG_STM32F7_RTC_LSECLOCK_RUN_DRV_CAPABILITY <<
-                RCC_BDCR_LSEDRV_SHIFT;
+      regval |= drives[CONFIG_STM32F7_RTC_LSECLOCK_RUN_DRV_CAPABILITY];
       putreg32(regval, STM32_RCC_BDCR);
 #endif
 

--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -1493,25 +1493,59 @@ endchoice #"RTC clock source"
 
 if STM32H7_RTC_LSECLOCK
 
+config STM32H7_RTC_AUTO_LSECLOCK_START_DRV_CAPABILITY
+	bool "Automaticaly boost the LSE oscillator drive capability level until it starts-up"
+	default n
+	---help---
+		This will cycle through the correct* values from low to high. To avoid
+		damaging the the crystal. We want to use the lowest setting that gets
+		the OSC running. See app note AN2867
+
+			0 = Low drive capability (default)
+			1 = Medium high drive capability
+			2 = Medium low drive capability
+			3 = High drive capability
+
+		*It will take into account the rev of the silicon and use
+		the correct code points to achive the drive strength.
+		See Eratta ES0392 Rev 7 2.2.14 LSE oscillator driving capability
+		selection bits are swapped.
+
 config STM32H7_RTC_LSECLOCK_START_DRV_CAPABILITY
 	int "LSE oscillator drive capability level at LSE start-up"
 	default 0
 	range 0 3
+	depends on !STM32H7_RTC_AUTO_LSECLOCK_START_DRV_CAPABILITY
 	---help---
 		0 = Low drive capability (default)
 		1 = Medium high drive capability
 		2 = Medium low drive capability
 		3 = High drive capability
 
+		It will take into account the rev of the silicon and use
+		the correct code points tp achive the drive strength.
+		See Eratta ES0392 Rev 7 2.2.14 LSE oscillator driving capability
+		selection bits are swapped.
+
 config STM32H7_RTC_LSECLOCK_RUN_DRV_CAPABILITY
 	int "LSE oscillator drive capability level after LSE start-up"
 	default 0
 	range 0 3
+	depends on !STM32H7_RTC_AUTO_LSECLOCK_START_DRV_CAPABILITY
 	---help---
 		0 = Low drive capability (default)
 		1 = Medium high drive capability
 		2 = Medium low drive capability
 		3 = High drive capability
+
+		It will take into account the rev of the silicon and use
+		the correct code points tp achive the drive strength.
+		See Eratta ES0392 Rev 7 2.2.14 LSE oscillator driving capability
+		selection bits are swapped.
+
+		WARNING this RUN setting does not apear to work!
+		it apears that the LSEDRV bits can not be changes once the OSC
+		is running.
 
 endif # STM32H7_RTC_LSECLOCK
 

--- a/arch/arm/src/stm32h7/hardware/stm32h7x3xx_rcc.h
+++ b/arch/arm/src/stm32h7/hardware/stm32h7x3xx_rcc.h
@@ -1132,10 +1132,12 @@
 #define RCC_BDCR_LSERDY                 (1 << 1)                     /* Bit 1: External Low Speed oscillator Ready */
 #define RCC_BDCR_LSEBYP                 (1 << 2)                     /* Bit 2: External Low Speed oscillator Bypass */
 #define RCC_BDCR_LSEDRV_SHIFT           (3)                          /* Bits 4:3: LSE oscillator Drive selection */
-#define RCC_BDCR_LSEDRV_MASK            (3 << RCC_BDCR_LSEDRV_SHIFT)
+#define RCC_BDCR_LSEDRV_MASK            (3 << RCC_BDCR_LSEDRV_SHIFT) /* See errata ES0392 Rev 7. 2.2.14 */
 #  define RCC_BDCR_LSEDRV_LOW           (0 << RCC_BDCR_LSEDRV_SHIFT) /* 00: Low driving capability */
-#  define RCC_BDCR_LSEDRV_MEDHI         (1 << RCC_BDCR_LSEDRV_SHIFT) /* 01: Medium high driving capability */
-#  define RCC_BDCR_LSEDRV_MEDLO         (2 << RCC_BDCR_LSEDRV_SHIFT) /* 10: Medium low driving capability */
+#  define RCC_BDCR_LSEDRV_MEDHI_Y       (1 << RCC_BDCR_LSEDRV_SHIFT) /* 01: Medium high driving capability rev y */
+#  define RCC_BDCR_LSEDRV_MEDHI         (2 << RCC_BDCR_LSEDRV_SHIFT) /* 10: Medium high driving capability */
+#  define RCC_BDCR_LSEDRV_MEDLO_Y       (2 << RCC_BDCR_LSEDRV_SHIFT) /* 10: Medium low driving capability rev y */
+#  define RCC_BDCR_LSEDRV_MEDLO         (1 << RCC_BDCR_LSEDRV_SHIFT) /* 01: Medium low driving capability */
 #  define RCC_BDCR_LSEDRV_HIGH          (3 << RCC_BDCR_LSEDRV_SHIFT) /* 11: High driving capability */
 #define RCC_BDCR_LSECSSON               (1 << 5)                     /* Bit 5: LSE clock security system enable */
 #define RCC_BDCR_LSECSSD                (1 << 6)                     /* Bit 6: LSE clock security system failure detection */

--- a/arch/arm/src/stm32h7/hardware/stm32h7xxx_dbgmcu.h
+++ b/arch/arm/src/stm32h7/hardware/stm32h7xxx_dbgmcu.h
@@ -1,0 +1,121 @@
+/***************************************************************************************************
+ * arch/arm/src/stm32f7/hardware/stm32f76xx77xx_dbgmcu.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ***************************************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_STM32H7_HARDWARE_STM32H7XXXDBGMCU_H
+#define __ARCH_ARM_SRC_STM32H7_HARDWARE_STM32H7XXXDBGMCU_H
+
+/***************************************************************************************************
+ * Included Files
+ ***************************************************************************************************/
+
+#include <nuttx/config.h>
+
+#include "chip.h"
+
+/***************************************************************************************************
+ * Pre-processor Definitions
+ ***************************************************************************************************/
+
+/* Register Offsets  *******************************************************************************/
+
+#define STM32_DBGMCU_IDC_OFFSET      0x0000  /* DBGMCU identity code register */
+#define STM32_DBGMCU_CR_OFFSET       0x0004  /* MCU debug */
+#define STM32_DBGMCU_APB3FZ1_OFFSET  0x0034  /* APB3 peripheral freeze register */
+#define STM32_DBGMCU_APB1LFZ1_OFFSET 0x003c  /* APB1L peripheral freeze register */
+#define STM32_DBGMCU_APB2FZ1_OFFSET  0x004c  /* APB2 peripheral freeze register */
+#define STM32_DBGMCU_APB4LFZ1_OFFSET 0x0054  /* APB4 peripheral freeze register */
+
+/* Register Addresses ******************************************************************************/
+
+#define STM32_DBGMCU_IDC      (STM32_DEBUGMCU_BASE + STM32_DBGMCU_IDC_OFFSET)
+#define STM32_DBGMCU_CR       (STM32_DEBUGMCU_BASE + STM32_DBGMCU_CR_OFFSET)
+#define STM32_DBGMCU_APB3FZ1  (STM32_DEBUGMCU_BASE + STM32_DBGMCU_APB3FZ1_OFFSET)
+#define STM32_DBGMCU_APB1LFZ1 (STM32_DEBUGMCU_BASE + STM32_DBGMCU_APB1LFZ1_OFFSET)
+#define STM32_DBGMCU_APB2FZ1  (STM32_DEBUGMCU_BASE + STM32_DBGMCU_APB2FZ1_OFFSET)
+#define STM32_DBGMCU_APB4LFZ1 (STM32_DEBUGMCU_BASE + STM32_DBGMCU_APB4LFZ1_OFFSET)
+
+/* Register Bitfield Definitions *******************************************************************/
+
+/* MCU identifier */
+
+#define DBGMCU_IDCODE_DEVID_SHIFT (0)       /* Bits 11-0: Device Identifier */
+#define DBGMCU_IDCODE_DEVID_MASK  (0x0fff << DBGMCU_IDCODE_DEVID_SHIFT)
+#  define STM32_IDCODE_DEVID      (0x0450 << DBGMCU_IDCODE_DEVID_SHIFT)
+#define DBGMCU_IDCODE_REVID_SHIFT (16)      /* Bits 31-16:  Revision Identifier */
+#define DBGMCU_IDCODE_REVID_MASK  (0xffff << DBGMCU_IDCODE_REVID_SHIFT)
+#  define STM32_IDCODE_REVID_Z     (0x1001 << DBGMCU_IDCODE_REVID_SHIFT)
+#  define STM32_IDCODE_REVID_Y     (0x1003 << DBGMCU_IDCODE_REVID_SHIFT)
+#  define STM32_IDCODE_REVID_X     (0x2001 << DBGMCU_IDCODE_REVID_SHIFT)
+#  define STM32_IDCODE_REVID_V     (0x2003 << DBGMCU_IDCODE_REVID_SHIFT)
+
+/* MCU debug */
+
+#define DBGMCU_CR_SLEEP           (1 << 0)  /* Bit 0: Debug Sleep Mode */
+#define DBGMCU_CR_STOP            (1 << 1)  /* Bit 1: Debug Stop Mode */
+#define DBGMCU_CR_STANDBY         (1 << 2)  /* Bit 2: Debug Standby mode */
+
+#define DBGMCU_CR_TRACECLKEN      (1 << 20)  /* Bit 20: Trace port clock enable */
+#define DBGMCU_CR_D1DBGCKEN       (1 << 21)  /* Bit 21: D1 debug clock enable */
+#define DBGMCU_CR_D3DBGCKEN       (1 << 22)  /* Bit 22: D3 debug clock enable */
+
+#define DBGMCU_CR_TRGOEN          (1 << 28)  /* Bit 28: External trigger output enable */
+
+/* Debug MCU APB3 freeze register */
+
+#define DBGMCU_APB3_WWDOG          (1 << 6)   /* Bit 6: WWDG1 stop in debug */
+
+/* Debug MCU APB1L freeze register */
+
+#define DBGMCU_APB1L_TIM2STOP      (1 << 0)   /* Bit 0: TIM2 stopped when halted */
+#define DBGMCU_APB1L_TIM3STOP      (1 << 1)   /* Bit 1: TIM3 stopped when halted */
+#define DBGMCU_APB1L_TIM4STOP      (1 << 2)   /* Bit 2: TIM4 stopped when halted */
+#define DBGMCU_APB1L_TIM5STOP      (1 << 3)   /* Bit 3: TIM5 stopped when halted */
+#define DBGMCU_APB1L_TIM6STOP      (1 << 4)   /* Bit 4: TIM6 stopped when halted */
+#define DBGMCU_APB1L_TIM7STOP      (1 << 5)   /* Bit 5: TIM7 stopped when halted */
+#define DBGMCU_APB1L_TIM12STOP     (1 << 6)   /* Bit 6: TIM12 stopped when halted */
+#define DBGMCU_APB1L_TIM13STOP     (1 << 7)   /* Bit 7: TIM13 stopped when halted */
+#define DBGMCU_APB1L_TIM14STOP     (1 << 8)   /* Bit 8: TIM14 stopped when halted */
+#define DBGMCU_APB1L_LPTIM1STOP    (1 << 9)   /* Bit 9: LPTIM1 stopped when halted */
+
+#define DBGMCU_APB1L_I2C1STOP      (1 << 21)  /* Bit 21: I2C1 SMBUS timeout stopped when halted */
+#define DBGMCU_APB1L_I2C2STOP      (1 << 22)  /* Bit 22: I2C2 SMBUS timeout stopped when halted */
+#define DBGMCU_APB1L_I2C3STOP      (1 << 23)  /* Bit 23: I2C3 SMBUS timeout stopped when halted */
+
+/* Debug MCU APB2 freeze register */
+
+#define DBGMCU_APB2Z1_TIM1STOP     (1 << 0)   /* Bit 0:  TIM1 stopped when halted */
+#define DBGMCU_APB2Z1_TIM8STOP     (1 << 1)   /* Bit 1:  TIM8 stopped when halted */
+#define DBGMCU_APB2Z1_TIM15STOP    (1 << 16)  /* Bit 16: TIM15 stopped when halted */
+#define DBGMCU_APB2Z1_TIM16STOP    (1 << 17)  /* Bit 17: TIM16 stopped when halted */
+#define DBGMCU_APB2Z1_TIM17STOP    (1 << 18)  /* Bit 18: TIM17 stopped when halted */
+#define DBGMCU_APB2Z1_TIM17STOP    (1 << 18)  /* Bit 18: TIM17 stopped when halted */
+#define DBGMCU_APB2Z1_HRTIMSTOP    (1 << 29)  /* Bit 29: HRTIM stopped when halted */
+
+/* Debug MCU APB4 freeze register */
+
+#define DBGMCU_APB4FZ1_I2C4STOP     (1 << 7)    /* Bit 7: I2C4 stopped when halted */
+#define DBGMCU_APB4FZ1_LPTIM2STOP   (1 << 9)    /* Bit 9: LPTIM2 stopped when halted */
+#define DBGMCU_APB4FZ1_LPTIM3STOP   (1 << 10)   /* Bit 10:LPTIM3 stopped when halted */
+#define DBGMCU_APB4FZ1_LPTIM4STOP   (1 << 11)   /* Bit 11:LPTIM4 stopped when halted */
+#define DBGMCU_APB4FZ1_LPTIM5STOP   (1 << 12)   /* Bit 12:LPTIM5 stopped when halted */
+#define DBGMCU_APB4FZ1_RTCSTOP      (1 << 16)   /* Bit 16:RTC stopped when halted */
+#define DBGMCU_APB4FZ1_IIWDG1STOP   (1 << 18)   /* Bit 18:IIWDG1 stopped when halted */
+
+#endif /* __ARCH_ARM_SRC_STM32H7_HARDWARE_STM32H7XXXDBGMCU_H */


### PR DESCRIPTION
## Summary

stm32f7:Add option to auto select LSE CAPABILITY

   This Knob will cycle through the values from
   low to high. To avoid damaging the crystal.
   We want to use the lowest setting that gets
   the OSC running. See app note AN2867

stm32h7:Add option to auto select LSE CAPABILITY

   This Knob will cycle through the correct*
   values from low to high. To avoid damaging
   the crystal. We want to use the lowest setting
   that gets the OSC running. See app note AN2867

    *It will take into account the rev of the silicon
    and use the correct code points to achive the drive
    strength. See Eratta ES0392 Rev 7 2.2.14 LSE oscillator
    driving capability selection bits are swapped.
## Impact

## Testing

@dinomani 

Use Kconfig and Set CONFIG_STM32F7_RTC_AUTO_LSECLOCK_START_DRV_CAPABILITY 

```
diff --git a/boards/holybro/durandal-v1/nuttx-config/nsh/defconfig b/boards/holybro/durandal-v1/nuttx-config/nsh/defconfig
index 17470801c3..e925df148f 100644
--- a/boards/holybro/durandal-v1/nuttx-config/nsh/defconfig
+++ b/boards/holybro/durandal-v1/nuttx-config/nsh/defconfig
@@ -171,6 +171,7 @@ CONFIG_STM32H7_I2C_DYNTIMEO_STARTSTOP=10
 CONFIG_STM32H7_OTGFS=y
 CONFIG_STM32H7_PROGMEM=y
 CONFIG_STM32H7_RTC=y
+CONFIG_STM32H7_RTC_AUTO_LSECLOCK_START_DRV_CAPABILITY=y
 CONFIG_STM32H7_RTC_MAGIC_REG=1
 CONFIG_STM32H7_SAVE_CRASHDUMP=y
 CONFIG_STM32H7_SDMMC1=y
```

```
diff --git a/boards/px4/fmu-v5x/nuttx-config/nsh/defconfig b/boards/px4/fmu-v5x/nuttx-config/nsh/defconfig
index 1ef345f1e0..c4c36c0cac 100644
--- a/boards/px4/fmu-v5x/nuttx-config/nsh/defconfig
+++ b/boards/px4/fmu-v5x/nuttx-config/nsh/defconfig
@@ -208,8 +208,7 @@ CONFIG_STM32F7_PHY_POLLING=y
 CONFIG_STM32F7_PROGMEM=y
 CONFIG_STM32F7_PWR=y
 CONFIG_STM32F7_RTC=y
-CONFIG_STM32F7_RTC_LSECLOCK_RUN_DRV_CAPABILITY=3
-CONFIG_STM32F7_RTC_LSECLOCK_START_DRV_CAPABILITY=3
+CONFIG_STM32F7_RTC_AUTO_LSECLOCK_START_DRV_CAPABILITY=y
 CONFIG_STM32F7_RTC_MAGIC_REG=1
 CONFIG_STM32F7_SAVE_CRASHDUMP=y
 CONFIG_STM32F7_SDMMC2=y
```
