### PR TITLE
drivers/can: Fix can_poll() POLLOUT calculation

### DIFF
--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -1148,13 +1148,13 @@ static int can_poll(FAR struct file *filep, FAR struct pollfd *fds,
       while (ret < 0);
       dev->cd_ntxwaiters--;
 
-      ndx = dev->cd_xmit.tx_head + 1;
+      ndx = dev->cd_xmit.tx_tail + 1;
       if (ndx >= CONFIG_CAN_FIFOSIZE)
         {
           ndx = 0;
         }
 
-      if (ndx != dev->cd_xmit.tx_tail)
+      if (ndx != dev->cd_xmit.tx_head)
         {
           eventset |= fds->events & POLLOUT;
         }


### PR DESCRIPTION
can_poll() would indicate that there is no space in the TX FIFO if there is
already one element in the FIFO.

https://github.com/apache/incubator-nuttx/pull/4712

Fixed by @ken-voly 