### PR TITLE
Added MPU Reset and EARLY MPU RESET

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -859,6 +859,34 @@ config ARM_MPU_NREGIONS
 	---help---
 		This is the number of protection regions supported by the MPU.
 
+config ARM_MPU_RESET
+	bool "MPU Reset before MPU initialization"
+	default n
+	depends on ARM_MPU
+	---help---
+		Configures the MPU initialization sequence to disable the MPU
+		before configuring it.
+
+		This may be needed in a system with a bootloader that has
+		configured the MPU prior to running NuttX. This may be all that is
+		needed to allow booting if the previous MPU configuration allow
+		the system to execute the MPU initialization code. If not use
+		ARM_MPU_EARLY_RESET.
+
+config ARM_MPU_EARLY_RESET
+	bool "MPU Early Reset"
+	default n
+	depends on ARCH_HAVE_MPU
+	---help---
+		Configures the early system initialization sequence to disable the MPU.
+
+		This may be needed in a system with a bootloader that has
+		configured the MPU prior to running NuttX. This is useful if the system
+		faults during bbs, or data initialization or before the
+		stm32_mpuinitialize can be called.
+
+		Note: This can be used without MPU Support enabled.
+
 config ARCH_HAVE_LOWVECTORS
 	bool
 

--- a/arch/arm/src/armv7-m/arm_mpu.c
+++ b/arch/arm/src/armv7-m/arm_mpu.c
@@ -178,6 +178,33 @@ static inline uint32_t mpu_subregion_ls(size_t offset, uint8_t l2size)
 }
 
 /****************************************************************************
+ * Name: mpu_reset_internal
+ *
+ * Description:
+ *   Resets the MPU to disabled.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_MPU_RESET) || defined(CONFIG_ARM_MPU_EARLY_RESET)
+static void mpu_reset_internal()
+{
+  int region;
+  int regions;
+  regions = (getreg32(MPU_TYPE) & MPU_TYPE_DREGION_MASK)
+                                  >> MPU_TYPE_DREGION_SHIFT;
+
+  for (region = 0; region < regions; region++)
+    {
+      putreg32(region, MPU_RNR);
+      putreg32(0, MPU_RASR);
+      putreg32(0, MPU_RBAR);
+    }
+
+  putreg32(0, MPU_CTRL);
+}
+#endif
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -387,3 +414,33 @@ void mpu_configure_region(uintptr_t base, size_t size,
            flags;
   putreg32(regval, MPU_RASR);
 }
+
+/****************************************************************************
+ * Name: mpu_reset
+ *
+ * Description:
+ *   Conditional public interface that resets the MPU to disabled during
+ *   MPU initialization.
+ *
+ ****************************************************************************/
+#if defined(CONFIG_MPU_RESET)
+void mpu_reset()
+{
+  mpu_reset_internal();
+}
+#endif
+
+/****************************************************************************
+ * Name: mpu_early_reset
+ *
+ * Description:
+ *   Conditional public interface that resets the MPU to disabled immediately
+ *   after reset.
+ *
+ ****************************************************************************/
+#if defined(CONFIG_ARM_MPU_EARLY_RESET)
+void mpu_early_reset()
+{
+  mpu_reset_internal();
+}
+#endif

--- a/arch/arm/src/armv7-m/mpu.h
+++ b/arch/arm/src/armv7-m/mpu.h
@@ -132,6 +132,36 @@
 #    define MPU_RASR_AP_RORO    (6 << MPU_RASR_AP_SHIFT)  /* P:RO   U:RO   */
 #  define MPU_RASR_XN           (1 << 28)                 /* Bit 28: Instruction access disable */
 
