### PR TITLE
[DIVERGED] sem_holder:Bug fix:Not restoring base priority

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -605,6 +605,7 @@ struct tcb_s
 
 #ifdef CONFIG_PRIORITY_INHERITANCE
 #if CONFIG_SEM_NNESTPRIO > 0
+  uint8_t  nsem_held;               /* used to condition priority restore */
   uint8_t  npend_reprio;             /* Number of nested reprioritizations  */
   uint8_t  pend_reprios[CONFIG_SEM_NNESTPRIO];
 #endif

--- a/libs/libc/pthread/pthread_barrierinit.c
+++ b/libs/libc/pthread/pthread_barrierinit.c
@@ -82,6 +82,7 @@ int pthread_barrier_init(FAR pthread_barrier_t *barrier,
   else
     {
       sem_init(&barrier->sem, 0, 0);
+      sem_setprotocol(&barrier->sem, SEM_PRIO_NONE);
       barrier->count = count;
     }
 


### PR DESCRIPTION
master:
   With CONFIG_PRIORITY_INHERITANCE set

   Three tasks (name:priority)  A:200, B:210, C:220
   A takes semaphore.                A:200
     B waits semaphore.              A:210
       C waits semaphore             A:220
            A posts semaphore        A:210 <- it is removed as a holder and
              C takes semaphore      A:210    not resotred.
              C posts semaphore      A:210
                 B takes semaphore   A:210
                 B posts semaphore   A:210

   The solution is to look if the thread holds more then the
   current semaphore S1 being posted. Then if the S1 holder is null
   (holder array) or the holder has no more counts (linked list)
   the posting thread's priority is restored to is base priority
   and the pend_reprios is rest.

   If the thread does hold another semaphore S2, the the pend_reprios
   highest prority is used. When S2 is posted by the thread it will
   be restorted to it's base priority.

sem_holder:TCB needs to track number of sems held

   Priority restoration requiers to keep track of the
   number of unique semaphores that are held by a task.
   This will be used to determine if the removal
   of the holder should revert to the base priority or
   from the pend_reprios array.

## Summary

## Impact

## Testing

