### PR TITLE
Backports of LSE changes from review.

### DIFF
--- a/arch/arm/src/stm32f7/stm32_lse.c
+++ b/arch/arm/src/stm32f7/stm32_lse.c
@@ -69,6 +69,7 @@
  * Private Data
  ****************************************************************************/
 
+#ifdef CONFIG_STM32F7_RTC_AUTO_LSECLOCK_START_DRV_CAPABILITY
 static const uint32_t drives[4] =
 {
     RCC_BDCR_LSEDRV_LOW,
@@ -76,6 +77,7 @@ static const uint32_t drives[4] =
     RCC_BDCR_LSEDRV_MEDHI,
     RCC_BDCR_LSEDRV_HIGH
 };
+#endif
 
 /****************************************************************************
  * Public Functions
@@ -123,7 +125,8 @@ void stm32_rcc_enablelse(void)
        */
 
       regval &= ~(RCC_BDCR_LSEDRV_MASK);
-      regval |= drives[CONFIG_STM32F7_RTC_LSECLOCK_START_DRV_CAPABILITY];
+      regval |= CONFIG_STM32F7_RTC_LSECLOCK_START_DRV_CAPABILITY <<
+                RCC_BDCR_LSEDRV_SHIFT;
 #endif
 
 #ifdef CONFIG_STM32F7_RTC_AUTO_LSECLOCK_START_DRV_CAPABILITY
@@ -166,7 +169,8 @@ void stm32_rcc_enablelse(void)
       /* Set running drive capability for LSE oscillator. */
 
       regval &= ~RCC_BDCR_LSEDRV_MASK;
-      regval |= drives[CONFIG_STM32F7_RTC_LSECLOCK_RUN_DRV_CAPABILITY];
+      regval |= CONFIG_STM32F7_RTC_LSECLOCK_RUN_DRV_CAPABILITY <<
+                RCC_BDCR_LSEDRV_SHIFT;
       putreg32(regval, STM32_RCC_BDCR);
 #endif
 

--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -1502,8 +1502,8 @@ config STM32H7_RTC_AUTO_LSECLOCK_START_DRV_CAPABILITY
 		the OSC running. See app note AN2867
 
 			0 = Low drive capability (default)
-			1 = Medium high drive capability
-			2 = Medium low drive capability
+			1 = Medium low drive capability
+			2 = Medium high drive capability
 			3 = High drive capability
 
 		*It will take into account the rev of the silicon and use
@@ -1518,8 +1518,8 @@ config STM32H7_RTC_LSECLOCK_START_DRV_CAPABILITY
 	depends on !STM32H7_RTC_AUTO_LSECLOCK_START_DRV_CAPABILITY
 	---help---
 		0 = Low drive capability (default)
-		1 = Medium high drive capability
-		2 = Medium low drive capability
+		1 = Medium low drive capability
+		2 = Medium high drive capability
 		3 = High drive capability
 
 		It will take into account the rev of the silicon and use
@@ -1534,8 +1534,8 @@ config STM32H7_RTC_LSECLOCK_RUN_DRV_CAPABILITY
 	depends on !STM32H7_RTC_AUTO_LSECLOCK_START_DRV_CAPABILITY
 	---help---
 		0 = Low drive capability (default)
-		1 = Medium high drive capability
-		2 = Medium low drive capability
+		1 = Medium low drive capability
+		2 = Medium high drive capability
 		3 = High drive capability
 
 		It will take into account the rev of the silicon and use


### PR DESCRIPTION
## Summary

This is to stay consistent with upstream, it does not effect any current board the use static config.
  
## Impact

None for PX4

## Testing