+/****************************************************************************
+ * Name: mpu_reset
+ *
+ * Description:
+ *   Conditional public interface that resets the MPU to disabled during
+ *   MPU initialization.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_MPU_RESET)
+void mpu_reset(void);
+#else
+#  define mpu_reset() do { } while (0)
+#endif
+
+/****************************************************************************
+ * Name: mpu_early_reset
+ *
+ * Description:
+ *   Conditional public interface that resets the MPU to disabled immediately
+ *   after reset.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_ARM_MPU_EARLY_RESET)
+void mpu_early_reset(void);
+#else
+#  define mpu_early_reset() do { } while (0)
+#endif
+
 #ifdef CONFIG_ARM_MPU
 
 /****************************************************************************

--- a/arch/arm/src/armv7-r/arm_mpu.c
+++ b/arch/arm/src/armv7-r/arm_mpu.c
@@ -178,6 +178,33 @@ static inline uint32_t mpu_subregion_ls(size_t offset, uint8_t l2size)
 }
 
 /****************************************************************************
+ * Name: mpu_reset_internal
+ *
+ * Description:
+ *   Resets the MPU to disabled.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_MPU_RESET) || defined(CONFIG_ARM_MPU_EARLY_RESET)
+static void mpu_reset_internal()
+{
+  int region;
+  int regions;
+  regions = (getreg32(MPU_TYPE) & MPU_TYPE_DREGION_MASK)
+                                  >> MPU_TYPE_DREGION_SHIFT;
+
+  for (region = 0; region < regions; region++)
+    {
+      putreg32(region, MPU_RNR);
+      putreg32(0, MPU_RASR);
+      putreg32(0, MPU_RBAR);
+    }
+
+  putreg32(0, MPU_CTRL);
+}
+#endif
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -300,3 +327,33 @@ uint32_t mpu_subregion(uintptr_t base, size_t size, uint8_t l2size)
   ret |= mpu_subregion_ls(offset, l2size);
   return ret;
 }
+
+/****************************************************************************
+ * Name: mpu_reset
+ *
+ * Description:
+ *   Conditional public interface that resets the MPU to disabled during
+ *   MPU initialization.
+ *
+ ****************************************************************************/
+#if defined(CONFIG_MPU_RESET)
+void mpu_reset()
+{
+  mpu_reset_internal();
+}
+#endif
+
+/****************************************************************************
+ * Name: mpu_early_reset
+ *
+ * Description:
+ *   Conditional public interface that resets the MPU to disabled immediately
+ *   after reset.
+ *
+ ****************************************************************************/
+#if defined(CONFIG_ARM_MPU_EARLY_RESET)
+void mpu_early_reset()
+{
+  mpu_reset_internal();
+}
+#endif

--- a/arch/arm/src/armv7-r/mpu.h
+++ b/arch/arm/src/armv7-r/mpu.h
@@ -121,6 +121,36 @@ extern "C"
 #endif
 
 /****************************************************************************
+ * Name: mpu_reset
+ *
+ * Description:
+ *   Conditional public interface that resets the MPU to disabled during
+ *   MPU initialization.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_MPU_RESET)
+void mpu_reset(void);
+#else
+#  define mpu_reset() do { } while (0)
+#endif
+
+/****************************************************************************
+ * Name: mpu_early_reset
+ *
+ * Description:
+ *   Conditional public interface that resets the MPU to disabled immediately
+ *   after reset.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_ARM_MPU_EARLY_RESET)
+void mpu_early_reset(void);
+#else
+#  define mpu_early_reset() do { } while (0)
+#endif
+
+/****************************************************************************
  * Name: mpu_allocregion
  *
  * Description:

--- a/arch/arm/src/armv8-m/arm_mpu.c
+++ b/arch/arm/src/armv8-m/arm_mpu.c
@@ -178,6 +178,33 @@ static inline uint32_t mpu_subregion_ls(size_t offset, uint8_t l2size)
 }
 
 /****************************************************************************
+ * Name: mpu_reset_internal
+ *
+ * Description:
+ *   Resets the MPU to disabled.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_MPU_RESET) || defined(CONFIG_ARM_MPU_EARLY_RESET)
+static void mpu_reset_internal()
+{
+  int region;
+  int regions;
+  regions = (getreg32(MPU_TYPE) & MPU_TYPE_DREGION_MASK)
+                                  >> MPU_TYPE_DREGION_SHIFT;
+
+  for (region = 0; region < regions; region++)
+    {
+      putreg32(region, MPU_RNR);
+      putreg32(0, MPU_RASR);
+      putreg32(0, MPU_RBAR);
+    }
+
+  putreg32(0, MPU_CTRL);
+}
+#endif
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -387,3 +414,33 @@ void mpu_configure_region(uintptr_t base, size_t size,
            flags;
   putreg32(regval, MPU_RASR);
 }
+
+/****************************************************************************
+ * Name: mpu_reset
+ *
+ * Description:
+ *   Conditional public interface that resets the MPU to disabled during
+ *   MPU initialization.
+ *
+ ****************************************************************************/
+#if defined(CONFIG_MPU_RESET)
+void mpu_reset()
+{
+  mpu_reset_internal();
+}
+#endif
+
+/****************************************************************************
+ * Name: mpu_early_reset
+ *
+ * Description:
+ *   Conditional public interface that resets the MPU to disabled immediately
+ *   after reset.
+ *
+ ****************************************************************************/
+#if defined(CONFIG_ARM_MPU_EARLY_RESET)
+void mpu_early_reset()
+{
+  mpu_reset_internal();
+}
+#endif

