### PR TITLE
Fix compilation of arm protected build

### DIFF
--- a/arch/arm/src/common/arm_pthread_exit.c
+++ b/arch/arm/src/common/arm_pthread_exit.c
@@ -57,6 +57,10 @@ void up_pthread_exit(pthread_exitroutine_t exit, FAR void *exit_value)
   /* Let sys_call2() do all of the work */
 
   sys_call2(SYS_pthread_exit, (uintptr_t)exit, (uintptr_t)exit_value);
+
+  /* Suppress "'noreturn' function does return" warning */
+
+  while (1);
 }
 
 #endif /* !CONFIG_BUILD_FLAT && __KERNEL__ && !CONFIG_DISABLE_PTHREAD */

--- a/arch/risc-v/src/common/riscv_pthread_exit.c
+++ b/arch/risc-v/src/common/riscv_pthread_exit.c
@@ -55,6 +55,10 @@
 void up_pthread_exit(pthread_exitroutine_t exit, FAR void *exit_value)
 {
   sys_call2(SYS_pthread_exit, (uintptr_t)exit, (uintptr_t)exit_value);
+
+  /* Suppress "'noreturn' function does return" warning */
+
+  while (1);
 }
 
 #endif /* !CONFIG_BUILD_FLAT && __KERNEL__ && !CONFIG_DISABLE_PTHREAD */

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -586,7 +586,7 @@ void up_task_start(main_t taskentry, int argc, FAR char *argv[])
  ****************************************************************************/
 
 void up_pthread_start(pthread_trampoline_t startup,
-                      pthread_startroutine_t entrypt, pthread_addr_t arg);
+                      pthread_startroutine_t entrypt, pthread_addr_t arg)
        noreturn_function;
 
 /****************************************************************************
@@ -605,7 +605,7 @@ void up_pthread_start(pthread_trampoline_t startup,
  *   None
  ****************************************************************************/
 
-void up_pthread_exit(pthread_exitroutine_t exit, FAR void *exit_value);
+void up_pthread_exit(pthread_exitroutine_t exit, FAR void *exit_value)
         noreturn_function;
 #endif
 


### PR DESCRIPTION
This is a backport from nuttx master, commit 1b75b5d5aa8c4924bc118cd3fd294984094857b8

---

Correct typos in include/nuttx/arch.h and suppress
"'noreturn' function does return" warning coming from arm_pthread_exit.c

Signed-off-by: Jukka Laitinen <jukkax@ssrc.tii.ae>



