### PR TITLE
Px4 firmware nuttx 10.1.0+ nuttx bp otgid cdcacm termios

### DIFF
--- a/arch/arm/src/stm32/Kconfig
+++ b/arch/arm/src/stm32/Kconfig
@@ -10626,6 +10626,19 @@ endmenu
 
 comment "USB Device Configuration"
 
+menu "OTG Configuration"
+	depends on STM32_OTGFS
+
+config OTG_ID_GPIO_DISABLE
+	bool "Disable the use of GPIO_OTG_ID pin."
+	default n
+	---help---
+		Disables/Enables the use of GPIO_OTG_ID pin. This allows non OTG use
+		cases to reuse this GPIO pin and ensure it is not set incorrectlty
+		during OS boot.
+
+endmenu
+
 config STM32_USB_ITRMP
 	bool "Re-map USB interrupt"
 	default n if !STM32_CAN1

--- a/arch/arm/src/stm32/stm32_otgfsdev.c
+++ b/arch/arm/src/stm32/stm32_otgfsdev.c
@@ -5623,7 +5623,11 @@ void arm_usbinitialize(void)
 
   stm32_configgpio(GPIO_OTGFS_DM);
   stm32_configgpio(GPIO_OTGFS_DP);
-  stm32_configgpio(GPIO_OTGFS_ID);    /* Only needed for OTG */
+
+  /* Only needed for OTG */
+#ifndef CONFIG_OTG_ID_GPIO_DISABLE
+  stm32_configgpio(GPIO_OTGFS_ID);
+#endif
 
   /* SOF output pin configuration is configurable. */
 

--- a/drivers/usbdev/cdcacm.c
+++ b/drivers/usbdev/cdcacm.c
@@ -2342,7 +2342,11 @@ static int cdcuart_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         termiosp->c_iflag = serdev->tc_iflag;
         termiosp->c_oflag = serdev->tc_oflag;
         termiosp->c_lflag = serdev->tc_lflag;
-        termiosp->c_cflag = CS8;
+        termiosp->c_cflag =
+            ((priv->linecoding.parity != CDC_PARITY_NONE) ? PARENB : 0) |
+            ((priv->linecoding.parity == CDC_PARITY_ODD) ? PARODD : 0) |
+            ((priv->linecoding.stop == CDC_CHFMT_STOP2) ? CSTOPB : 0) |
+            CS8;
 
 #ifdef CONFIG_CDCACM_OFLOWCONTROL
         /* Report state of output flow control */
@@ -2354,6 +2358,10 @@ static int cdcuart_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
         termiosp->c_cflag |= (priv->iflow) ? CRTS_IFLOW : 0;
 #endif
+      cfsetispeed(termiosp, (speed_t) priv->linecoding.baud[3] << 24 |
+                            (speed_t) priv->linecoding.baud[2] << 16 |
+                            (speed_t) priv->linecoding.baud[1] << 8  |
+                            (speed_t) priv->linecoding.baud[0]);
       }
       break;
 


### PR DESCRIPTION
## Summary

Added OTGID disable to stm32
Completed cdcacm termios to return baudrate and line coding

## Impact

## Testing

