### PR TITLE
BACKPORT fs/cromfs: Fix a hardFault caused by unaligned memory access

### DIFF
--- a/fs/cromfs/cromfs.h
+++ b/fs/cromfs/cromfs.h
@@ -102,7 +102,7 @@ struct cromfs_volume_s
  *                Return 0
  */
 
-struct cromfs_node_s
+begin_packed_struct struct cromfs_node_s
 {
   uint16_t cn_mode;      /* File type, attributes, and access mode bits */
   uint16_t cn_pad;       /* Not used */
@@ -116,6 +116,6 @@ struct cromfs_node_s
     uint32_t cn_link;    /* Offset to an arbitrary node (for hard link) */
     uint32_t cn_blocks;  /* Offset to first block of compressed data (for read) */
   } u;
-};
+} end_packed_struct; /* Use packed access since cromfs nodes may be unaligned */
 
 #endif /* __FS_CROMFS_CROMFS_H */

--- a/tools/gencromfs.c
+++ b/tools/gencromfs.c
@@ -1302,7 +1302,7 @@ int main(int argc, char **argv, char **envp)
   /* Now append the volume header to output file */
 
   fprintf(g_outstream, "/* CROMFS image */\n\n");
-  fprintf(g_outstream, "const uint8_t g_cromfs_image[] =\n");
+  fprintf(g_outstream, "const uint8_t aligned_data(4) g_cromfs_image[] =\n");
   fprintf(g_outstream, "{\n");
   fprintf(g_outstream, "  /* Offset %6lu:  Volume header */\n\n", 0ul);
 


### PR DESCRIPTION
## Summary
This is a backport of [apache/incubator-nuttx/#6347](https://github.com/apache/incubator-nuttx/pull/6347) and [apache/incubator-nuttx/#6350](https://github.com/apache/incubator-nuttx/pull/6350). These two fixes solve a hardFault [bug](https://github.com/PX4/PX4-Autopilot/issues/19491) in cromfs.

## Impact
The fix lets the compiler know that the nodes in nsh_romfsimg might not be word aligned. The rest is taken care off by compiler.

## Testing
This fix is tested with current PX4-Autopilot master branch.
