### PR TITLE
Px4 firmware nuttx pr s32k3

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -254,6 +254,7 @@ config ARCH_CHIP_S32K3XX
 	select ARCH_HAVE_MPU
 	select ARCH_HAVE_RAMFUNCS
 	select ARM_HAVE_MPU_UNIFIED
+	select ARCH_HAVE_I2CRESET
 	---help---
 		NPX S32K3XX architectures (ARM Cortex-M7).
 

--- a/arch/arm/src/s32k3xx/Kconfig
+++ b/arch/arm/src/s32k3xx/Kconfig
@@ -193,6 +193,14 @@ config S32K3XX_HAVE_ENET
 	select ARCH_PHY_INTERRUPT
 	select ARCH_HAVE_NETDEV_STATISTICS
 
+# Select MPU when D-cache is enabled for ARM errata 1624041
+
+config S32K3XX_NEEDS_MPU
+    bool
+    default y
+	depends on ARMV7M_DCACHE
+	select ARM_MPU
+
 config S32K3XX_HAVE_FLEXCAN3
 	bool
 	default n

--- a/arch/arm/src/s32k3xx/Kconfig
+++ b/arch/arm/src/s32k3xx/Kconfig
@@ -1209,12 +1209,69 @@ config S32K3XX_LPSPI5_PINCFG
 	
 endmenu # LPSPI Configuration
 
+menu "LPI2C Configuration"
+	depends on S32K3XX_LPI2C
+
+config S32K3XX_LPI2C_DMA
+	bool "I2C DMA Support"
+	default n
+	depends on S32K3XX_LPI2C && S32K3XX_EDMA && !I2C_POLLED
+	---help---
+		This option enables the DMA for I2C transfers.
+		Note: The user can define CONFIG_I2C_DMAPRIO: a custom priority value
+		for the I2C dma streams, else the default priority level is set to
+		medium.
+
+config S32K3XX_LPI2C_DMA_MAXMSG
+	int "Maximum number messages that will be DMAed"
+	default 8
+	depends on S32K3XX_LPI2C_DMA
+	---help---
+		This option set the mumber of mesg that can be in a transfer.
+		It is used to allocate space for the 16 bit LPI2C commands
+		that will be DMA-ed to the LPI2C device.
+
+config S32K3XX_LPI2C_DYNTIMEO
+	bool "Use dynamic timeouts"
+	default n
+	depends on S32K3XX_LPI2C
+
+config S32K3XX_LPI2C_DYNTIMEO_USECPERBYTE
+	int "Timeout Microseconds per Byte"
+	default 500
+	depends on S32K3XX_LPI2C_DYNTIMEO
+
+config S32K3XX_LPI2C_DYNTIMEO_STARTSTOP
+	int "Timeout for Start/Stop (Milliseconds)"
+	default 1000
+	depends on S32K3XX_LPI2C_DYNTIMEO
+
+config S32K3XX_LPI2C_TIMEOSEC
+	int "Timeout seconds"
+	default 0
+	depends on S32K3XX_LPI2C
+
+config S32K3XX_LPI2C_TIMEOMS
+	int "Timeout Milliseconds"
+	default 500
+	depends on S32K3XX_LPI2C && !S32K3XX_LPI2C_DYNTIMEO
+
+config S32K3XX_LPI2C_TIMEOTICKS
+	int "Timeout for Done and Stop (ticks)"
+	default 500
+	depends on S32K3XX_LPI2C && !S32K3XX_LPI2C_DYNTIMEO
+
 menu "LPI2C0 Configuration"
 	depends on S32K3XX_LPI2C0
 
 config LPI2C0_BUSYIDLE
 	int "Bus idle timeout period in clock cycles"
 	default 0
+
+config LPI2C0_DMA
+	bool "Enable DMA for I2C0"
+	default n
+	depends on S32K3XX_LPI2C_DMA
 
 config LPI2C0_FILTSCL
 	int "I2C master digital glitch filters for SCL input in clock cycles"
@@ -1233,6 +1290,11 @@ config LPI2C1_BUSYIDLE
 	int "Bus idle timeout period in clock cycles"
 	default 0
 
+config LPI2C1_DMA
+	bool "Enable DMA for I2C1"
+	default n
+	depends on S32K3XX_LPI2C_DMA
+
 config LPI2C1_FILTSCL
 	int "I2C master digital glitch filters for SCL input in clock cycles"
 	default 0
@@ -1242,7 +1304,7 @@ config LPI2C1_FILTSDA
 	default 0
 
 endmenu # LPI2C1 Configuration
-
+endmenu # LPI2C Configuration
 
 menu "LPUART Configuration"
 	depends on S32K3XX_LPUART

--- a/arch/arm/src/s32k3xx/hardware/s32k3xx_edma.h
+++ b/arch/arm/src/s32k3xx/hardware/s32k3xx_edma.h
@@ -1379,8 +1379,6 @@
 
 struct s32k3xx_edmatcd_s
 {
-  sq_entry_t node;
-  uint8_t    flags;         /* See EDMA_CONFIG_* definitions */
   uint32_t   saddr;         /* Offset: 0x0000  TCD Source Address */
   uint16_t   soff;          /* Offset: 0x0004  TCD Signed Source Address Offset */
   uint16_t   attr;          /* Offset: 0x0006  TCD Transfer Attributes */

--- a/arch/arm/src/s32k3xx/s32k3xx_edma.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_edma.c
@@ -1061,8 +1061,8 @@ DMACH_HANDLE s32k3xx_dmach_alloc(uint16_t dmamux, uint8_t dchpri)
 
           /* Make sure that the channel is disabled. */
 
-          putreg8(EDMA_CH_INT, S32K3XX_EDMA_TCD[dmach->chan] +
-                  S32K3XX_EDMA_CH_INT_OFFSET);
+          putreg32(EDMA_CH_INT, S32K3XX_EDMA_TCD[dmach->chan] +
+                   S32K3XX_EDMA_CH_INT_OFFSET);
 
           /* Disable the associated DMAMUX for now */
 
@@ -1129,8 +1129,8 @@ void s32k3xx_dmach_free(DMACH_HANDLE handle)
 
   /* Make sure that the channel is disabled. */
 
-  putreg8(EDMA_CH_INT, S32K3XX_EDMA_TCD[dmach->chan]
-                       + S32K3XX_EDMA_CH_INT_OFFSET);
+  putreg32(EDMA_CH_INT, S32K3XX_EDMA_TCD[dmach->chan] +
+           S32K3XX_EDMA_CH_INT_OFFSET);
 
   /* Disable the associated DMAMUX */
 
@@ -1140,7 +1140,7 @@ void s32k3xx_dmach_free(DMACH_HANDLE handle)
     }
   else
     {
-      putreg8(0, S32K3XX_DMAMUX1_CHCFG(dmach->chan));
+      putreg8(0, S32K3XX_DMAMUX1_CHCFG(dmach->chan - 16));
     }
 }
 
@@ -1598,7 +1598,7 @@ void s32k3xx_dmasample(DMACH_HANDLE handle, struct s32k3xx_dmaregs_s *regs)
     }
   else
     {
-      regs->dmamux   = getreg32(S32K3XX_DMAMUX1_CHCFG(chan)); /* Channel configuration */
+      regs->dmamux   = getreg32(S32K3XX_DMAMUX1_CHCFG(chan - 16)); /* Channel configuration */
     }
 
   spin_unlock_irqrestore(NULL, flags);

--- a/arch/arm/src/s32k3xx/s32k3xx_edma.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_edma.c
@@ -91,21 +91,15 @@
  */
 
 #ifdef CONFIG_ARMV7M_DCACHE
-/* Align to the cache line size which we assume is >= 8 */
-
-#  define EDMA_ALIGN        ARMV7M_DCACHE_LINESIZE
-#  define EDMA_ALIGN_MASK   (EDMA_ALIGN - 1)
-#  define EDMA_ALIGN_UP(n)  (((n) + EDMA_ALIGN_MASK) & ~EDMA_ALIGN_MASK)
-
+#  define EDMA_ALIGN  ARMV7M_DCACHE_LINESIZE
 #else
-/* Special alignment is not required in this case,
- * but we will align to 8-bytes
- */
+/* 32 byte alignment for TCDs is required for scatter gather */
 
-#  define EDMA_ALIGN        8
-#  define EDMA_ALIGN_MASK   7
-#  define EDMA_ALIGN_UP(n)  (((n) + 7) & ~7)
+#define EDMA_ALIGN        32
 #endif
+
+#define EDMA_ALIGN_MASK   (EDMA_ALIGN - 1)
+#define EDMA_ALIGN_UP(n)  (((n) + EDMA_ALIGN_MASK) & ~EDMA_ALIGN_MASK)
 
 /****************************************************************************
  * Private Types
@@ -127,7 +121,6 @@ struct s32k3xx_dmach_s
   uint8_t chan;                   /* DMA channel number (0-S32K3XX_EDMA_NCHANNELS) */
   bool inuse;                     /* true: The DMA channel is in use */
   uint8_t dmamux;                 /* The DMAMUX channel selection */
-  uint8_t ttype;                  /* Transfer type: M2M, M2P, P2M, or P2P */
   uint8_t state;                  /* Channel state.  See enum s32k3xx_dmastate_e */
   uint32_t flags;                 /* DMA channel flags */
   edma_callback_t callback;       /* Callback invoked when the DMA completes */