--- a/arch/arm/src/armv8-m/mpu.h
+++ b/arch/arm/src/armv8-m/mpu.h
@@ -132,6 +132,36 @@
 #    define MPU_RASR_AP_RORO    (6 << MPU_RASR_AP_SHIFT)  /* P:RO   U:RO   */
 #  define MPU_RASR_XN           (1 << 28)                 /* Bit 28: Instruction access disable */
 
+/****************************************************************************
+ * Name: mpu_reset
+ *
+ * Description:
+ *   Conditional public interface that resets the MPU to disabled during
+ *   MPU initialization.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_MPU_RESET)
+void mpu_reset(void);
+#else
+#  define mpu_reset() do { } while (0)
+#endif
+
+/****************************************************************************
+ * Name: mpu_early_reset
+ *
+ * Description:
+ *   Conditional public interface that resets the MPU to disabled immediately
+ *   after reset.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_ARM_MPU_EARLY_RESET)
+void mpu_early_reset(void);
+#else
+#  define mpu_early_reset() do { } while (0)
+#endif
+
 #ifdef CONFIG_ARM_MPU
 
 /****************************************************************************

--- a/arch/arm/src/stm32/Make.defs
+++ b/arch/arm/src/stm32/Make.defs
@@ -53,7 +53,7 @@ ifeq ($(CONFIG_ARCH_RAMVECTORS),y)
 CMN_CSRCS += arm_ramvec_initialize.c arm_ramvec_attach.c
 endif
 
-ifeq ($(CONFIG_ARM_MPU),y)
+ifneq ($(filter y,$(CONFIG_ARM_MPU) $(CONFIG_ARM_MPU_EARLY_RESET)),)
 CMN_CSRCS += arm_mpu.c
 endif
 

--- a/arch/arm/src/stm32/stm32_mpuinit.c
+++ b/arch/arm/src/stm32/stm32_mpuinit.c
@@ -78,6 +78,10 @@ void stm32_mpuinitialize(void)
 
   mpu_showtype();
 
+  /* Reset MPU if enabled */
+
+  mpu_reset();
+
   /* Configure user flash and SRAM space */
 
   mpu_user_flash(USERSPACE->us_textstart,

--- a/arch/arm/src/stm32/stm32_start.c
+++ b/arch/arm/src/stm32/stm32_start.c
@@ -33,6 +33,7 @@
 #include "arm_arch.h"
 #include "arm_internal.h"
 #include "nvic.h"
+#include "mpu.h"
 
 #include "stm32.h"
 #include "stm32_gpio.h"
@@ -216,6 +217,10 @@ void __start(void)
   __asm__ volatile("sub r10, sp, %0" : :
                    "r"(CONFIG_IDLETHREAD_STACKSIZE - 64) :);
 #endif
+
+  /* If enabled reset the MPU */
+
+  mpu_early_reset();
 
   /* Configure the UART so that we can get debug output as soon as possible */
 

--- a/arch/arm/src/stm32f7/Make.defs
+++ b/arch/arm/src/stm32f7/Make.defs
@@ -67,7 +67,7 @@ ifeq ($(CONFIG_ARMV7M_ITMSYSLOG),y)
 CMN_CSRCS += arm_itm_syslog.c
 endif
 
-ifeq ($(CONFIG_ARM_MPU),y)
+ifneq ($(filter y,$(CONFIG_ARM_MPU) $(CONFIG_ARM_MPU_EARLY_RESET)),)
 CMN_CSRCS += arm_mpu.c
 endif
 

--- a/arch/arm/src/stm32f7/stm32_mpuinit.c
+++ b/arch/arm/src/stm32f7/stm32_mpuinit.c
@@ -70,6 +70,10 @@ void stm32_mpuinitialize(void)
 
   mpu_showtype();
 
+  /* Reset MPU if enabled */
+
+  mpu_reset();
+
   /* Configure user flash space */
 
   mpu_user_flash(USERSPACE->us_textstart,

--- a/arch/arm/src/stm32f7/stm32_start.c
+++ b/arch/arm/src/stm32f7/stm32_start.c
@@ -35,6 +35,7 @@
 #include "arm_arch.h"
 #include "arm_internal.h"
 #include "nvic.h"
+#include "mpu.h"
 #include "barriers.h"
 
 #include "stm32_rcc.h"
@@ -260,6 +261,10 @@ void __start(void)
   __asm__ volatile("sub r10, sp, %0" : :
                    "r"(CONFIG_IDLETHREAD_STACKSIZE - 64) :);
 #endif
+
+  /* If enabled reset the MPU */
+
+  mpu_early_reset();
 
   /* Clear .bss.  We'll do this inline (vs. calling memset) just to be
    * certain that there are no issues with the state of global variables.

--- a/arch/arm/src/stm32h7/Make.defs
+++ b/arch/arm/src/stm32h7/Make.defs
@@ -66,7 +66,7 @@ ifeq ($(CONFIG_STM32H7_PROGMEM),y)
 CMN_CSRCS += stm32_flash.c
 endif
 
-ifeq ($(CONFIG_ARM_MPU),y)
+ifneq ($(filter y,$(CONFIG_ARM_MPU) $(CONFIG_ARM_MPU_EARLY_RESET)),)
 CMN_CSRCS += arm_mpu.c
 endif
 

--- a/arch/arm/src/stm32h7/stm32_mpuinit.c
+++ b/arch/arm/src/stm32h7/stm32_mpuinit.c
@@ -70,6 +70,10 @@ void stm32_mpuinitialize(void)
 
   mpu_showtype();
 
+  /* Reset MPU if enabled */
+
+  mpu_reset();
+
   /* Configure user flash and SRAM space */
 
   mpu_user_flash(USERSPACE->us_textstart,

--- a/arch/arm/src/stm32h7/stm32_start.c
+++ b/arch/arm/src/stm32h7/stm32_start.c
@@ -36,6 +36,7 @@
 #include "arm_internal.h"
 #include "barriers.h"
 #include "nvic.h"
+#include "mpu.h"
 
 #include "stm32_rcc.h"
 #include "stm32_userspace.h"
@@ -276,7 +277,11 @@ void __start(void)
                    "r"(CONFIG_IDLETHREAD_STACKSIZE - 64) :);
 #endif
 
-  /* Clear .bss.  We'll do this inline (vs. calling memset) just to be
+  /* If enabled reset the MPU */
+
+  mpu_early_reset();
+
+/* Clear .bss.  We'll do this inline (vs. calling memset) just to be
    * certain that there are no issues with the state of global variables.
    */
 


### PR DESCRIPTION
## Summary

   When NuttX is booted from a foreign (non NuttX)
   bootloader. There as a possibility that the
   bootloader configured the MPU, in an
   incompatible way for the NuttX memory usage.

   The option to reset the MPU before it is initialized
   may not succeed if the bss and data initialization
   code violated the previous MPU configurations.

   Added herein are ARM_MPU_RESET and
   ARM_MPU_EARLY_RESET. The former can be used
   If the system is capable of booting and running
   NuttX MPU configuration code without an MPU
   violation. The latter is used if the system can
   not run the bss and data initialization code.

   These are options so that a NuttX may be configured to
   not clobber a bootloader MPU configuration in a system
   that is architected to share the MPU configuration task.

## Impact

## Testing

