### PR TITLE
stm32h7: add option to select SMPS/LDO PWR options

### DIFF
--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -785,6 +785,20 @@ config STM32H7_SYSCFG_IOCOMPENSATION
 		The I/O compensation cell can be used only when the supply voltage ranges
 		from 2.4 to 3.6 V
 
+menu "STM32H7 PWR Selection"
+	depends on STM32H7_STM32H7X7XX
+choice STM32H7_PWR_REGULATOR
+	prompt "PWR Regulator"
+	default STM32H7_PWR_REGULATOR_SMPS
+	---help---
+		Select the regulator used to drive the internal voltage rails.
+config STM32H7_PWR_REGULATOR_SMPS
+	bool "SMPS"
+config STM32H7_PWR_REGULATOR_LDO
+	bool "LDO"
+endchoice # STM32H7 PWR Regulator
+endmenu # STM32H7 PWR Selection
+
 menu "OTG_HS Configuration"
 	depends on STM32H7_OTGHS
 

--- a/arch/arm/src/stm32h7/hardware/stm32h7x3xx_pwr.h
+++ b/arch/arm/src/stm32h7/hardware/stm32h7x3xx_pwr.h
@@ -123,7 +123,11 @@
 
 #define STM32_PWR_CR3_BYPASS        (1 << 0)  /* Bit 0: Power management unit bypass */
 #define STM32_PWR_CR3_LDOEN         (1 << 1)  /* Bit 1: Low drop-out regulator enable */
+#if defined(CONFIG_STM32H7_STM32H7X7XX)
+#define STM32_PWR_CR3_SMPSEN        (1 << 2)  /* Bit 2: Switched-mode power supply enable */
+#else
 #define STM32_PWR_CR3_LDOESCUEN     (1 << 2)  /* Bit 2: Supply configuration update enable */
+#endif
                                               /* Bits 3-7: Reserved */
 #define STM32_PWR_CR3_VBE           (1 << 8)  /* Bit 8: VBAT charging enable */
 #define STM32_PWR_CR3_VBRS          (1 << 9)  /* Bit 9: VBAT charging resistor selection */

--- a/arch/arm/src/stm32h7/hardware/stm32h7x3xx_spi.h
+++ b/arch/arm/src/stm32h7/hardware/stm32h7x3xx_spi.h
@@ -27,7 +27,7 @@
 
 #include <nuttx/config.h>
 
-#if defined(CONFIG_STM32H7_STM32H7X3XX)
+#if defined(CONFIG_STM32H7_STM32H7X3XX) || defined(CONFIG_STM32H7_STM32H7X7XX)
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/arch/arm/src/stm32h7/stm32h7x7xx_rcc.c
+++ b/arch/arm/src/stm32h7/stm32h7x7xx_rcc.c
@@ -827,7 +827,15 @@ void stm32_stdclockconfig(void)
        */
 
       regval = getreg32(STM32_PWR_CR3);
-      regval |= STM32_PWR_CR3_LDOEN | STM32_PWR_CR3_LDOESCUEN;
+#if defined(CONFIG_STM32H7_PWR_REGULATOR_LDO)
+      regval |= STM32_PWR_CR3_LDOEN;
+      regval &= ~STM32_PWR_CR3_SMPSEN;
+#elif defined(CONFIG_STM32H7_PWR_REGULATOR_SMPS)
+      regval &= ~STM32_PWR_CR3_LDOEN;
+      regval |= STM32_PWR_CR3_SMPSEN;
+#else
+#     error "No power supply selected"
+#endif
       putreg32(regval, STM32_PWR_CR3);
 
       /* Set the voltage output scale */


### PR DESCRIPTION
Adds support for STM32H757 chip based boards like CubePilot CubeOrange+.