### PR TITLE
[BACKPORT] stm32f7: fix cache invalidation issue in Ethernet RX

### DIFF
--- a/arch/arm/src/stm32f7/stm32_ethernet.c
+++ b/arch/arm/src/stm32f7/stm32_ethernet.c
@@ -219,8 +219,8 @@
 #  define CONFIG_STM32F7_ETH_NTXDESC 4
 #endif
 
-#ifndef min
-#  define min(a,b) ((a) < (b) ? (a) : (b))
+#ifndef MIN
+#  define MIN(a,b) ((a) < (b) ? (a) : (b))
 #endif
 
 /* We need at least one more free buffer than transmit buffers */
@@ -1742,7 +1742,8 @@ static int stm32_recvframe(struct stm32_ethmac_s *priv)
                    */
 
                   up_invalidate_dcache((uintptr_t)dev->d_buf,
-                                       min(dev->d_len, ALIGNED_BUFSIZE));
+                                       (uintptr_t)dev->d_buf +
+                                       MIN(dev->d_len, ALIGNED_BUFSIZE));
 
                   ninfo("rxhead: %p d_buf: %p d_len: %d\n",
                         priv->rxhead, dev->d_buf, dev->d_len);


### PR DESCRIPTION
Signed-off-by: Petro Karashchenko <petro.karashchenko@gmail.com>

## Summary

## Impact

## Testing

