### PR TITLE
Backport usr workqueue fix

### DIFF
--- a/include/nuttx/clock.h
+++ b/include/nuttx/clock.h
@@ -395,6 +395,51 @@ clock_t clock_systime_ticks(void);
 #endif
 
 /****************************************************************************
+ * Name: clock_time2ticks
+ *
+ * Description:
+ *   Return the given struct timespec as systime ticks.
+ *
+ *   NOTE:  This is an internal OS interface and should not be called from
+ *   application code.
+ *
+ * Input Parameters:
+ *   reltime - Pointer to the time presented as struct timespec
+ *
+ * Output Parameters:
+ *   ticks - Pointer to receive the time value presented as systime ticks
+ *
+ * Returned Value:
+ *   Always returns OK (0)
+ *
+ ****************************************************************************/
+
+int clock_time2ticks(FAR const struct timespec *reltime,
+                     FAR sclock_t *ticks);
+
+/****************************************************************************
+ * Name: clock_ticks2time
+ *
+ * Description:
+ *   Return the given systime ticks as a struct timespec.
+ *
+ *   NOTE:  This is an internal OS interface and should not be called from
+ *   application code.
+ *
+ * Input Parameters:
+ *   ticks - Time presented as systime ticks
+ *
+ * Output Parameters:
+ *   reltime - Pointer to receive the time value presented as struct timespec
+ *
+ * Returned Value:
+ *   Always returns OK (0)
+ *
+ ****************************************************************************/
+
+int clock_ticks2time(sclock_t ticks, FAR struct timespec *reltime);
+
+/****************************************************************************
  * Name: clock_systime_timespec
  *
  * Description:

--- a/libs/libc/sched/Make.defs
+++ b/libs/libc/sched/Make.defs
@@ -21,6 +21,8 @@
 # Add the sched C files to the build
 
 CSRCS += sched_getprioritymax.c sched_getprioritymin.c
+CSRCS += clock_ticks2time.c clock_time2ticks.c
+CSRCS += clock_timespec_add.c clock_timespec_subtract.c
 
 ifneq ($(CONFIG_CANCELLATION_POINTS),y)
 CSRCS += task_setcanceltype.c task_testcancel.c

--- a/libs/libc/sched/clock_ticks2time.c
+++ b/libs/libc/sched/clock_ticks2time.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * sched/clock/clock_ticks2time.c
+ * libs/libc/sched/clock_ticks2time.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -25,7 +25,7 @@
 #include <nuttx/config.h>
 
 #include <time.h>
-#include "clock/clock.h"
+#include <nuttx/clock.h>
 
 /****************************************************************************
  * Public Functions

--- a/libs/libc/sched/clock_time2ticks.c
+++ b/libs/libc/sched/clock_time2ticks.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * sched/clock/clock_time2ticks.c
+ * libs/libc/sched/clock_time2ticks.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -28,7 +28,7 @@
 #include <time.h>
 #include <assert.h>
 
-#include "clock/clock.h"
+#include <nuttx/clock.h>
 
 /****************************************************************************
  * Public Functions

--- a/libs/libc/sched/clock_timespec_add.c
+++ b/libs/libc/sched/clock_timespec_add.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * sched/clock/clock_timespec_subtract.c
+ * libs/libc/sched/clock_timespec_add.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -27,21 +27,20 @@
 #include <stdint.h>
 #include <time.h>
 
-#include "clock/clock.h"
+#include <nuttx/clock.h>
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name:  clock_timespec_subtract
+ * Name:  clock_timespec_add
  *
  * Description:
- *   Subtract timespec ts2 from to1 and return the result in ts3.
- *   Zero is returned if the time difference is negative.
+ *   Add timespec ts1 to to2 and return the result in ts3
  *
  * Input Parameters:
- *   ts1 and ts2: The two timespecs to be subtracted (ts1 - ts2)
+ *   ts1 and ts2: The two timespecs to be added
  *   ts3: The location to return the result (may be ts1 or ts2)
  *
  * Returned Value:
@@ -49,37 +48,19 @@
  *
  ****************************************************************************/
 
-void clock_timespec_subtract(FAR const struct timespec *ts1,
-                             FAR const struct timespec *ts2,
-                             FAR struct timespec *ts3)
+void clock_timespec_add(FAR const struct timespec *ts1,
+                        FAR const struct timespec *ts2,
+                        FAR struct timespec *ts3)
 {
-  time_t sec;
-  long nsec;
+  time_t sec = ts1->tv_sec + ts2->tv_sec;
+  long nsec  = ts1->tv_nsec + ts2->tv_nsec;
 
-  if (ts1->tv_sec < ts2->tv_sec)
+  if (nsec >= NSEC_PER_SEC)
     {
-      sec  = 0;
-      nsec = 0;
-    }
-  else if (ts1->tv_sec == ts2->tv_sec && ts1->tv_nsec <= ts2->tv_nsec)
-    {
-      sec  = 0;
-      nsec = 0;
-    }
-  else
-    {
-      sec = ts1->tv_sec - ts2->tv_sec;
-      if (ts1->tv_nsec < ts2->tv_nsec)
-        {
-          nsec = (ts1->tv_nsec + NSEC_PER_SEC) - ts2->tv_nsec;
-          sec--;
-        }
-      else
-        {
-          nsec = ts1->tv_nsec - ts2->tv_nsec;
-        }
+      nsec -= NSEC_PER_SEC;
+      sec++;
     }
 
-  ts3->tv_sec = sec;
+  ts3->tv_sec  = sec;
   ts3->tv_nsec = nsec;
 }

