### PR TITLE
[BACKPORT] [FlexCAN] Correct reset state for CTRL1 register

### DIFF
--- a/arch/arm/src/kinetis/kinetis_flexcan.c
+++ b/arch/arm/src/kinetis/kinetis_flexcan.c
@@ -1585,6 +1585,15 @@ static int kinetis_initialize(struct kinetis_driver_s *priv)
       return -1;
     }
 
+  /* Reset CTRL1 register to reset value */
+
+  regval  = getreg32(priv->base + KINETIS_CAN_CTRL1_OFFSET);
+  regval &= ~(CAN_CTRL1_LOM | CAN_CTRL1_LBUF | CAN_CTRL1_TSYN |
+              CAN_CTRL1_BOFFREC | CAN_CTRL1_SMP | CAN_CTRL1_RWRNMSK |
+              CAN_CTRL1_TWRNMSK | CAN_CTRL1_LPB | CAN_CTRL1_ERRMSK |
+              CAN_CTRL1_BOFFMSK);
+  putreg32(regval, priv->base + KINETIS_CAN_CTRL1_OFFSET);
+
 #ifndef CONFIG_NET_CAN_CANFD
   regval  = getreg32(priv->base + KINETIS_CAN_CTRL1_OFFSET);
 

--- a/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
@@ -1587,6 +1587,15 @@ static int s32k1xx_initialize(struct s32k1xx_driver_s *priv)
       return -1;
     }
 
+  /* Reset CTRL1 register to reset value */
+
+  regval  = getreg32(priv->base + S32K1XX_CAN_CTRL1_OFFSET);
+  regval &= ~(CAN_CTRL1_LOM | CAN_CTRL1_LBUF | CAN_CTRL1_TSYN |
+              CAN_CTRL1_BOFFREC | CAN_CTRL1_SMP | CAN_CTRL1_RWRNMSK |
+              CAN_CTRL1_TWRNMSK | CAN_CTRL1_LPB | CAN_CTRL1_ERRMSK |
+              CAN_CTRL1_BOFFMSK);
+  putreg32(regval, priv->base + S32K1XX_CAN_CTRL1_OFFSET);
+
 #ifndef CONFIG_NET_CAN_CANFD
   regval  = getreg32(priv->base + S32K1XX_CAN_CTRL1_OFFSET);
 


### PR DESCRIPTION
Author: Peter van der Perk <peter.vanderperk@nxp.com>
Date:   Tue Mar 16 19:38:39 2021 +0100

[FlexCAN] Correct reset state for CTRL1 register
