### PR TITLE
fs_fat32: Do not dirty the the buffer on non changes

### DIFF
--- a/fs/fat/fs_fat32.c
+++ b/fs/fat/fs_fat32.c
@@ -1408,15 +1408,15 @@ static int fat_sync(FAR struct file *filep)
        * entry: the file size, and the start cluster
        */
 
-      direntry[DIR_ATTRIBUTES] |= FATATTR_ARCHIVE;
+      dircopy[DIR_ATTRIBUTES] |= FATATTR_ARCHIVE;
 
-      DIR_PUTFILESIZE(direntry, ff->ff_size);
-      DIR_PUTFSTCLUSTLO(direntry, ff->ff_startcluster);
-      DIR_PUTFSTCLUSTHI(direntry, ff->ff_startcluster >> 16);
+      DIR_PUTFILESIZE(dircopy, ff->ff_size);
+      DIR_PUTFSTCLUSTLO(dircopy, ff->ff_startcluster);
+      DIR_PUTFSTCLUSTHI(dircopy, ff->ff_startcluster >> 16);
 
       wrttime = fat_systime2fattime();
-      DIR_PUTWRTTIME(direntry, wrttime & 0xffff);
-      DIR_PUTWRTDATE(direntry, wrttime >> 16);
+      DIR_PUTWRTTIME(dircopy, wrttime & 0xffff);
+      DIR_PUTWRTDATE(dircopy, wrttime >> 16);
 
       /* Clear the modified bit in the flags */
 
@@ -1426,6 +1426,7 @@ static int fat_sync(FAR struct file *filep)
 
       if (memcmp(direntry, dircopy, DIR_SIZE) != 0)
         {
+          memcpy(direntry, dircopy, DIR_SIZE);
           fs->fs_dirty = true;
         }
 


### PR DESCRIPTION
## Summary

This the root cause of the seek error. The d-cache is dirty-ed by the in-place Directory information update into `fs_buffer`. However if the the directory information is the same it will not be written out. This leaves the dirty cache lines in the buffer. On the next read of the FAT Sector, if eviction happens the dirty lines will overwrite the data in the DMA buffer. 

## Impact

seek fails on the FAT FS. because the in memory copy of the FAT is corrupted.

## Testing

16 threads of `tests dataman` on PX4

