### PR TITLE
BACKPORT  STM32 F4, F7, H7 USB OTG Device Ensure EP initialized to proper state on usb reset and configure

### DIFF
--- a/arch/arm/src/stm32/stm32_otgfsdev.c
+++ b/arch/arm/src/stm32/stm32_otgfsdev.c
@@ -2090,6 +2090,8 @@ static void stm32_usbreset(struct stm32_usbdev_s *priv)
       /* Reset IN endpoint status */
 
       privep->stalled = false;
+      privep->active  = false;
+      privep->zlp     = false;
 
       /* Return read requests to the class implementation */
 
@@ -2099,6 +2101,8 @@ static void stm32_usbreset(struct stm32_usbdev_s *priv)
       /* Reset endpoint status */
 
       privep->stalled = false;
+      privep->active  = false;
+      privep->zlp     = false;
     }
 
   stm32_putreg(0xffffffff, STM32_OTGFS_DAINT);
@@ -4003,6 +4007,8 @@ static int stm32_epout_configure(FAR struct stm32_ep_s *privep,
       privep->ep.maxpacket = maxpacket;
       privep->eptype       = eptype;
       privep->stalled      = false;
+      privep->active       = false;
+      privep->zlp          = false;
     }
 
   /* Enable the interrupt for this endpoint */
@@ -4101,6 +4107,8 @@ static int stm32_epin_configure(FAR struct stm32_ep_s *privep,
       privep->ep.maxpacket = maxpacket;
       privep->eptype       = eptype;
       privep->stalled      = false;
+      privep->active       = false;
+      privep->zlp          = false;
     }
 
   /* Enable the interrupt for this endpoint */

--- a/arch/arm/src/stm32f7/stm32_otgdev.c
+++ b/arch/arm/src/stm32f7/stm32_otgdev.c
@@ -2121,6 +2121,8 @@ static void stm32_usbreset(struct stm32_usbdev_s *priv)
       /* Reset IN endpoint status */
 
       privep->stalled = false;
+      privep->active  = false;
+      privep->zlp     = false;
 
       /* Return read requests to the class implementation */
 
@@ -2130,6 +2132,8 @@ static void stm32_usbreset(struct stm32_usbdev_s *priv)
       /* Reset endpoint status */
 
       privep->stalled = false;
+      privep->active  = false;
+      privep->zlp     = false;
     }
 
   stm32_putreg(0xffffffff, STM32_OTG_DAINT);
@@ -4017,8 +4021,10 @@ static int stm32_epout_configure(FAR struct stm32_ep_s *privep,
       /* Save the endpoint configuration */
 
       privep->ep.maxpacket = maxpacket;
-      privep->eptype = eptype;
-      privep->stalled = false;
+      privep->eptype       = eptype;
+      privep->stalled      = false;
+      privep->active       = false;
+      privep->zlp          = false;
     }
 
   /* Enable the interrupt for this endpoint */
@@ -4114,8 +4120,10 @@ static int stm32_epin_configure(FAR struct stm32_ep_s *privep,
       /* Save the endpoint configuration */
 
       privep->ep.maxpacket = maxpacket;
-      privep->eptype = eptype;
-      privep->stalled = false;
+      privep->eptype       = eptype;
+      privep->stalled      = false;
+      privep->active       = false;
+      privep->zlp          = false;
     }
 
   /* Enable the interrupt for this endpoint */

--- a/arch/arm/src/stm32h7/stm32_otgdev.c
+++ b/arch/arm/src/stm32h7/stm32_otgdev.c
@@ -2080,6 +2080,8 @@ static void stm32_usbreset(struct stm32_usbdev_s *priv)
       /* Reset IN endpoint status */
 
       privep->stalled = false;
+      privep->active  = false;
+      privep->zlp     = false;
 
       /* Return read requests to the class implementation */
 
@@ -2089,6 +2091,8 @@ static void stm32_usbreset(struct stm32_usbdev_s *priv)
       /* Reset endpoint status */
 
       privep->stalled = false;
+      privep->active  = false;
+      privep->zlp     = false;
     }
 
   stm32_putreg(0xffffffff, STM32_OTG_DAINT);
@@ -3959,6 +3963,8 @@ static int stm32_epout_configure(FAR struct stm32_ep_s *privep,
       privep->ep.maxpacket = maxpacket;
       privep->eptype       = eptype;
       privep->stalled      = false;
+      privep->active       = false;
+      privep->zlp          = false;
     }
 
   /* Enable the interrupt for this endpoint */
@@ -4030,6 +4036,8 @@ static int stm32_epin_configure(FAR struct stm32_ep_s *privep,
       privep->ep.maxpacket = maxpacket;
       privep->eptype       = eptype;
       privep->stalled      = false;
+      privep->active       = false;
+      privep->zlp          = false;
     }
 
   /* Enable the interrupt for this endpoint */


### PR DESCRIPTION
Repeated automated sercon, serdis on VBUS proved to fail
   for CDCACM DATA IN (device Serial TX). The root cause was
   that the EP was left active after disconnect. This resulted
   in the first serial write falling to kick-off the EP IN request.
   That should restart the EP ISR.