### PR TITLE
stm32f7:sdmmc invalidate before and after DMA

### DIFF
--- a/arch/arm/src/stm32f7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32f7/stm32_sdmmc.c
@@ -3115,6 +3115,8 @@ static int stm32_dmarecvsetup(FAR struct sdio_dev_s *dev,
     {
       priv->rxbuffer = buffer;
       priv->rxend    = buffer + buflen;
+      up_invalidate_dcache((uintptr_t)priv->rxbuffer,
+                           (uintptr_t)priv->rxend);
     }
 
   /* Start the DMA */


### PR DESCRIPTION
## Summary

## Impact

## Testing