--- a/libs/libc/sched/clock_timespec_subtract.c
+++ b/libs/libc/sched/clock_timespec_subtract.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * sched/clock/clock_timespec_add.c
+ * libs/libc/sched/clock_timespec_subtract.c
  *
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -27,20 +27,21 @@
 #include <stdint.h>
 #include <time.h>
 
-#include "clock/clock.h"
+#include <nuttx/clock.h>
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name:  clock_timespec_add
+ * Name:  clock_timespec_subtract
  *
  * Description:
- *   Add timespec ts1 to to2 and return the result in ts3
+ *   Subtract timespec ts2 from to1 and return the result in ts3.
+ *   Zero is returned if the time difference is negative.
  *
  * Input Parameters:
- *   ts1 and ts2: The two timespecs to be added
+ *   ts1 and ts2: The two timespecs to be subtracted (ts1 - ts2)
  *   ts3: The location to return the result (may be ts1 or ts2)
  *
  * Returned Value:
@@ -48,19 +49,37 @@
  *
  ****************************************************************************/
 
-void clock_timespec_add(FAR const struct timespec *ts1,
-                        FAR const struct timespec *ts2,
-                        FAR struct timespec *ts3)
+void clock_timespec_subtract(FAR const struct timespec *ts1,
+                             FAR const struct timespec *ts2,
+                             FAR struct timespec *ts3)
 {
-  time_t sec = ts1->tv_sec + ts2->tv_sec;
-  long nsec  = ts1->tv_nsec + ts2->tv_nsec;
+  time_t sec;
+  long nsec;
 
-  if (nsec >= NSEC_PER_SEC)
+  if (ts1->tv_sec < ts2->tv_sec)
     {
-      nsec -= NSEC_PER_SEC;
-      sec++;
+      sec  = 0;
+      nsec = 0;
+    }
+  else if (ts1->tv_sec == ts2->tv_sec && ts1->tv_nsec <= ts2->tv_nsec)
+    {
+      sec  = 0;
+      nsec = 0;
+    }
+  else
+    {
+      sec = ts1->tv_sec - ts2->tv_sec;
+      if (ts1->tv_nsec < ts2->tv_nsec)
+        {
+          nsec = (ts1->tv_nsec + NSEC_PER_SEC) - ts2->tv_nsec;
+          sec--;
+        }
+      else
+        {
+          nsec = ts1->tv_nsec - ts2->tv_nsec;
+        }
     }
 
-  ts3->tv_sec  = sec;
+  ts3->tv_sec = sec;
   ts3->tv_nsec = nsec;
 }

--- a/libs/libc/wqueue/work_usrthread.c
+++ b/libs/libc/wqueue/work_usrthread.c
@@ -265,17 +265,18 @@ void work_process(FAR struct usr_wqueue_s *wqueue)
     }
   else
     {
+      struct timespec now;
+      struct timespec delay;
       struct timespec rqtp;
-      time_t sec;
 
       /* Wait awhile to check the work list.  We will wait here until
        * either the time elapses or until we are awakened by a signal.
        * Interrupts will be re-enabled while we wait.
        */
 
-      sec          = next / 1000000;
-      rqtp.tv_sec  = sec;
-      rqtp.tv_nsec = (next - (sec * 1000000)) * 1000;
+      clock_gettime(CLOCK_REALTIME, &now);
+      clock_ticks2time(next, &delay);
+      clock_timespec_add(&now, &delay, &rqtp);
 
       sigtimedwait(&sigset, NULL, &rqtp);
     }

--- a/sched/clock/Make.defs
+++ b/sched/clock/Make.defs
@@ -19,9 +19,9 @@
 ############################################################################
 
 CSRCS += clock_initialize.c clock_settime.c clock_gettime.c clock_getres.c
-CSRCS += clock_time2ticks.c clock_abstime2ticks.c clock_ticks2time.c
-CSRCS += clock_systime_ticks.c clock_systime_timespec.c clock_timespec_add.c
-CSRCS += clock_timespec_subtract.c clock.c
+CSRCS += clock_abstime2ticks.c
+CSRCS += clock_systime_ticks.c clock_systime_timespec.c
+CSRCS += clock.c
 
 ifeq ($(CONFIG_CLOCK_TIMEKEEPING),y)
 CSRCS += clock_timekeeping.c

--- a/sched/clock/clock.h
+++ b/sched/clock/clock.h
@@ -84,8 +84,5 @@ void weak_function clock_timer(void);
 int  clock_abstime2ticks(clockid_t clockid,
                          FAR const struct timespec *abstime,
                          FAR sclock_t *ticks);
-int  clock_time2ticks(FAR const struct timespec *reltime,
-                      FAR sclock_t *ticks);
-int  clock_ticks2time(sclock_t ticks, FAR struct timespec *reltime);
 
 #endif /* __SCHED_CLOCK_CLOCK_H */


### PR DESCRIPTION
## Summary

This is a backport from nuttx master, fixing workqueue in protected/kernel builds in user side

## Impact

As long as there is an item in user side workqueue, the queue is busylooping when waiting for the time to schedule the item. This fix allows proper sleep in semaphore while waiting

This doesn't imapact other than CONFIG_BUILD_PROTECTED and CONFIG_BUILD_KERNEL builds, so no impact on any of the existing px4 targets

## Testing

This is tested on Pixhawk 4, on protected build PR. 