### PR TITLE
[BACKPORT] stm32h7 - Fix HEAP clobbering static data in SRAM4

### DIFF
--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -1689,6 +1689,13 @@ config STM32H7_CUSTOM_CLOCKCONFIG
 	---help---
 		Enables special, board-specific STM32 clock configuration.
 
+config STM32H7_SRAM4EXCLUDE
+	bool "Exclude SRAM4 from the heap"
+	default n
+	---help---
+		Exclude SRAM4 from the HEAP in order to use this 64 KB region
+		for other uses, such as DMA buffers, etc.
+
 config STM32H7_DTCMEXCLUDE
 	bool "Exclude DTCM SRAM from the heap"
 	default y if LIBC_ARCH_ELF

--- a/arch/arm/src/stm32h7/stm32_allocateheap.c
+++ b/arch/arm/src/stm32h7/stm32_allocateheap.c
@@ -1,35 +1,20 @@
 /****************************************************************************
  * arch/arm/src/stm32h7/stm32_allocateheap.c
  *
- *   Copyright (C) 2018 Gregory Nutt. All rights reserved.
- *   Author: Gregory Nutt <gnutt@nuttx.org>
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
  *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright
- *    notice, this list of conditions and the following disclaimer in
- *    the documentation and/or other materials provided with the
- *    distribution.
- * 3. Neither the name NuttX nor the names of its contributors may be
- *    used to endorse or promote products derived from this software
- *    without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
- * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
- * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
  *
  ****************************************************************************/
 
@@ -38,8 +23,10 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <nuttx/compiler.h>
 
 #include <sys/types.h>
+#include <inttypes.h>
 #include <stdint.h>
 #include <string.h>
 #include <assert.h>
@@ -121,8 +108,15 @@
 #define SRAM123_START STM32_SRAM123_BASE
 #define SRAM123_END   (SRAM123_START + STM32H7_SRAM123_SIZE)
 
-#define SRAM4_START  STM32_SRAM4_BASE
-#define SRAM4_END    (SRAM4_START + STM32H7_SRAM4_SIZE)
+#undef HAVE_SRAM4
+#if !defined(CONFIG_STM32H7_SRAM4EXCLUDE)
+#  define HAVE_SRAM4 1
+
+#  define SRAM4_START ((uint32_t)(STM32_SRAM4_BASE))
+#  define SRAM4_END   ((uint32_t)(SRAM4_START + STM32H7_SRAM4_SIZE))
+
+#  define SRAM4_HEAP_START ((uint32_t)(&_sram4_heap_start))
+#endif
 
 /* The STM32 H7 has DTCM memory */
 
@@ -136,6 +130,14 @@
 
 #ifdef CONFIG_STM32H7_DTCMEXCLUDE
 #  undef HAVE_DTCM
+#endif
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+#ifdef HAVE_SRAM4
+extern const uint32_t _sram4_heap_start;
 #endif
 
 /****************************************************************************
@@ -314,7 +316,7 @@ static void addregion (uintptr_t start, uint32_t size, const char *desc)
 {
   /* Display memory ranges to help debugging */
 
-  minfo("%uKb of %s at %p\n", size / 1024, desc, (FAR void *)start);
+  minfo("%" PRIu32 "Kb of %s at %p\n", size / 1024, desc, (FAR void *)start);
 
 #if defined(CONFIG_BUILD_PROTECTED) && defined(CONFIG_MM_KERNEL_HEAP)
 