@@ -217,193 +210,193 @@ static struct s32k3xx_edmatcd_s g_tcd_pool[CONFIG_S32K3XX_EDMA_NTCD]
 
 const struct peripheral_clock_config_s edma_clockconfig[] =
 {
-#if CONFIG_S32K3XX_EDMA_NTCD > 0
+#if S32K3XX_EDMA_NCHANNELS > 0
   {
     .clkname = EDMA_TCD0_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 1
+#if S32K3XX_EDMA_NCHANNELS > 1
   {
     .clkname = EDMA_TCD1_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 2
+#if S32K3XX_EDMA_NCHANNELS > 2
   {
     .clkname = EDMA_TCD2_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 3
+#if S32K3XX_EDMA_NCHANNELS > 3
   {
     .clkname = EDMA_TCD3_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 4
+#if S32K3XX_EDMA_NCHANNELS > 4
   {
     .clkname = EDMA_TCD4_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 5
+#if S32K3XX_EDMA_NCHANNELS > 5
   {
     .clkname = EDMA_TCD5_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 6
+#if S32K3XX_EDMA_NCHANNELS > 6
   {
     .clkname = EDMA_TCD6_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 7
+#if S32K3XX_EDMA_NCHANNELS > 7
   {
     .clkname = EDMA_TCD7_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 8
+#if S32K3XX_EDMA_NCHANNELS > 8
   {
     .clkname = EDMA_TCD8_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 9
+#if S32K3XX_EDMA_NCHANNELS > 9
   {
     .clkname = EDMA_TCD9_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 10
+#if S32K3XX_EDMA_NCHANNELS > 10
   {
     .clkname = EDMA_TCD10_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 11
+#if S32K3XX_EDMA_NCHANNELS > 11
   {
     .clkname = EDMA_TCD11_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 12
+#if S32K3XX_EDMA_NCHANNELS > 12
   {
     .clkname = EDMA_TCD12_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 13
+#if S32K3XX_EDMA_NCHANNELS > 13
   {
     .clkname = EDMA_TCD13_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 14
+#if S32K3XX_EDMA_NCHANNELS > 14
   {
     .clkname = EDMA_TCD14_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 15
+#if S32K3XX_EDMA_NCHANNELS > 15
   {
     .clkname = EDMA_TCD15_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 16
+#if S32K3XX_EDMA_NCHANNELS > 16
   {
     .clkname = EDMA_TCD16_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 17
+#if S32K3XX_EDMA_NCHANNELS > 17
   {
     .clkname = EDMA_TCD17_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 18
+#if S32K3XX_EDMA_NCHANNELS > 18
   {
     .clkname = EDMA_TCD18_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 19
+#if S32K3XX_EDMA_NCHANNELS > 19
   {
     .clkname = EDMA_TCD19_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 20
+#if S32K3XX_EDMA_NCHANNELS > 20
   {
     .clkname = EDMA_TCD20_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 21
+#if S32K3XX_EDMA_NCHANNELS > 21
   {
     .clkname = EDMA_TCD21_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 22
+#if S32K3XX_EDMA_NCHANNELS > 22
   {
     .clkname = EDMA_TCD22_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 23
+#if S32K3XX_EDMA_NCHANNELS > 23
   {
     .clkname = EDMA_TCD23_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 24
+#if S32K3XX_EDMA_NCHANNELS > 24
   {
     .clkname = EDMA_TCD24_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 25
+#if S32K3XX_EDMA_NCHANNELS > 25
   {
     .clkname = EDMA_TCD25_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 26
+#if S32K3XX_EDMA_NCHANNELS > 26
   {
     .clkname = EDMA_TCD26_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 27
+#if S32K3XX_EDMA_NCHANNELS > 27
   {
     .clkname = EDMA_TCD27_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 28
+#if S32K3XX_EDMA_NCHANNELS > 28
   {
     .clkname = EDMA_TCD28_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 29
+#if S32K3XX_EDMA_NCHANNELS > 29
   {
     .clkname = EDMA_TCD29_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 30
+#if S32K3XX_EDMA_NCHANNELS > 30
   {
     .clkname = EDMA_TCD30_CLK,
     .clkgate = true,
   },
 #endif
-#if CONFIG_S32K3XX_EDMA_NTCD > 31
+#if S32K3XX_EDMA_NCHANNELS > 31
   {
     .clkname = EDMA_TCD31_CLK,
     .clkgate = true,
@@ -576,18 +569,13 @@ static inline void s32k3xx_tcd_chanlink(uint8_t flags,
 
   if (linkch == NULL || flags == EDMA_CONFIG_LINKTYPE_LINKNONE)
     {
-#if 0 /* Already done */
       /* No link or no link channel provided */
 
       /* Disable minor links */
 
-      tcd->citer &= ~EDMA_TCD_CITER_ELINK;
-      tcd->biter &= ~EDMA_TCD_BITER_ELINK;
-
       /* Disable major link */
 
       tcd->csr   &= ~EDMA_TCD_CSR_MAJORELINK;
-#endif
     }
   else if (flags == EDMA_CONFIG_LINKTYPE_MINORLINK) /* Minor link config */
     {
@@ -605,7 +593,7 @@ static inline void s32k3xx_tcd_chanlink(uint8_t flags,
 
       regval16    = tcd->biter;
       regval16   &= ~EDMA_TCD_BITER_LINKCH_MASK;
-      regval16   |= EDMA_TCD_CITER_LINKCH(linkch->chan);
+      regval16   |= EDMA_TCD_BITER_LINKCH(linkch->chan);
       tcd->biter  = regval16;
     }
   else /* if (flags == EDMA_CONFIG_LINKTYPE_MAJORLINK)  Major link config */
@@ -638,7 +626,6 @@ static inline void s32k3xx_tcd_chanlink(uint8_t flags,
 static inline void s32k3xx_tcd_configure(struct s32k3xx_edmatcd_s *tcd,
                             const struct s32k3xx_edma_xfrconfig_s *config)
 {
-  tcd->flags    = config->flags;
   tcd->saddr    = config->saddr;
   tcd->soff     = config->soff;
   tcd->attr     = EDMA_TCD_ATTR_SSIZE(config->ssize) |  /* Transfer Attributes */
@@ -648,16 +635,16 @@ static inline void s32k3xx_tcd_configure(struct s32k3xx_edmatcd_s *tcd,
                    EDMA_TCD_ATTR_DMOD(config->dmod);
 #endif
   tcd->nbytes   = config->nbytes;
-  tcd->slast    = config->flags & EDMA_CONFIG_LOOPSRC ?  -config->iter : 0;
+  tcd->slast    = config->flags & EDMA_CONFIG_LOOPSRC ? -config->iter : 0;
   tcd->daddr    = config->daddr;
   tcd->doff     = config->doff;
   tcd->citer    = config->iter & EDMA_TCD_CITER_MASK;
   tcd->biter    = config->iter & EDMA_TCD_BITER_MASK;
-  tcd->csr      = config->flags & EDMA_CONFIG_LOOPDEST ?
+  tcd->csr      = config->flags & EDMA_CONFIG_LOOP_MASK ?
                                   0 : EDMA_TCD_CSR_DREQ;
-  tcd->csr      |= config->flags & EDMA_CONFIG_INTHALF ?
+  tcd->csr     |= config->flags & EDMA_CONFIG_INTHALF ?
                                   EDMA_TCD_CSR_INTHALF : 0;
-  tcd->dlastsga = config->flags & EDMA_CONFIG_LOOPDEST ?  -config->iter : 0;
+  tcd->dlastsga = config->flags & EDMA_CONFIG_LOOPDEST ? -config->iter : 0;
 
   /* And special case flags */
 
@@ -686,6 +673,10 @@ static void s32k3xx_tcd_instantiate(struct s32k3xx_dmach_s *dmach,
 
   /* Push tcd into hardware TCD register */
 
+  /* Clear DONE bit first, otherwise ESG cannot be set */
+
+  putreg16(0,             base + S32K3XX_EDMA_TCD_CSR_OFFSET);
+
   putreg32(tcd->saddr,    base + S32K3XX_EDMA_TCD_SADDR_OFFSET);
   putreg16(tcd->soff,     base + S32K3XX_EDMA_TCD_SOFF_OFFSET);
   putreg16(tcd->attr,     base + S32K3XX_EDMA_TCD_ATTR_OFFSET);
@@ -696,9 +687,6 @@ static void s32k3xx_tcd_instantiate(struct s32k3xx_dmach_s *dmach,
   putreg16(tcd->citer,    base + S32K3XX_EDMA_TCD_CITER_OFFSET);
   putreg32(tcd->dlastsga, base + S32K3XX_EDMA_TCD_DLAST_SGA_OFFSET);
 
-  /* Clear DONE bit first, otherwise ESG cannot be set */
-
-  putreg16(0,             base + S32K3XX_EDMA_TCD_CSR_OFFSET);
   putreg16(tcd->csr,      base + S32K3XX_EDMA_TCD_CSR_OFFSET);
 
   putreg16(tcd->biter,    base + S32K3XX_EDMA_TCD_BITER_OFFSET);
@@ -725,23 +713,7 @@ static void s32k3xx_dmaterminate(struct s32k3xx_dmach_s *dmach, int result)
 
   /* Disable channel IRQ requests */
 
-  putreg8(EDMA_CH_INT, S32K3XX_EDMA_TCD[chan] + S32K3XX_EDMA_CH_INT_OFFSET);
-
-  /* Check for an Rx (memory-to-peripheral/memory-to-memory) DMA transfer */
-
-  if (dmach->ttype == EDMA_MEM2MEM || dmach->ttype == EDMA_PERIPH2MEM)
-    {
-      /* Invalidate the cache to force reloads from memory. */
-
-#warning Missing logic
-    }
-
-  /* Perform the DMA complete callback */
-
-  if (dmach->callback)
-    {
-      dmach->callback((DMACH_HANDLE)dmach, dmach->arg, true, result);
-    }
+  putreg32(EDMA_CH_INT, S32K3XX_EDMA_TCD[chan] + S32K3XX_EDMA_CH_INT_OFFSET);
 
   /* Clear CSR to disable channel. Because if the given channel started,
    * transfer CSR will be not zero. Because if it is the last transfer, DREQ
@@ -749,6 +721,8 @@ static void s32k3xx_dmaterminate(struct s32k3xx_dmach_s *dmach, int result)
    */
 
   putreg32(0, S32K3XX_EDMA_TCD[chan] + S32K3XX_EDMA_CH_CSR_OFFSET);
+
+  putreg16(0, S32K3XX_EDMA_TCD[chan] + S32K3XX_EDMA_TCD_CSR_OFFSET);
 
   /* Cancel next TCD transfer. */
 
@@ -763,7 +737,7 @@ static void s32k3xx_dmaterminate(struct s32k3xx_dmach_s *dmach, int result)
        * if not continue to free tcds in chain
        */
 
-       next = tcd->flags & EDMA_CONFIG_LOOPDEST ?
+       next = dmach->flags & EDMA_CONFIG_LOOPDEST ?
               NULL : (struct s32k3xx_edmatcd_s *)tcd->dlastsga;
 
        s32k3xx_tcd_free(tcd);
@@ -772,6 +746,13 @@ static void s32k3xx_dmaterminate(struct s32k3xx_dmach_s *dmach, int result)
   dmach->head = NULL;
   dmach->tail = NULL;
 #endif
+
+  /* Perform the DMA complete callback */
+
+  if (dmach->callback)
+    {
+      dmach->callback((DMACH_HANDLE)dmach, dmach->arg, true, result);
+    }
 
   dmach->callback = NULL;
   dmach->arg      = NULL;
@@ -799,8 +780,8 @@ static int s32k3xx_edma_interrupt(int irq, void *context, void *arg)
 {
   struct s32k3xx_dmach_s *dmach;
 
-  uintptr_t regaddr;
   uint32_t  regval32;
+  uint32_t  errval32;
   uint8_t   chan;
   int       result;
 
@@ -811,6 +792,29 @@ static int s32k3xx_edma_interrupt(int irq, void *context, void *arg)
 
   chan  = dmach->chan;
   DEBUGASSERT(chan < S32K3XX_EDMA_NCHANNELS && dmach == &g_edma.dmach[chan]);
+
+  /* Get the eDMA Error Status register value. */
+
+  errval32  = getreg32(S32K3XX_EDMA_TCD[chan] +
+                      S32K3XX_EDMA_CH_ES_OFFSET);
+
+  if (errval32 & EDMA_CH_ES_ERR)
+    {
+      DEBUGASSERT(dmach->state == S32K3XX_DMA_ACTIVE);
+
+      /* Clear the error */
+
+      putreg32(EDMA_CH_ES_ERR, S32K3XX_EDMA_TCD[chan] +
+                      S32K3XX_EDMA_CH_ES_OFFSET);
+
+      /* Clear the pending eDMA channel interrupt */
+
+      putreg32(EDMA_CH_INT, S32K3XX_EDMA_TCD[chan] +
+               S32K3XX_EDMA_CH_INT_OFFSET);
+
+      s32k3xx_dmaterminate(dmach, -EIO);
+      return OK;
+    }
 
   /* Check for an eDMA pending interrupt on this channel */
 
@@ -825,35 +829,34 @@ static int s32k3xx_edma_interrupt(int irq, void *context, void *arg)
 
       /* Clear the pending eDMA channel interrupt */
 
-      putreg8(EDMA_CH_INT, S32K3XX_EDMA_TCD[chan] +
-              S32K3XX_EDMA_CH_INT_OFFSET);
+      putreg32(EDMA_CH_INT, S32K3XX_EDMA_TCD[chan] +
+               S32K3XX_EDMA_CH_INT_OFFSET);
 
       /* Get the eDMA TCD Control and Status register value. */
 
-      regaddr  = getreg32(S32K3XX_EDMA_TCD[chan] +
+      regval32  = getreg32(S32K3XX_EDMA_TCD[chan] +
                           S32K3XX_EDMA_CH_CSR_OFFSET);
 
       /* Check if transfer has finished. */
 
-      if ((regaddr & EDMA_CH_CSR_DONE) != 0)
+      if ((regval32 & EDMA_CH_CSR_DONE) != 0)
         {
           /* Clear the pending DONE interrupt status. */
 
-          regaddr &= ~EDMA_CH_CSR_DONE;
-          putreg32(regaddr, S32K3XX_EDMA_TCD[chan] +
+          regval32 |= EDMA_CH_CSR_DONE;
+          putreg32(regval32, S32K3XX_EDMA_TCD[chan] +
                    S32K3XX_EDMA_CH_CSR_OFFSET);
           result = OK;
         }
       else
-
         {
 #if CONFIG_S32K3XX_EDMA_NTCD > 0
-          /* Perform the end-of-major-cycle DMA callback */
+          /* Perform the half or end-of-major-cycle DMA callback */
 
           if (dmach->callback != NULL)
             {
               dmach->callback((DMACH_HANDLE)dmach, dmach->arg,
-                              false, 0);
+                              false, OK);
             }
 
           return OK;
@@ -867,7 +870,15 @@ static int s32k3xx_edma_interrupt(int irq, void *context, void *arg)
 
       /* Terminate the transfer when it is done. */
 
-      s32k3xx_dmaterminate(dmach, result);
+      if ((dmach->flags & EDMA_CONFIG_LOOP_MASK) == 0)
+        {
+          s32k3xx_dmaterminate(dmach, result);
+        }
+      else if (dmach->callback != NULL)
+        {
+          dmach->callback((DMACH_HANDLE)dmach, dmach->arg,
+                          true, result);
+        }
     }
 
   return OK;
@@ -967,11 +978,20 @@ void weak_function arm_dma_initialize(void)
 
   /* Disable all DMA channel interrupts at the eDMA controller */
 
-  for (i = 0; i < CONFIG_S32K3XX_EDMA_NTCD; i++)
+  for (i = 0; i < S32K3XX_EDMA_NCHANNELS; i++)
     {
       /* Disable all DMA channels and DMA channel interrupts */
 
       putreg32(0, S32K3XX_EDMA_TCD[i] + S32K3XX_EDMA_CH_CSR_OFFSET);
+
+      /* Set all TCD CSR, biter and citer entries to 0 so that
+       * will be 0 when DONE is not set so that s32k3xx_dmach_getcount
+       * reports 0.
+       */
+
+      putreg16(0, S32K3XX_EDMA_TCD[i] + S32K3XX_EDMA_TCD_CSR_OFFSET);
+      putreg16(0, S32K3XX_EDMA_TCD[i] + S32K3XX_EDMA_TCD_CITER_OFFSET);
+      putreg16(0, S32K3XX_EDMA_TCD[i] + S32K3XX_EDMA_TCD_BITER_OFFSET);
     }
 
   /* Clear all pending DMA channel interrupts */
@@ -982,7 +1002,7 @@ void weak_function arm_dma_initialize(void)
    * controller).
    */
 
-  for (i = 0; i < CONFIG_S32K3XX_EDMA_NTCD; i++)
+  for (i = 0; i < S32K3XX_EDMA_NCHANNELS; i++)
     {
       up_enable_irq(S32K3XX_IRQ_DMA_CH0 + i);
     }
@@ -1177,11 +1197,17 @@ int s32k3xx_dmach_xfrsetup(DMACH_HANDLE *handle,
 #if CONFIG_S32K3XX_EDMA_NTCD > 0
   struct s32k3xx_edmatcd_s *tcd;
   struct s32k3xx_edmatcd_s *prev;
+  uint16_t mask = config->flags & EDMA_CONFIG_INTMAJOR ? 0 :
+                                  EDMA_TCD_CSR_INTMAJOR;
+#else
+  uint32_t regval32;
 #endif
   uint16_t regval16;
 
   DEBUGASSERT(dmach != NULL);
   dmainfo("dmach%u: %p config: %p\n", dmach->chan, dmach, config);
+
+  dmach->flags  = config->flags;
 
 #if CONFIG_S32K3XX_EDMA_NTCD > 0
   /* Scatter/gather DMA is supported */
@@ -1202,27 +1228,6 @@ int s32k3xx_dmach_xfrsetup(DMACH_HANDLE *handle,
 
   tcd->csr |= EDMA_TCD_CSR_INTMAJOR;
 
-  /* Is looped to it's self? */
-
-  if (config->flags & EDMA_CONFIG_LOOP_MASK)
-    {
-      /* Enable major link */
-
-      tcd->csr |= EDMA_TCD_CSR_MAJORELINK;
-
-      /* Set major linked channel back to this one */
-
-      tcd->csr   &= ~EDMA_TCD_CSR_MAJORLINKCH_MASK;
-      tcd->csr   |=  EDMA_TCD_CSR_MAJORLINKCH(dmach->chan);
-    }
-
-#ifdef CONFIG_S32K3XX_EDMA_BWC
-  if (config->bwc > 0)
-    {
-      tcd->csr   |= config->bwc;
-    }
-#endif
-
   /* Is this the first descriptor in the list? */
 
   if (dmach->head == NULL)
@@ -1231,7 +1236,6 @@ int s32k3xx_dmach_xfrsetup(DMACH_HANDLE *handle,
 
       dmach->head  = tcd;
       dmach->tail  = tcd;
-      dmach->ttype = config->ttype;
 
       /* And instantiate the first TCD in the DMA channel TCD registers. */
 
@@ -1239,12 +1243,9 @@ int s32k3xx_dmach_xfrsetup(DMACH_HANDLE *handle,
     }
   else
     {
-      /* Cannot mix transfer types (only because of cache-related operations.
-       * this restriction could be removed with some effort).
-       */
+      /* Cannot mix transfer types */
 
-      if (dmach->ttype != config->ttype ||
-          dmach->flags & EDMA_CONFIG_LOOPDEST)
+      if (dmach->flags & EDMA_CONFIG_LOOP_MASK)
         {
           s32k3xx_tcd_free(tcd);
           return -EINVAL;
@@ -1256,7 +1257,7 @@ int s32k3xx_dmach_xfrsetup(DMACH_HANDLE *handle,
 
       prev           = dmach->tail;
       regval16       = prev->csr;
-      regval16      &= ~EDMA_TCD_CSR_DREQ;
+      regval16      &= ~(EDMA_TCD_CSR_DREQ | mask);
       regval16      |= EDMA_TCD_CSR_ESG;
       prev->csr      = regval16;
 
@@ -1278,11 +1279,11 @@ int s32k3xx_dmach_xfrsetup(DMACH_HANDLE *handle,
           /* Enable scatter/gather also in the TCD registers. */
 
           regval16  = getreg16(S32K3XX_EDMA_TCD[dmach->chan]
-                               + S32K3XX_EDMA_CH_CSR_OFFSET);
-          regval16 &= ~EDMA_TCD_CSR_DREQ;
+                               + S32K3XX_EDMA_TCD_CSR_OFFSET);
+          regval16 &= ~(EDMA_TCD_CSR_DREQ | mask);
           regval16 |= EDMA_TCD_CSR_ESG;
           putreg16(regval16, S32K3XX_EDMA_TCD[dmach->chan]
-                   + S32K3XX_EDMA_CH_CSR_OFFSET);
+                   + S32K3XX_EDMA_TCD_CSR_OFFSET);
 
           putreg32((uint32_t)tcd, S32K3XX_EDMA_TCD[dmach->chan]
                    + S32K3XX_EDMA_TCD_DLAST_SGA_OFFSET);
@@ -1300,55 +1301,26 @@ int s32k3xx_dmach_xfrsetup(DMACH_HANDLE *handle,
    * non-zero.
    */
 
-  regval16  = getreg16(S32K3XX_EDMA_TCD[dmach->chan]
+  regval32  = getreg32(S32K3XX_EDMA_TCD[dmach->chan]
                                + S32K3XX_EDMA_CH_CSR_OFFSET);
 
-  if (regval16 != 0 && (regval16 & EDMA_CH_CSR_DONE) == 0)
+  if (regval32 != 0 && (regval32 & EDMA_CH_CSR_DONE) == 0)
     {
       return -EBUSY;
     }
 
   /* Configure channel TCD registers to the values specified in config. */
 
-  /* s32k3xx_tcd_configure((struct s32k3xx_edmatcd_s *)
-   *                    S32K3XX_EDMA_TCD_BASE(dmach->chan), config);
-   */
+  s32k3xx_tcd_configure((struct s32k3xx_edmatcd_s *)
+                        S32K3XX_EDMA_TCD[dmach->chan] +
+                        S32K3XX_EDMA_TCD_SADDR_OFFSET, config);
 
   /* Enable the DONE interrupt when the major iteration count completes. */
 
   modifyreg16(S32K3XX_EDMA_TCD[dmach->chan]
-                   + S32K3XX_EDMA_CH_CSR_OFFSET, 0,
+                   + S32K3XX_EDMA_TCD_CSR_OFFSET, 0,
               EDMA_TCD_CSR_INTMAJOR);
 #endif
-
-  /* Check for an Rx (memory-to-peripheral/memory-to-memory) DMA transfer */
-
-  if (dmach->ttype == EDMA_MEM2MEM || dmach->ttype == EDMA_PERIPH2MEM)
-    {
-      /* Invalidate caches associated with the destination DMA memory.
-       * REVISIT:  nbytes is the number of bytes transferred on each
-       * minor loop.  The following is only valid when the major loop
-       * is one.
-       */
-
-      up_invalidate_dcache((uintptr_t)config->daddr,
-                           (uintptr_t)config->daddr + config->nbytes);
-    }
-
-  /* Check for an Tx (peripheral-to-memory/memory-to-memory) DMA transfer */
-
-  if (dmach->ttype == EDMA_MEM2MEM || dmach->ttype == EDMA_MEM2PERIPH)
-    {
-      /* Clean caches associated with the source DMA memory.
-       * REVISIT:  nbytes is the number of bytes transferred on each
-       * minor loop.  The following is only valid when the major loop
-       * is one.
-       */
-#warning Missing logic
-
-      up_clean_dcache((uintptr_t)config->saddr,
-                      (uintptr_t)config->saddr + config->nbytes);
-    }
 
   /* Set the DMAMUX source and enable and optional trigger */
 
@@ -1374,8 +1346,8 @@ int s32k3xx_dmach_xfrsetup(DMACH_HANDLE *handle,
  *
  *   At the conclusion of each major DMA loop, a callback to the user
  *   provided function is made:  |For "normal" DMAs, this will correspond to
- *   the DMA DONE interrupt; for scatter gather DMAs, multiple interrupts
- *   will be generated with the final being the DONE interrupt.
+ *   the DMA DONE interrupt; for scatter gather DMAs,
+ *   this will be generated with the final TCD.
  *
  *   At the conclusion of the DMA, the DMA channel is reset, all TCDs are
  *   freed, and the callback function is called with the the success/fail
@@ -1426,18 +1398,9 @@ int s32k3xx_dmach_start(DMACH_HANDLE handle, edma_callback_t callback,
     {
       dmach->state    = S32K3XX_DMA_ACTIVE;
 
-      /* Enable channel ERROR interrupts */
-
-#if 0
-      regval8         = EDMA_SEEI(chan);
-      putreg8(regval8, S32K3XX_EDMA_SEEI);
-
-      /* Enable the DMA request for this channel */
-
-#endif
       regval         = getreg32(S32K3XX_EDMA_TCD[chan]
                        + S32K3XX_EDMA_CH_CSR_OFFSET);
-      regval        |= EDMA_CH_CSR_ERQ;
+      regval        |= EDMA_CH_CSR_ERQ | EDMA_CH_CSR_EEI;
       putreg32(regval, S32K3XX_EDMA_TCD[chan] + S32K3XX_EDMA_CH_CSR_OFFSET);
     }
 
@@ -1512,17 +1475,17 @@ unsigned int s32k3xx_dmach_getcount(DMACH_HANDLE *handle)
 {
   struct s32k3xx_dmach_s *dmach = (struct s32k3xx_dmach_s *)handle;
   unsigned int remaining = 0;
-  uintptr_t regaddr;
+  uintptr_t regval32;
   uint16_t regval16;
 
   DEBUGASSERT(dmach != NULL);
 
   /* If the DMA is done, then the remaining count is zero */
 
-  regaddr  = getreg32(S32K3XX_EDMA_TCD[dmach->chan]
+  regval32  = getreg32(S32K3XX_EDMA_TCD[dmach->chan]
              + S32K3XX_EDMA_CH_CSR_OFFSET);
 
-  if ((regaddr & EDMA_CH_CSR_DONE) == 0)
+  if ((regval32 & EDMA_CH_CSR_DONE) == 0)
     {
       /* Calculate the unfinished bytes */
 

--- a/arch/arm/src/s32k3xx/s32k3xx_edma.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_edma.c
@@ -153,6 +153,12 @@ struct s32k3xx_edma_s
   struct s32k3xx_dmach_s dmach[S32K3XX_EDMA_NCHANNELS];
 };
 
+#ifdef CONFIG_S32K3XX_DTCM_HEAP
+extern uint8_t DTCM_BASE_ADDR[];
+extern uint8_t DTCM_END_ADDR[];
+#define DTCM_BACKDOOR_OFFSET 0x1000000
+#endif
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -645,6 +651,22 @@ static inline void s32k3xx_tcd_configure(struct s32k3xx_edmatcd_s *tcd,
   tcd->csr     |= config->flags & EDMA_CONFIG_INTHALF ?
                                   EDMA_TCD_CSR_INTHALF : 0;
   tcd->dlastsga = config->flags & EDMA_CONFIG_LOOPDEST ? -config->iter : 0;
+
+#ifdef CONFIG_S32K3XX_DTCM_HEAP
+  /* Remap address to backdoor address for eDMA */
+
+  if (tcd->saddr >= (uint32_t)DTCM_BASE_ADDR
+      && tcd->saddr < (uint32_t)DTCM_END_ADDR)
+    {
+        tcd->saddr += DTCM_BACKDOOR_OFFSET;
+    }
+
+  if (tcd->daddr >= (uint32_t)DTCM_BASE_ADDR
+      && tcd->daddr < (uint32_t)DTCM_END_ADDR)
+    {
+        tcd->daddr += DTCM_BACKDOOR_OFFSET;
+    }
+#endif
 
   /* And special case flags */
 

--- a/arch/arm/src/s32k3xx/s32k3xx_edma.h
+++ b/arch/arm/src/s32k3xx/s32k3xx_edma.h
@@ -130,7 +130,11 @@
 #  define EDMA_CONFIG_LOOPSRC            (1 << EDMA_CONFIG_LOOP_SHIFT) /* Source looping */
 #  define EDMA_CONFIG_LOOPDEST           (2 << EDMA_CONFIG_LOOP_SHIFT) /* Dest looping */
 
-#define EDMA_CONFIG_INTHALF              (1 << 3) /* Bits 3: Int on HALF */
+#define EDMA_CONFIG_INTHALF              (1 << 4) /* Bits 4: Int on HALF */
+#define EDMA_CONFIG_INTMAJOR             (1 << 5) /* Bits 5: Int on all Major completion
+                                                   * Default is only on last completion
+                                                   * if using scatter gather
+                                                   */
 
 /****************************************************************************
  * Public Types

--- a/arch/arm/src/s32k3xx/s32k3xx_lpi2c.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_lpi2c.c
@@ -45,8 +45,9 @@
 #include <arch/irq.h>
 
 #include "arm_internal.h"
-
+#include "s32k3xx_edma.h"
 #include "s32k3xx_pin.h"
+#include "hardware/s32k3xx_dmamux.h"
 #include "hardware/s32k3xx_pinmux.h"
 #include "hardware/s32k3xx_lpi2c.h"
 #include "s32k3xx_lpi2c.h"
@@ -116,15 +117,11 @@
 #define LPI2C_MASTER    1
 #define LPI2C_SLAVE     2
 
-#define MKI2C_OUTPUT(p) (((p) & GPIO_PADMUX_MASK) | \
-                         IOMUX_OPENDRAIN | IOMUX_DRIVE_33OHM | \
-                         IOMUX_SLEW_SLOW | (5 << GPIO_ALT_SHIFT) | \
-                         IOMUX_PULL_NONE | GPIO_OUTPUT_ONE)
+#define MKI2C_OUTPUT(p) (((p) & (_PIN_PORT_MASK | _PIN_MASK)) | \
+                         GPIO_OUTPUT | GPIO_OUTPUT_ONE)
 
-#define MKI2C_INPUT(p) (((p) & GPIO_PADMUX_MASK) | \
-                        IOMUX_DRIVE_HIZ | IOMUX_SLEW_SLOW | \
-                        IOMUX_CMOS_INPUT | (5 << GPIO_ALT_SHIFT) | \
-                        IOMUX_PULL_NONE)
+#define MKI2C_INPUT(p) (((p) & (_PIN_PORT_MASK | _PIN_MASK)) | \
+                         GPIO_INPUT)
 
 /****************************************************************************
  * Private Types
@@ -178,6 +175,10 @@ struct s32k3xx_lpi2c_config_s
 #ifndef CONFIG_I2C_POLLED
   uint32_t irq;               /* Event IRQ */
 #endif
+#ifdef CONFIG_S32K3XX_LPI2C_DMA
+  uint32_t        dma_rxreqsrc;  /* DMA mux rx source */
+  uint32_t        dma_txreqsrc;  /* DMA mux tx source */
+#endif
 };
 
 /* I2C Device Private Data */
@@ -217,6 +218,11 @@ struct s32k3xx_lpi2c_priv_s
   struct s32k3xx_trace_s trace[CONFIG_I2C_NTRACE];
 #endif
 
+#ifdef CONFIG_S32K3XX_LPI2C_DMA
+  DMACH_HANDLE rxdma;                                  /* rx DMA handle */
+  DMACH_HANDLE txdma;                                  /* tx DMA handle */
+  uint16_t     cmnds[CONFIG_S32K3XX_LPI2C_DMA_MAXMSG]; /* Commands */
+#endif
   uint32_t status;             /* End of transfer SR2|SR1 status */
 };
 
@@ -280,6 +286,13 @@ static int s32k3xx_lpi2c_transfer(struct i2c_master_s *dev,
 static int s32k3xx_lpi2c_reset(struct i2c_master_s *dev);
 #endif
 
+#ifdef CONFIG_S32K3XX_LPI2C_DMA
+static void s32k3xx_rxdma_callback(DMACH_HANDLE handle, void *arg, bool done,
+                                  int result);
+static void s32k3xx_txdma_callback(DMACH_HANDLE handle, void *arg, bool done,
+                                  int result);
+#endif
+
 /****************************************************************************
  * Private Data
  ****************************************************************************/
@@ -329,6 +342,10 @@ static const struct s32k3xx_lpi2c_config_s s32k3xx_lpi2c0_config =
 #ifndef CONFIG_I2C_POLLED
   .irq        = S32K3XX_IRQ_LPI2C0,
 #endif
+#ifdef CONFIG_LPI2C0_DMA
+  .dma_rxreqsrc    = DMA_REQ_LPI2C0_RX,
+  .dma_txreqsrc    = DMA_REQ_LPI2C0_TX,
+#endif
 };
 
 static struct s32k3xx_lpi2c_priv_s s32k3xx_lpi2c0_priv =
@@ -362,6 +379,10 @@ static const struct s32k3xx_lpi2c_config_s s32k3xx_lpi2c1_config =
 #endif
 #ifndef CONFIG_I2C_POLLED
   .irq        = S32K3XX_IRQ_LPI2C1,
+#endif
+#ifdef CONFIG_LPI2C1_DMA
+  .dma_rxreqsrc    = DMA_REQ_LPI2C1_RX,
+  .dma_txreqsrc    = DMA_REQ_LPI2C1_TX,
 #endif
 };
 
@@ -489,13 +510,17 @@ static inline int
 
   flags = enter_critical_section();
 
+#ifdef CONFIG_S32K3XX_LPI2C_DMA
+  if (priv->rxdma == NULL && priv->txdma == NULL)
+    {
+#endif
   /* Enable Interrupts when master mode */
 
   if (priv->config->mode == LPI2C_MASTER)
     {
       if ((priv->flags & I2C_M_READ) != 0)
         {
-          regval = LPI2C_MIER_TDIE | LPI2C_MIER_RDIE | LPI2C_MIER_NDIE | \
+          regval = LPI2C_MIER_TDIE | LPI2C_MIER_RDIE | LPI2C_MIER_NDIE |
                    LPI2C_MIER_ALIE | LPI2C_MIER_SDIE;
           s32k3xx_lpi2c_putreg(priv, S32K3XX_LPI2C_MIER_OFFSET, regval);
         }
@@ -518,7 +543,10 @@ static inline int
    * are currently disabled but will be temporarily re-enabled below when
    * nxsem_tickwait_uninterruptible() sleeps.
    */
+#ifdef CONFIG_S32K3XX_LPI2C_DMA
+    }
 
+#endif
   priv->intstate = INTSTATE_WAITING;
   do
     {
@@ -531,7 +559,6 @@ static inline int
       ret = nxsem_tickwait_uninterruptible(&priv->sem_isr,
                                            CONFIG_S32K3XX_I2CTIMEOTICKS);
 #endif
-
       if (ret < 0)
         {
           /* Break out of the loop on irrecoverable errors.  This would
@@ -572,7 +599,7 @@ static inline int
 }
 #else
 static inline int
-  s32k3xx_lpi2c_sem_waitdone(struct s32k3xx_lpi2c_priv_s *priv)
+s32k3xx_lpi2c_sem_waitdone(struct s32k3xx_lpi2c_priv_s *priv)
 {
   clock_t timeout;
   clock_t start;
@@ -632,7 +659,7 @@ static inline int
  ****************************************************************************/
 
 static inline void
-  s32k3xx_lpi2c_sem_waitstop(struct s32k3xx_lpi2c_priv_s *priv)
+s32k3xx_lpi2c_sem_waitstop(struct s32k3xx_lpi2c_priv_s *priv)
 {
   clock_t start;
   clock_t elapsed;
@@ -765,6 +792,112 @@ static inline void
 }
 
 /****************************************************************************
+ * Name: s32k3xx_rxdma_callback
+ *
+ * Description:
+ *   This function performs the next I2C operation
+ *
+ ****************************************************************************/
+#ifdef CONFIG_S32K3XX_LPI2C_DMA
+static void s32k3xx_rxdma_callback(DMACH_HANDLE handle, void *arg, bool done,
+                              int result)
+{
+  struct s32k3xx_lpi2c_priv_s *priv = (struct s32k3xx_lpi2c_priv_s *)arg;
+
+  s32k3xx_lpi2c_modifyreg(priv, S32K3XX_LPI2C_MIER_OFFSET, 0,
+                              LPI2C_MIER_SDIE);
+
+  if (result != OK)
+    {
+      priv->status = s32k3xx_lpi2c_getstatus(priv);
+
+      if ((priv->status & LPI2C_MSR_ERROR_MASK) != 0)
+        {
+          i2cerr("ERROR: MSR: status: 0x0%" PRIx32 "\n", priv->status);
+
+          s32k3xx_lpi2c_traceevent(priv, I2CEVENT_ERROR, 0);
+
+          /* Clear the TX and RX FIFOs */
+
+          s32k3xx_lpi2c_modifyreg(priv, S32K3XX_LPI2C_MCR_OFFSET, 0,
+                                LPI2C_MCR_RTF | LPI2C_MCR_RRF);
+
+          /* Clear the error */
+
+          s32k3xx_lpi2c_putreg(priv, S32K3XX_LPI2C_MSR_OFFSET,
+                             (priv->status & (LPI2C_MSR_NDF |
+                                              LPI2C_MSR_ALF |
+                                              LPI2C_MSR_FEF |
+                                              LPI2C_MSR_PLTF)));
+
+          if (priv->intstate == INTSTATE_WAITING)
+            {
+              /* inform the thread that transfer is complete
+               * and wake it up
+               */
+
+              priv->intstate = INTSTATE_DONE;
+              nxsem_post(&priv->sem_isr);
+            }
+        }
+    }
+}
+#endif
+
+/****************************************************************************
+ * Name: s32k3xx_txdma_callback
+ *
+ * Description:
+ *   This function performs the next I2C operation
+ *
+ ****************************************************************************/
+#ifdef CONFIG_S32K3XX_LPI2C_DMA
+static void s32k3xx_txdma_callback(DMACH_HANDLE handle, void *arg, bool done,
+                              int result)
+{
+  struct s32k3xx_lpi2c_priv_s *priv = (struct s32k3xx_lpi2c_priv_s *)arg;
+
+  s32k3xx_lpi2c_modifyreg(priv, S32K3XX_LPI2C_MIER_OFFSET, 0,
+                              LPI2C_MIER_SDIE);
+
+  if (result != OK)
+    {
+      priv->status = s32k3xx_lpi2c_getstatus(priv);
+
+      if ((priv->status & LPI2C_MSR_ERROR_MASK) != 0)
+        {
+          i2cerr("ERROR: MSR: status: 0x0%" PRIx32 "\n", priv->status);
+
+          s32k3xx_lpi2c_traceevent(priv, I2CEVENT_ERROR, 0);
+
+          /* Clear the TX and RX FIFOs */
+
+          s32k3xx_lpi2c_modifyreg(priv, S32K3XX_LPI2C_MCR_OFFSET, 0,
+                                LPI2C_MCR_RTF | LPI2C_MCR_RRF);
+
+          /* Clear the error */
+
+          s32k3xx_lpi2c_putreg(priv, S32K3XX_LPI2C_MSR_OFFSET,
+                             (priv->status & (LPI2C_MSR_NDF |
+                                              LPI2C_MSR_ALF |
+                                              LPI2C_MSR_FEF |
+                                              LPI2C_MSR_PLTF)));
+
+          if (priv->intstate == INTSTATE_WAITING)
+            {
+              /* inform the thread that transfer is complete
+               * and wake it up
+               */
+
+              priv->intstate = INTSTATE_DONE;
+              nxsem_post(&priv->sem_isr);
+            }
+        }
+    }
+}
+#endif
+
+/****************************************************************************
  * Name: s32k3xx_lpi2c_trace*
  *
  * Description:
@@ -886,7 +1019,7 @@ static void s32k3xx_lpi2c_tracedump(struct s32k3xx_lpi2c_priv_s *priv)
  * Name: s32k3xx_lpi2c_pckfreq
  *
  * Description:
- *   Get the peripheral clock frequency for the LPSPI peripheral
+ *   Get the peripheral clock frequency for the LPI2C peripheral
  *
  * Input Parameters:
  *   base - The base address of the LPI2C peripheral registers
@@ -1111,6 +1244,20 @@ static inline void s32k3xx_lpi2c_sendstop(struct s32k3xx_lpi2c_priv_s *priv)
 }
 
 /****************************************************************************
+ * Name: s32k3xx_lpi2c_getenabledints
+ *
+ * Description:
+ *   Get 32-bit status
+ *
+ ****************************************************************************/
+
+static inline uint32_t
+s32k3xx_lpi2c_getenabledints(struct s32k3xx_lpi2c_priv_s *priv)
+{
+  return s32k3xx_lpi2c_getreg(priv, S32K3XX_LPI2C_MIER_OFFSET);
+}
+
+/****************************************************************************
  * Name: s32k3xx_lpi2c_getstatus
  *
  * Description:
@@ -1136,11 +1283,93 @@ static int s32k3xx_lpi2c_isr_process(struct s32k3xx_lpi2c_priv_s *priv)
 {
   uint32_t status = s32k3xx_lpi2c_getstatus(priv);
 
+#ifdef CONFIG_S32K3XX_LPI2C_DMA
+  uint32_t current_status = status;
+
+  /* Condition the status with only the enabled interrupts */
+
+  status &= s32k3xx_lpi2c_getenabledints(priv);
+
+  if (priv->rxdma != NULL || priv->txdma != NULL)
+    {
+      /* End of packet or Stop */
+
+      if ((status & (LPI2C_MSR_SDF | LPI2C_MSR_EPF)) != 0)
+        {
+          s32k3xx_lpi2c_traceevent(priv, I2CEVENT_STOP, 0);
+
+          /* Acknowledge End of packet or Stop */
+
+          s32k3xx_lpi2c_putreg(priv, S32K3XX_LPI2C_MSR_OFFSET, status &
+                                                           (LPI2C_MSR_SDF |
+                                                           LPI2C_MSR_EPF));
+        }
+
+      /* Is there an Error condition */
+
+      if (current_status & LPI2C_MSR_ERROR_MASK)
+        {
+          s32k3xx_lpi2c_traceevent(priv, I2CEVENT_ERROR, 0);
+
+          /* Shutdown DMA */
+
+          if (priv->rxdma != NULL)
+            {
+              s32k3xx_dmach_stop(priv->rxdma);
+            }
+
+          if (priv->txdma != NULL)
+            {
+               s32k3xx_dmach_stop(priv->txdma);
+            }
+
+          /* Clear the TX and RX FIFOs */
+
+          s32k3xx_lpi2c_modifyreg(priv, S32K3XX_LPI2C_MCR_OFFSET, 0,
+                                LPI2C_MCR_RTF | LPI2C_MCR_RRF);
+
+          /* Clear the error */
+
+          s32k3xx_lpi2c_putreg(priv, S32K3XX_LPI2C_MSR_OFFSET,
+                            (current_status & (LPI2C_MSR_NDF |
+                                               LPI2C_MSR_ALF |
+                                               LPI2C_MSR_FEF)));
+
+          /* Return the full error status */
+
+          status = current_status;
+        }
+
+      /* Mark that this transaction stopped */
+
+      priv->msgv = NULL;
+      priv->msgc = 0;
+      priv->dcnt = -1;
+
+      if (priv->intstate == INTSTATE_WAITING)
+        {
+          /* Update Status once at the end */
+
+          priv->status = status;
+
+          /* inform the thread that transfer is complete
+           * and wake it up
+           */
+
+          priv->intstate = INTSTATE_DONE;
+          nxsem_post(&priv->sem_isr);
+        }
+
+      return OK;
+    }
+
+#endif
+
   /* Check for new trace setup */
 
   s32k3xx_lpi2c_tracenew(priv, status);
 
-  /* After an error we can get an SDF  */
+  /* After an error we can get a STOP Detect Flag  */
 
   if (priv->intstate == INTSTATE_DONE && (status & LPI2C_MSR_SDF) != 0)
     {
@@ -1213,9 +1442,9 @@ static int s32k3xx_lpi2c_isr_process(struct s32k3xx_lpi2c_priv_s *priv)
     {
       if (priv->msgc > 0 && priv->msgv != NULL)
         {
-          priv->ptr        = priv->msgv->buffer;
-          priv->dcnt    = priv->msgv->length;
-          priv->flags    = priv->msgv->flags;
+          priv->ptr   = priv->msgv->buffer;
+          priv->dcnt  = priv->msgv->length;
+          priv->flags = priv->msgv->flags;
 
           if ((priv->msgv->flags & I2C_M_NOSTART) == 0)
             {
@@ -1279,8 +1508,8 @@ static int s32k3xx_lpi2c_isr_process(struct s32k3xx_lpi2c_priv_s *priv)
                * and wake it up
                */
 
-              nxsem_post(&priv->sem_isr);
               priv->intstate = INTSTATE_DONE;
+              nxsem_post(&priv->sem_isr);
             }
 #else
           priv->status = status;
@@ -1332,8 +1561,8 @@ static int s32k3xx_lpi2c_isr_process(struct s32k3xx_lpi2c_priv_s *priv)
                * and wake it up
                */
 
-              nxsem_post(&priv->sem_isr);
               priv->intstate = INTSTATE_DONE;
+              nxsem_post(&priv->sem_isr);
             }
 #else
           priv->status = status;
@@ -1374,7 +1603,7 @@ static int s32k3xx_lpi2c_init(struct s32k3xx_lpi2c_priv_s *priv)
 {
   /* Power-up and configure GPIOs .
    *
-   * NOTE: Clocking to the LPSPI peripheral must be provided by
+   * NOTE: Clocking to the LPI2C peripheral must be provided by
    * board-specific logic as part of the clock configuration logic.
    */
 
@@ -1406,7 +1635,7 @@ static int s32k3xx_lpi2c_init(struct s32k3xx_lpi2c_priv_s *priv)
   /* Set tx and rx watermarks */
 
   s32k3xx_lpi2c_putreg(priv, S32K3XX_LPI2C_MFCR_OFFSET,
-                     LPI2C_MFCR_TXWATER(0) | LPI2C_MFCR_RXWATER(0));
+                       LPI2C_MFCR_TXWATER(0) | LPI2C_MFCR_RXWATER(0));
 
   /* Force a frequency update */
 
@@ -1416,14 +1645,14 @@ static int s32k3xx_lpi2c_init(struct s32k3xx_lpi2c_priv_s *priv)
   /* Set scl, sda glitch filters and busy idle */
 
   s32k3xx_lpi2c_putreg(priv, S32K3XX_LPI2C_MCFGR2_OFFSET,
-                    LPI2C_MCFGR2_BUSIDLE(priv->config->busy_idle) |
-                    LPI2C_MCFGR2_FILTSCL_CYCLES(priv->config->filtscl) |
-                    LPI2C_MCFGR2_FILTSDA_CYCLES(priv->config->filtsda));
+                       LPI2C_MCFGR2_BUSIDLE(priv->config->busy_idle) |
+                       LPI2C_MCFGR2_FILTSCL_CYCLES(priv->config->filtscl) |
+                       LPI2C_MCFGR2_FILTSDA_CYCLES(priv->config->filtsda));
 
   /* Set pin low cycles to 0 (disable) */
 
   s32k3xx_lpi2c_putreg(priv, S32K3XX_LPI2C_MCFGR3_OFFSET,
-                     LPI2C_MCFGR3_PINLOW_CYCLES(0));
+                       LPI2C_MCFGR3_PINLOW_CYCLES(0));
 
   /* Attach ISRs */
 
@@ -1472,6 +1701,223 @@ static int s32k3xx_lpi2c_deinit(struct s32k3xx_lpi2c_priv_s *priv)
 /****************************************************************************
  * Device Driver Operations
  ****************************************************************************/
+
+/****************************************************************************
+ * Name: s32k3xx_lpi2c_dma_command_configure
+ *
+ * Description:
+ *   Create a command TCD
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_S32K3XX_LPI2C_DMA
+static int
+s32k3xx_lpi2c_dma_command_configure(struct s32k3xx_lpi2c_priv_s
+                                    *priv, uint16_t *ccmd,
+                                     uint32_t ncmd)
+{
+  struct s32k3xx_edma_xfrconfig_s config;
+  memset(&config, 0, sizeof(config));
+
+  config.saddr  = (uint32_t) ccmd;
+  config.daddr  = priv->config->base + S32K3XX_LPI2C_MTDR_OFFSET;
+  config.soff   = sizeof(uint16_t);
+  config.doff   = 0;
+  config.iter   = 1;
+  config.flags  = EDMA_CONFIG_LINKTYPE_LINKNONE;
+  config.ssize  = EDMA_16BIT;
+  config.dsize  = EDMA_16BIT;
+  config.nbytes = sizeof(uint16_t) * ncmd;
+
+  up_clean_dcache((uintptr_t)config.saddr,
+                  (uintptr_t)config.saddr + config.nbytes);
+
+  return s32k3xx_dmach_xfrsetup(priv->txdma, &config);
+}
+#endif
+
+/****************************************************************************
+ * Name: s32k3xx_lpi2c_dma_data_configure
+ *
+ * Description:
+ *   Create a data TCD
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_S32K3XX_LPI2C_DMA
+static int s32k3xx_lpi2c_dma_data_configure(struct s32k3xx_lpi2c_priv_s
+                                              *priv,
+                                              struct i2c_msg_s *msg)
+{
+  DMACH_HANDLE dma;
+  struct s32k3xx_edma_xfrconfig_s config;
+  memset(&config, 0, sizeof(config));
+
+  config.iter   = msg->length;
+  config.flags  = EDMA_CONFIG_LINKTYPE_LINKNONE;
+  config.ssize  = EDMA_8BIT;
+  config.dsize  = EDMA_8BIT;
+  config.nbytes = sizeof(msg->buffer[0]);
+
+  if (msg->flags & I2C_M_READ)
+    {
+      dma           = priv->rxdma;
+      config.saddr  = priv->config->base + S32K3XX_LPI2C_MRDR_OFFSET;
+      config.daddr  = (uint32_t) msg->buffer;
+      config.soff   = 0;
+      config.doff   = sizeof(msg->buffer[0]);
+      up_invalidate_dcache((uintptr_t)msg->buffer,
+                           (uintptr_t)msg->buffer + msg->length);
+    }
+  else
+    {
+      dma           = priv->txdma;
+      config.saddr  = (uint32_t) msg->buffer;
+      config.daddr  = priv->config->base + S32K3XX_LPI2C_MTDR_OFFSET;
+      config.soff   = sizeof(msg->buffer[0]);
+      config.doff   = 0;
+      up_clean_dcache((uintptr_t)msg->buffer,
+                      (uintptr_t)msg->buffer + msg->length);
+    }
+
+  return s32k3xx_dmach_xfrsetup(dma, &config) ? 0 : msg->length;
+}
+#endif
+
+/****************************************************************************
+ * Name: s32k3xx_lpi2c_configure_dma_transfer
+ *
+ * Description:
+ *   DMA based I2C transfer function
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_S32K3XX_LPI2C_DMA
+static int s32k3xx_lpi2c_form_command_list(struct s32k3xx_lpi2c_priv_s
+                                              *priv, struct i2c_msg_s *msg,
+                                              int ncmds)
+{
+  ssize_t length = 0;
+
+  if (priv->flags & I2C_M_NOSTART)
+    {
+      if (priv->flags & I2C_M_READ)
+        {
+          /* No start read operation */
+
+          priv->cmnds[ncmds++] = LPI2C_MTDR_CMD_RXD |
+                                 LPI2C_MTDR_DATA(msg->length - 1);
+        }
+    }
+  else
+    {
+      /* A start based read or write operation */
+
+      /* Create bus address with R/W */
+
+      uint16_t badd = (priv->flags & I2C_M_READ) ? I2C_READADDR8(msg->addr) :
+                                                   I2C_WRITEADDR8(msg->addr);
+
+      priv->cmnds[ncmds++] = LPI2C_MTDR_CMD_START | LPI2C_MTDR_DATA(badd);
+
+      if (badd & I2C_READBIT)
+        {
+          length =  msg->length;
+          while (length)
+            {
+              if (length > 256u)
+                {
+                  priv->cmnds[ncmds++] = LPI2C_MTDR_CMD_RXD |
+                                         LPI2C_MTDR_DATA(256u - 1);
+                  length -= 256u;
+                }
+              else
+                {
+                  priv->cmnds[ncmds++] = LPI2C_MTDR_CMD_RXD |
+                                         LPI2C_MTDR_DATA(length - 1);
+                  length = 0;
+                }
+            }
+        }
+    }
+
+  return ncmds;
+}
+#endif
+
+/****************************************************************************
+ * Name: s32k3xx_lpi2c_dma_transfer
+ *
+ * Description:
+ *   DMA based I2C transfer function
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_S32K3XX_LPI2C_DMA
+static int s32k3xx_lpi2c_dma_transfer(struct s32k3xx_lpi2c_priv_s *priv)
+{
+  int m;
+  int ntotcmds = 0;
+  int ncmds = 0;
+  uint16_t *ccmnd = NULL;
+
+  /* Disable Interrupts */
+
+  s32k3xx_lpi2c_modifyreg(priv, S32K3XX_LPI2C_MIER_OFFSET,
+                            LPI2C_MIER_RDIE | LPI2C_MIER_TDIE, 0);
+
+  /* Disable DMA */
+
+  s32k3xx_lpi2c_modifyreg(priv, S32K3XX_LPI2C_MDER_OFFSET, LPI2C_MDER_TDDE |
+                                                       LPI2C_MDER_RDDE, 0);
+
+  /* Turn off auto_stop option */
+
+  s32k3xx_lpi2c_modifyreg(priv, S32K3XX_LPI2C_MCFGR1_OFFSET, 0,
+                          LPI2C_MCFGR1_IGNACK | LPI2C_MCFGR1_AUTOSTOP);
+
+  /* Form chains of tcd to process the messages */
+
+  for (m = 0; m < priv->msgc; m++)
+    {
+      ncmds = 0;
+      priv->flags = priv->msgv[m].flags;
+
+      /* Form a command list */
+
+      ccmnd = &priv->cmnds[ntotcmds];
+
+      ncmds = s32k3xx_lpi2c_form_command_list(priv, &priv->msgv[m],
+                                              ntotcmds);
+
+      /* Have commands for this message ? */
+
+      if (ncmds != 0)
+        {
+          /* Build up a TCD with the command from this message */
+
+          s32k3xx_lpi2c_dma_command_configure(priv, ccmnd, ncmds - ntotcmds);
+
+          ntotcmds += ncmds;
+
+          DEBUGASSERT(ntotcmds < CONFIG_S32K3XX_LPI2C_DMA_MAXMSG);
+
+          s32k3xx_lpi2c_dma_data_configure(priv, &priv->msgv[m]);
+        }
+    }
+
+  s32k3xx_lpi2c_putreg(priv, S32K3XX_LPI2C_MIER_OFFSET,
+                     LPI2C_MIER_NDIE | LPI2C_MIER_ALIE |
+                     LPI2C_MIER_PLTIE | LPI2C_MIER_FEIE);
+
+  s32k3xx_dmach_start(priv->rxdma, s32k3xx_rxdma_callback, (void *)priv);
+  s32k3xx_dmach_start(priv->txdma, s32k3xx_txdma_callback, (void *)priv);
+
+  s32k3xx_lpi2c_modifyreg(priv, S32K3XX_LPI2C_MDER_OFFSET, 0,
+                          LPI2C_MDER_TDDE | LPI2C_MDER_RDDE);
+  return OK;
+}
+#endif
 
 /****************************************************************************
  * Name: s32k3xx_lpi2c_transfer
@@ -1530,8 +1976,27 @@ static int s32k3xx_lpi2c_transfer(struct i2c_master_s *dev,
    * the BUSY flag.
    */
 
+#ifdef CONFIG_S32K3XX_LPI2C_DMA
+  if (priv->rxdma || priv->txdma)
+    {
+      s32k3xx_lpi2c_dma_transfer(priv);
+    }
+#endif
+
   if (s32k3xx_lpi2c_sem_waitdone(priv) < 0)
     {
+#ifdef CONFIG_S32K3XX_LPI2C_DMA
+      if (priv->rxdma != NULL)
+        {
+          s32k3xx_dmach_stop(priv->rxdma);
+        }
+
+      if (priv->txdma != NULL)
+        {
+          s32k3xx_dmach_stop(priv->txdma);
+        }
+
+#endif
       ret = -ETIMEDOUT;
 
       i2cerr("ERROR: Timed out: MCR: status: 0x%" PRIx32 "\n", priv->status);
@@ -1640,12 +2105,12 @@ static int s32k3xx_lpi2c_reset(struct i2c_master_s *dev)
 
   /* Let SDA go high */
 
-  s32k3xx_gpio_write(sda_gpio, 1);
+  s32k3xx_gpiowrite(sda_gpio, 1);
 
   /* Clock the bus until any slaves currently driving it let it go. */
 
   clock_count = 0;
-  while (!s32k3xx_gpio_read(sda_gpio))
+  while (!s32k3xx_gpioread(sda_gpio))
     {
       /* Give up if we have tried too hard */
 
@@ -1660,7 +2125,7 @@ static int s32k3xx_lpi2c_reset(struct i2c_master_s *dev)
        */
 
       stretch_count = 0;
-      while (!s32k3xx_gpio_read(scl_gpio))
+      while (!s32k3xx_gpioread(scl_gpio))
         {
           /* Give up if we have tried too hard */
 
@@ -1674,12 +2139,12 @@ static int s32k3xx_lpi2c_reset(struct i2c_master_s *dev)
 
       /* Drive SCL low */
 
-      s32k3xx_gpio_write(scl_gpio, 0);
+      s32k3xx_gpiowrite(scl_gpio, 0);
       up_udelay(10);
 
       /* Drive SCL high again */
 
-      s32k3xx_gpio_write(scl_gpio, 1);
+      s32k3xx_gpiowrite(scl_gpio, 1);
       up_udelay(10);
     }
 
@@ -1687,13 +2152,13 @@ static int s32k3xx_lpi2c_reset(struct i2c_master_s *dev)
    * state machines.
    */
 
-  s32k3xx_gpio_write(sda_gpio, 0);
+  s32k3xx_gpiowrite(sda_gpio, 0);
   up_udelay(10);
-  s32k3xx_gpio_write(scl_gpio, 0);
+  s32k3xx_gpiowrite(scl_gpio, 0);
   up_udelay(10);
-  s32k3xx_gpio_write(scl_gpio, 1);
+  s32k3xx_gpiowrite(scl_gpio, 1);
   up_udelay(10);
-  s32k3xx_gpio_write(sda_gpio, 1);
+  s32k3xx_gpiowrite(sda_gpio, 1);
   up_udelay(10);
 
   /* Revert the GPIO configuration. */
@@ -1769,6 +2234,22 @@ struct i2c_master_s *s32k3xx_i2cbus_initialize(int port)
     {
       s32k3xx_lpi2c_sem_init(priv);
       s32k3xx_lpi2c_init(priv);
+
+#ifdef CONFIG_S32K3XX_LPI2C_DMA
+      if (priv->config->dma_txreqsrc != 0)
+        {
+          priv->txdma = s32k3xx_dmach_alloc(priv->config->dma_txreqsrc |
+                                        DMAMUX_CHCFG_ENBL, 0);
+          DEBUGASSERT(priv->txdma != NULL);
+        }
+
+      if (priv->config->dma_rxreqsrc != 0)
+        {
+          priv->rxdma = s32k3xx_dmach_alloc(priv->config->dma_rxreqsrc |
+                                        DMAMUX_CHCFG_ENBL, 0);
+          DEBUGASSERT(priv->rxdma != NULL);
+        }
+#endif
     }
 
   leave_critical_section(flags);
@@ -1809,6 +2290,22 @@ int s32k3xx_i2cbus_uninitialize(struct i2c_master_s *dev)
   leave_critical_section(flags);
 
   /* Disable power and other HW resource (GPIO's) */
+
+#ifdef CONFIG_S32K3XX_LPI2C_DMA
+  if (priv->rxdma != NULL)
+    {
+      s32k3xx_dmach_stop(priv->rxdma);
+      s32k3xx_dmach_free(priv->rxdma);
+      priv->rxdma = NULL;
+    }
+
+  if (priv->txdma != NULL)
+    {
+      s32k3xx_dmach_stop(priv->txdma);
+      s32k3xx_dmach_free(priv->txdma);
+      priv->txdma = NULL;
+    }
+#endif
 
   s32k3xx_lpi2c_deinit(priv);
 

--- a/arch/arm/src/s32k3xx/s32k3xx_lpspi.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_lpspi.c
@@ -1885,11 +1885,11 @@ static void s32k3xx_lpspi_exchange(struct spi_dev_s *dev,
 
   /* Then wait for each to complete */
 
-  ret = spi_dmarxwait(priv);
+  ret = spi_dmatxwait(priv);
 
   if (ret < 0)
     {
-      ret = spi_dmatxwait(priv);
+      ret = spi_dmarxwait(priv);
     }
 
   /* Reset any status */

--- a/arch/arm/src/s32k3xx/s32k3xx_qspi.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_qspi.c
@@ -884,6 +884,7 @@ static int qspi_transmit_blocking(struct s32k3xx_qspidev_s *priv,
   uint32_t count = UINT32_MAX;
   uint32_t *data = (uint32_t *)meminfo->buffer;
   uint32_t write_cycle = min(32, ((uint32_t)remaining) >> 2U);
+  uint32_t timeout = 1000;
   int ret = 0;
 
   /* Copy sequence in LUT registers */
@@ -912,29 +913,32 @@ static int qspi_transmit_blocking(struct s32k3xx_qspidev_s *priv,
 
   putreg32(QSPI_AMBA_BASE + meminfo->addr, S32K3XX_QSPI_SFAR);
 
-  /* Re-attempt filling TX fifo if size doesn't match */
+  /* Clear TX fifo */
 
-  while ((getreg32(S32K3XX_QSPI_TBSR) & QSPI_TBSR_TRBLF_MASK) != count)
+  regval  = getreg32(S32K3XX_QSPI_MCR);
+  regval |= QSPI_MCR_CLR_TXF;
+  putreg32(regval, S32K3XX_QSPI_MCR);
+
+  do /* Wait for fifo clear otherwise timeout */
     {
-      /* Clear TX fifo */
+      timeout--;
+    }
+  while ((getreg32(S32K3XX_QSPI_TBSR) & QSPI_TBSR_TRBLF_MASK) != 0
+          && timeout > 0);
 
-      regval  = getreg32(S32K3XX_QSPI_MCR);
-      regval |= QSPI_MCR_CLR_TXF;
-      putreg32(regval, S32K3XX_QSPI_MCR);
+  if (timeout == 0)
+    {
+      return -ETIMEDOUT;
+    }
 
-      spiinfo("Transmit: %lu size: %lu\n", meminfo->addr, meminfo->buflen);
+  spiinfo("Transmit: %" PRIu32 " size: %" PRIu32 "\n",
+          meminfo->addr, meminfo->buflen);
 
-      for (count = 0U; count < write_cycle; count++)
-        {
-          while ((getreg32(S32K3XX_QSPI_TBSR)
-                & QSPI_TBSR_TRBLF_MASK) != count)
-            {
-            }
-
-          putreg32(*data, S32K3XX_QSPI_TBDR);
-          data++;
-          remaining -= 4U;
-        }
+  for (count = 0U; count < write_cycle; count++)
+    {
+      putreg32(*data, S32K3XX_QSPI_TBDR);
+      data++;
+      remaining -= 4U;
     }
 
   /* Trigger IP command with specified sequence and size */

--- a/arch/arm/src/s32k3xx/s32k3xx_serial.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_serial.c
@@ -2463,7 +2463,10 @@ static int s32k3xx_ioctl(struct file *filep, int cmd, unsigned long arg)
             stat &= ~LPUART_STAT_RXINV;
           }
 
-        if (arg & SER_INVERT_ENABLED_TX)
+        /* Do not invert TX when in TIOCSSINGLEWIRE */
+
+        if ((arg & SER_INVERT_ENABLED_TX) &&
+            ((ctrl & LPUART_CTRL_LOOPS) != LPUART_CTRL_LOOPS))
           {
             ctrl |= LPUART_CTRL_TXINV;
           }

--- a/arch/arm/src/s32k3xx/s32k3xx_start.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_start.c
@@ -36,6 +36,7 @@
 #include <arch/irq.h>
 
 #include "arm_internal.h"
+#include "barriers.h"
 #include "nvic.h"
 
 #ifdef CONFIG_BUILD_PROTECTED
@@ -49,8 +50,8 @@
 #include "s32k3xx_serial.h"
 #include "s32k3xx_swt.h"
 #include "s32k3xx_start.h"
-#if defined(CONFIG_ARCH_USE_MPU) && defined(CONFIG_S32K3XX_ENET)
-#include "hardware/s32k3xx_mpu.h"
+#if defined(CONFIG_ARCH_USE_MPU)
+#include "mpu.h"
 #endif
 
 #ifdef CONFIG_S32K3XX_PROGMEM
@@ -94,6 +95,31 @@
 
 #define STARTUP_ECC_INITVALUE   0
 
+#ifndef CONFIG_ARMV7M_DCACHE
+  /*  With Dcache off:
+   *  Cacheable (MPU_RASR_C) and Bufferable (MPU_RASR_B) needs to be off
+   */
+#  undef  MPU_RASR_B
+#  define MPU_RASR_B    0
+#  define RASR_B_VALUE  0
+#  define RASR_C_VALUE  0
+#else
+#  ifndef CONFIG_ARMV7M_DCACHE_WRITETHROUGH
+  /*  With Dcache on:
+   *  Cacheable (MPU_RASR_C) and Bufferable (MPU_RASR_B) needs to be on
+   */
+#  define RASR_B_VALUE  MPU_RASR_B
+#  define RASR_C_VALUE  MPU_RASR_C
+
+#  else
+  /*  With Dcache in WRITETHROUGH Bufferable (MPU_RASR_B)
+   * needs to be off, except for FLASH for alignment leniency
+   */
+#  define RASR_B_VALUE  0
+#  define RASR_C_VALUE  MPU_RASR_C
+#  endif
+#endif
+
 /****************************************************************************
  * Name: showprogress
  *
@@ -112,12 +138,14 @@
  * Private Types
  ****************************************************************************/
 
-extern const uint32_t SRAM_BASE_ADDR;
-extern const uint32_t SRAM_END_ADDR;
-extern const uint32_t ITCM_BASE_ADDR;
-extern const uint32_t ITCM_END_ADDR;
-extern const uint32_t DTCM_BASE_ADDR;
-extern const uint32_t DTCM_END_ADDR;
+extern uint8_t SRAM_BASE_ADDR[];
+extern uint8_t SRAM_INIT_END_ADDR[];
+extern uint8_t ITCM_BASE_ADDR[];
+extern uint8_t ITCM_END_ADDR[];
+extern uint8_t DTCM_BASE_ADDR[];
+extern uint8_t DTCM_END_ADDR[];
+extern uint8_t FLASH_BASE_ADDR[];
+extern uint8_t FLASH_END_ADDR[];
 
 /****************************************************************************
  * Private Functions
@@ -131,20 +159,95 @@ extern const uint32_t DTCM_END_ADDR;
  *
  ****************************************************************************/
 
-#if defined(CONFIG_ARCH_USE_MPU) && defined(CONFIG_S32K3XX_ENET)
+#if defined(CONFIG_ARCH_USE_MPU)
 static inline void s32k3xx_mpu_config(void)
 {
   uint32_t regval;
+  uint32_t region;
 
-  /* Bus masters 0-2 are already enabled r/w/x in supervisor and user modes
-   * after reset.  Enable also bus master 3 (ENET) in S/U modes in default
-   * region 0:  User=r+w+x, Supervisor=same as used.
-   */
+  /* Show MPU information */
 
-  regval = (MPU_RGDAAC_M3UM_XACCESS | MPU_RGDAAC_M3UM_WACCESS |
-            MPU_RGDAAC_M3UM_RACCESS | MPU_RGDAAC_M3SM_M3UM);
+  mpu_showtype();
 
-  putreg32(regval, S32K3XX_MPU_RGDAAC(0));
+#ifdef CONFIG_ARMV7M_DCACHE
+  /* Memory barrier */
+
+  ARM_DMB();
+#endif
+
+  /* Reset MPU if enabled */
+
+  mpu_reset();
+
+  /* ARM errata 1013783-B Workaround */
+
+  region = mpu_allocregion();
+  DEBUGASSERT(region == 0);
+
+  /* Select the region */
+
+  putreg32(region, MPU_RNR);
+
+  /* Select the region base address */
+
+  putreg32(region | MPU_RBAR_VALID, MPU_RBAR);
+
+  /* The configure the region */
+
+  regval = MPU_RASR_ENABLE        | /* Enable region  */
+           MPU_RASR_SIZE_LOG2(32) | /* entire memory */
+           MPU_RASR_TEX_SO        | /* Strongly ordered */
+           MPU_RASR_AP_RWRW       | /* P:RW   U:RW */
+           MPU_RASR_XN;             /* Execute-never to prevent instruction fetch */
+  putreg32(regval, MPU_RASR);
+
+  mpu_configure_region((uintptr_t)FLASH_BASE_ADDR,
+                     FLASH_END_ADDR - FLASH_BASE_ADDR,
+                     MPU_RASR_TEX_SO   | /* Strongly ordered    */
+                     RASR_C_VALUE      | /* Cacheable          */
+                     MPU_RASR_B        | /* Bufferable
+                                          * Not Shareable      */
+                     MPU_RASR_AP_RORO);  /* P:RO   U:RO
+                                          * Instruction access */
+
+  mpu_configure_region((uintptr_t)SRAM_BASE_ADDR,
+                     SRAM_INIT_END_ADDR - SRAM_BASE_ADDR,
+                     MPU_RASR_TEX_SO   | /* Strongly ordered   */
+                     RASR_C_VALUE      | /* Cacheable          */
+                     RASR_B_VALUE      | /* Bufferable
+                                          * Not Shareable      */
+                     MPU_RASR_AP_RWRW);  /* P:RW   U:RW
+                                          * Instruction access */
+
+  mpu_configure_region((uintptr_t)ITCM_BASE_ADDR,
+                     ITCM_END_ADDR - ITCM_BASE_ADDR,
+                     MPU_RASR_TEX_SO   | /* Strongly ordered   */
+                     RASR_C_VALUE      | /* Cacheable          */
+                     RASR_B_VALUE      | /* Bufferable
+                                          * Not Shareable      */
+                     MPU_RASR_AP_RWRW);  /* P:RW   U:RW
+                                          * Instruction access */
+
+  mpu_configure_region((uintptr_t)DTCM_BASE_ADDR,
+                     DTCM_END_ADDR - DTCM_BASE_ADDR,
+                     MPU_RASR_TEX_SO   | /* Strongly ordered   */
+                     RASR_C_VALUE      | /* Cacheable          */
+                     RASR_B_VALUE      | /* Bufferable
+                                          * Not Shareable      */
+                     MPU_RASR_AP_RWRW);  /* P:RW   U:RW
+                                          * Instruction access */
+
+  mpu_configure_region(0x40000000, 3 * 2048 * 1024,
+                     MPU_RASR_TEX_DEV  | /* Device
+                                          * Not Cacheable
+                                          * Not Bufferable
+                                          * Not Shareable      */
+                     MPU_RASR_AP_RWRW);  /* P:RW   U:RW
+                                          * Instruction access */
+
+  /* Then enable the MPU */
+
+  mpu_control(true, false, true);
 }
 #endif
 
@@ -160,9 +263,6 @@ static inline void s32k3xx_mpu_config(void)
  *
  ****************************************************************************/
 
-#define STR(x) #x
-#define XSTR(s) STR(s)
-
 void s32k3xx_start(void)
 {
   register uint64_t *src;
@@ -173,24 +273,24 @@ void s32k3xx_start(void)
    * then on a cold boot we go into a bootloop somehow
    */
 
-  dest = (uint64_t *)&SRAM_BASE_ADDR;
-  while (dest < (uint64_t *)&SRAM_END_ADDR)
+  dest = (uint64_t *)SRAM_BASE_ADDR;
+  while (dest < (uint64_t *)SRAM_INIT_END_ADDR)
     {
       *dest++ = STARTUP_ECC_INITVALUE;
     }
 
   /* ITCM */
 
-  dest = (uint64_t *)&ITCM_BASE_ADDR;
-  while (dest < (uint64_t *)&ITCM_END_ADDR)
+  dest = (uint64_t *)ITCM_BASE_ADDR;
+  while (dest < (uint64_t *)ITCM_END_ADDR)
     {
       *dest++ = STARTUP_ECC_INITVALUE;
     }
 
   /* DTCM */
 
-  dest = (uint64_t *)&DTCM_BASE_ADDR;
-  while (dest < (uint64_t *)&DTCM_END_ADDR)
+  dest = (uint64_t *)DTCM_BASE_ADDR;
+  while (dest < (uint64_t *)DTCM_END_ADDR)
     {
       *dest++ = STARTUP_ECC_INITVALUE;
     }
@@ -248,20 +348,20 @@ void s32k3xx_start(void)
 
   arm_fpuconfig();
 
+#if defined(CONFIG_ARCH_USE_MPU)
+
+  /* Config MPU regions */
+
+  s32k3xx_mpu_config();
+  showprogress('D');
+#endif
+
   /* Enable I- and D-Caches */
 
   up_enable_icache();
   up_enable_dcache();
 
   showprogress('C');
-
-#if defined(CONFIG_ARCH_USE_MPU) && defined(CONFIG_S32K3XX_ENET)
-
-  /* Enable all MPU bus masters */
-
-  s32k3xx_mpu_config();
-  showprogress('D');
-#endif
 
   /* Perform early serial initialization */
 

--- a/arch/arm/src/s32k3xx/startup.S
+++ b/arch/arm/src/s32k3xx/startup.S
@@ -38,7 +38,7 @@ __start:
 
     /* Initialize SRAM ECC */
     ldr r1, =SRAM_BASE_ADDR
-    ldr r2, =SRAM_END_ADDR
+    ldr r2, =SRAM_INIT_END_ADDR
 
     subs    r2, r1
     subs    r2, #1

--- a/boards/arm/s32k3xx/mr-canhubk3/scripts/flash.ld
+++ b/boards/arm/s32k3xx/mr-canhubk3/scripts/flash.ld
@@ -152,6 +152,7 @@ SECTIONS
   SRAM_END_ADDR          = ORIGIN(sram) + LENGTH(sram);
   SRAM_STDBY_BASE_ADDR   = ORIGIN(sram0_stdby);
   SRAM_STDBY_END_ADDR    = ORIGIN(sram0_stdby) + LENGTH(sram0_stdby);
+  SRAM_INIT_END_ADDR     = ORIGIN(sram) + 320K;
   ITCM_BASE_ADDR         = ORIGIN(itcm);
   ITCM_END_ADDR          = ORIGIN(itcm) + LENGTH(itcm);
   DTCM_BASE_ADDR         = ORIGIN(dtcm);

--- a/boards/arm/s32k3xx/s32k344evb/scripts/flash.ld
+++ b/boards/arm/s32k3xx/s32k344evb/scripts/flash.ld
@@ -149,6 +149,7 @@ SECTIONS
   SRAM_END_ADDR          = ORIGIN(sram) + LENGTH(sram);
   SRAM_STDBY_BASE_ADDR   = ORIGIN(sram0_stdby);
   SRAM_STDBY_END_ADDR    = ORIGIN(sram0_stdby) + LENGTH(sram0_stdby);
+  SRAM_INIT_END_ADDR     = ORIGIN(sram) + 320K;
   ITCM_BASE_ADDR         = ORIGIN(itcm);
   ITCM_END_ADDR          = ORIGIN(itcm) + LENGTH(itcm);
   DTCM_BASE_ADDR         = ORIGIN(dtcm);


### PR DESCRIPTION
## Summary
Backport for S32K3 changes from upstream into PX4 NuttX branch

## Impact
Fixes DMA for LPSPI and LPI2C
MPU protection

## Testing
Tested on PX4 target nxp_mrcanhubk3 
See https://github.com/PX4/PX4-Autopilot/pull/20700

