### PR TITLE
[BACKPORT] binnfmt:Fix return before close ELF fd

### DIFF
--- a/binfmt/elf.c
+++ b/binfmt/elf.c
@@ -235,7 +235,7 @@ static int elf_loadbinary(FAR struct binary_s *binp)
   if (ret != 0)
     {
       berr("Failed to initialize for load of ELF program: %d\n", ret);
-      goto errout;
+      goto errout_with_init;
     }
 
   /* Load the program binary */
@@ -302,7 +302,6 @@ errout_with_load:
   elf_unload(&loadinfo);
 errout_with_init:
   elf_uninit(&loadinfo);
-errout:
   return ret;
 }
 


### PR DESCRIPTION
   elf_init open a elf file , if both enabled
   CONFIG_NSH_BUIlTAPPS and CONFIG_NSH_FILE_APPS ,
   elf_init will read elf file in /bin directory, but
   that length is zero , elf_read failed return and NOT
   close elf fd, so this line MUST be return to errout_with_init