@@ -344,15 +346,23 @@ static void addregion (uintptr_t start, uint32_t size, const char *desc)
 
 void arm_addregion(void)
 {
-  addregion (SRAM123_START, SRAM123_END - SRAM123_START, "SRAM1,2,3");
+  /* At this point there is already one region allocated for "kernel" heap */
 
   unsigned mm_regions = 1;
 
   if (mm_regions < CONFIG_MM_REGIONS)
     {
-      addregion (SRAM4_START, SRAM4_END - SRAM4_START, "SRAM4");
+      addregion (SRAM123_START, SRAM123_END - SRAM123_START, "SRAM1,2,3");
       mm_regions++;
     }
+
+#ifdef HAVE_SRAM4
+  if (mm_regions < CONFIG_MM_REGIONS)
+    {
+      addregion (SRAM4_HEAP_START, SRAM4_END - SRAM4_HEAP_START, "SRAM4");
+      mm_regions++;
+    }
+#endif
 
 #ifdef HAVE_DTCM
   if (mm_regions < CONFIG_MM_REGIONS)

--- a/boards/arm/stm32h7/nucleo-h743zi/scripts/flash.ld
+++ b/boards/arm/stm32h7/nucleo-h743zi/scripts/flash.ld
@@ -185,10 +185,17 @@ SECTIONS
         _ebss = ABSOLUTE(.);
     } > sram
 
-    /* Emit the the D3 power domain section for locating BDMA data */
+    /* Emit the the D3 power domain section for locating BDMA data
+     *
+     * Static data with __attribute__ ((section (".sram4"))) will be located
+     * at start of SRAM4; the rest of SRAM4 will be added to the heap.
+     */
 
-    .sram4 :
+    .sram4_reserve (NOLOAD) :
     {
+        *(.sram4)
+        . = ALIGN(4);
+        _sram4_heap_start = ABSOLUTE(.);
     } > sram4
 
     /* Stabs debugging sections. */

--- a/boards/arm/stm32h7/nucleo-h743zi/scripts/kernel.space.ld
+++ b/boards/arm/stm32h7/nucleo-h743zi/scripts/kernel.space.ld
@@ -94,10 +94,17 @@ SECTIONS
         _ebss = ABSOLUTE(.);
     } > ksram
 
-    /* Emit the the D3 power domain section for locating BDMA data */
+    /* Emit the the D3 power domain section for locating BDMA data
+     *
+     * Static data with __attribute__ ((section (".sram4"))) will be located
+     * at start of SRAM4; the rest of SRAM4 will be added to the heap.
+     */
 
-    .sram4 :
+    .sram4_reserve (NOLOAD) :
     {
+        *(.sram4)
+        . = ALIGN(4);
+        _sram4_heap_start = ABSOLUTE(.);
     } > sram4
 
     /* Stabs debugging sections */

--- a/boards/arm/stm32h7/stm32h747i-disco/scripts/flash.ld
+++ b/boards/arm/stm32h7/stm32h747i-disco/scripts/flash.ld
@@ -183,10 +183,17 @@ SECTIONS
         _ebss = ABSOLUTE(.);
     } > sram
 
-    /* Emit the the D3 power domain section for locating BDMA data */
+    /* Emit the the D3 power domain section for locating BDMA data
+     *
+     * Static data with __attribute__ ((section (".sram4"))) will be located
+     * at start of SRAM4; the rest of SRAM4 will be added to the heap.
+     */
 
-    .sram4 :
+    .sram4_reserve (NOLOAD) :
     {
+        *(.sram4)
+        . = ALIGN(4);
+        _sram4_heap_start = ABSOLUTE(.);
     } > sram4
 
     /* Stabs debugging sections. */

--- a/boards/arm/stm32h7/stm32h747i-disco/scripts/kernel.space.ld
+++ b/boards/arm/stm32h7/stm32h747i-disco/scripts/kernel.space.ld
@@ -94,10 +94,17 @@ SECTIONS
         _ebss = ABSOLUTE(.);
     } > ksram
 
-    /* Emit the the D3 power domain section for locating BDMA data */
+    /* Emit the the D3 power domain section for locating BDMA data
+     *
+     * Static data with __attribute__ ((section (".sram4"))) will be located
+     * at start of SRAM4; the rest of SRAM4 will be added to the heap.
+     */
 
-    .sram4 :
+    .sram4_reserve (NOLOAD) :
     {
+        *(.sram4)
+        . = ALIGN(4);
+        _sram4_heap_start = ABSOLUTE(.);
     } > sram4
 
 


### PR DESCRIPTION
This is a backport of a change in the heap allocation to add remaining SRAM4 to heap.