### PR TITLE
[BACKPORT] S32K automatically calculate size of periphclocks array

### DIFF
--- a/arch/arm/src/s32k1xx/s32k1xx_clockconfig.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_clockconfig.c
@@ -2564,7 +2564,7 @@ int s32k1xx_clockconfig(const struct clock_configuration_s *clkcfg)
 
       /* Set PCC configuration */
 
-      s32k1xx_periphclocks(clkcfg->pcc.count, clkcfg->pcc.pclks);
+      s32k1xx_periphclocks(num_of_peripheral_clocks_0, clkcfg->pcc.pclks);
 
       /* Set SIM configuration */
 

--- a/arch/arm/src/s32k1xx/s32k1xx_clockconfig.h
+++ b/arch/arm/src/s32k1xx/s32k1xx_clockconfig.h
@@ -86,6 +86,8 @@
  * Public Types
  ****************************************************************************/
 
+extern const unsigned int num_of_peripheral_clocks_0;
+
 /* Clock Configuration ******************************************************/
 
 enum scg_system_clock_type_e
@@ -412,7 +414,6 @@ struct sim_clock_config_s
 struct peripheral_clock_config_s;      /* Forward reference */
 struct pcc_config_s
 {
-  unsigned int count;                            /* Number of peripherals to be configured */
   const struct peripheral_clock_config_s *pclks; /* The peripheral clock configuration array */
 };
 

--- a/arch/arm/src/s32k3xx/s32k3xx_clockconfig.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_clockconfig.c
@@ -1053,7 +1053,7 @@ int s32k3xx_clockconfig(const struct clock_configuration_s *clkcfg)
   ret = s32k3xx_cgm_config(&clkcfg->cgm);
   if (ret >= 0)
     {
-        s32k3xx_periphclocks(clkcfg->pcc.count, clkcfg->pcc.pclks);
+        s32k3xx_periphclocks(num_of_peripheral_clocks_0, clkcfg->pcc.pclks);
     }
 
   return 0;

--- a/arch/arm/src/s32k3xx/s32k3xx_clockconfig.h
+++ b/arch/arm/src/s32k3xx/s32k3xx_clockconfig.h
@@ -53,6 +53,8 @@
  * Public Types
  ****************************************************************************/
 
+extern const unsigned int num_of_peripheral_clocks_0;
+
 /* Clock Configuration ******************************************************/
 
 enum cgm_system_clock_type_e

--- a/boards/arm/s32k1xx/rddrone-bms772/src/rddrone-bms772.h
+++ b/boards/arm/s32k1xx/rddrone-bms772/src/rddrone-bms772.h
@@ -77,10 +77,6 @@
 
 #define NUM_OF_GPIO 12
 
-/* Count of peripheral clock user configurations */
-
-#define NUM_OF_PERIPHERAL_CLOCKS_0 12
-
 /****************************************************************************
  * Public Data
  ****************************************************************************/

--- a/boards/arm/s32k1xx/rddrone-bms772/src/s32k1xx_clockconfig.c
+++ b/boards/arm/s32k1xx/rddrone-bms772/src/s32k1xx_clockconfig.c
@@ -163,7 +163,6 @@ const struct clock_configuration_s g_initial_clkconfig =
   },
   .pcc             =
   {
-    .count         = NUM_OF_PERIPHERAL_CLOCKS_0,       /* Number peripheral clock configurations */
     .pclks         = g_peripheral_clockconfig0,        /* Peripheral clock configurations */
   },
   .pmc             =

--- a/boards/arm/s32k1xx/rddrone-bms772/src/s32k1xx_periphclocks.c
+++ b/boards/arm/s32k1xx/rddrone-bms772/src/s32k1xx_periphclocks.c
@@ -123,6 +123,10 @@ const struct peripheral_clock_config_s g_peripheral_clockconfig0[] =
   },
 };
 
+unsigned int const num_of_peripheral_clocks_0 =
+    sizeof(g_peripheral_clockconfig0) /
+    sizeof(g_peripheral_clockconfig0[0]);
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/

--- a/boards/arm/s32k1xx/s32k118evb/src/s32k118evb.h
+++ b/boards/arm/s32k1xx/s32k118evb/src/s32k118evb.h
@@ -64,10 +64,6 @@
 #define GPIO_SW2    (PIN_PTD3  | PIN_INT_BOTH)
 #define GPIO_SW3    (PIN_PTD5  | PIN_INT_BOTH)
 
-/* Count of peripheral clock user configurations */
-
-#define NUM_OF_PERIPHERAL_CLOCKS_0 11
-
 /****************************************************************************
  * Public Data
  ****************************************************************************/

--- a/boards/arm/s32k1xx/s32k118evb/src/s32k1xx_clockconfig.c
+++ b/boards/arm/s32k1xx/s32k118evb/src/s32k1xx_clockconfig.c
@@ -145,7 +145,6 @@ const struct clock_configuration_s g_initial_clkconfig =
   },
   .pcc             =
   {
-    .count         = NUM_OF_PERIPHERAL_CLOCKS_0,       /* Number peripheral clock configurations */
     .pclks         = g_peripheral_clockconfig0,        /* Peripheral clock configurations */
   },
   .pmc             =

--- a/boards/arm/s32k1xx/s32k118evb/src/s32k1xx_periphclocks.c
+++ b/boards/arm/s32k1xx/s32k118evb/src/s32k1xx_periphclocks.c
@@ -115,6 +115,10 @@ const struct peripheral_clock_config_s g_peripheral_clockconfig0[] =
   },
 };
 
+unsigned int const num_of_peripheral_clocks_0 =
+    sizeof(g_peripheral_clockconfig0) /
+    sizeof(g_peripheral_clockconfig0[0]);
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/

--- a/boards/arm/s32k1xx/s32k144evb/src/s32k144evb.h
+++ b/boards/arm/s32k1xx/s32k144evb/src/s32k144evb.h
@@ -64,10 +64,6 @@
 #define GPIO_SW2    (PIN_PTC12 | PIN_INT_BOTH)
 #define GPIO_SW3    (PIN_PTC13 | PIN_INT_BOTH)
 
-/* Count of peripheral clock user configurations */
-
-#define NUM_OF_PERIPHERAL_CLOCKS_0 15
-
 /****************************************************************************
  * Public Data
  ****************************************************************************/

--- a/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_clockconfig.c
+++ b/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_clockconfig.c
@@ -163,7 +163,6 @@ const struct clock_configuration_s g_initial_clkconfig =
   },
   .pcc             =
   {
-    .count         = NUM_OF_PERIPHERAL_CLOCKS_0,       /* Number peripheral clock configurations */
     .pclks         = g_peripheral_clockconfig0,        /* Peripheral clock configurations */
   },
   .pmc             =

--- a/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_periphclocks.c
+++ b/boards/arm/s32k1xx/s32k144evb/src/s32k1xx_periphclocks.c
@@ -149,6 +149,10 @@ const struct peripheral_clock_config_s g_peripheral_clockconfig0[] =
   },
 };
 
+unsigned int const num_of_peripheral_clocks_0 =
+    sizeof(g_peripheral_clockconfig0) /
+    sizeof(g_peripheral_clockconfig0[0]);
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/

--- a/boards/arm/s32k1xx/s32k146evb/src/s32k146evb.h
+++ b/boards/arm/s32k1xx/s32k146evb/src/s32k146evb.h
@@ -64,10 +64,6 @@
 #define GPIO_SW2    (PIN_PTC12 | PIN_INT_BOTH)
 #define GPIO_SW3    (PIN_PTC13 | PIN_INT_BOTH)
 
-/* Count of peripheral clock user configurations */
-
-#define NUM_OF_PERIPHERAL_CLOCKS_0 15
-
 /****************************************************************************
  * Public Data
  ****************************************************************************/

--- a/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_clockconfig.c
+++ b/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_clockconfig.c
@@ -163,7 +163,6 @@ const struct clock_configuration_s g_initial_clkconfig =
   },
   .pcc             =
   {
-    .count         = NUM_OF_PERIPHERAL_CLOCKS_0,       /* Number peripheral clock configurations */
     .pclks         = g_peripheral_clockconfig0,        /* Peripheral clock configurations */
   },
   .pmc             =

--- a/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_periphclocks.c
+++ b/boards/arm/s32k1xx/s32k146evb/src/s32k1xx_periphclocks.c
@@ -149,6 +149,10 @@ const struct peripheral_clock_config_s g_peripheral_clockconfig0[] =
   },
 };
 
+size_t const num_of_peripheral_clocks_0 =
+    sizeof(g_peripheral_clockconfig0) /
+    sizeof(g_peripheral_clockconfig0[0]);
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/

--- a/boards/arm/s32k1xx/s32k148evb/src/s32k148evb.h
+++ b/boards/arm/s32k1xx/s32k148evb/src/s32k148evb.h
@@ -64,10 +64,6 @@
 #define GPIO_SW3    (PIN_PTC12 | PIN_INT_BOTH)
 #define GPIO_SW4    (PIN_PTC13 | PIN_INT_BOTH)
 
-/* Count of peripheral clock user configurations */
-
-#define NUM_OF_PERIPHERAL_CLOCKS_0 18
-
 /****************************************************************************
  * Public Data
  ****************************************************************************/

--- a/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_clockconfig.c
+++ b/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_clockconfig.c
@@ -169,7 +169,6 @@ const struct clock_configuration_s g_initial_clkconfig =
   },
   .pcc             =
   {
-    .count         = NUM_OF_PERIPHERAL_CLOCKS_0,       /* Number peripheral clock configurations */
     .pclks         = g_peripheral_clockconfig0,        /* Peripheral clock configurations */
   },
   .pmc             =

--- a/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_periphclocks.c
+++ b/boards/arm/s32k1xx/s32k148evb/src/s32k1xx_periphclocks.c
@@ -177,6 +177,10 @@ const struct peripheral_clock_config_s g_peripheral_clockconfig0[] =
   },
 };
 
+unsigned int const num_of_peripheral_clocks_0 =
+    sizeof(g_peripheral_clockconfig0) /
+    sizeof(g_peripheral_clockconfig0[0]);
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/

--- a/boards/arm/s32k1xx/ucans32k146/src/s32k1xx_clockconfig.c
+++ b/boards/arm/s32k1xx/ucans32k146/src/s32k1xx_clockconfig.c
@@ -163,7 +163,6 @@ const struct clock_configuration_s g_initial_clkconfig =
   },
   .pcc             =
   {
-    .count         = NUM_OF_PERIPHERAL_CLOCKS_0,       /* Number peripheral clock configurations */
     .pclks         = g_peripheral_clockconfig0,        /* Peripheral clock configurations */
   },
   .pmc             =

--- a/boards/arm/s32k1xx/ucans32k146/src/s32k1xx_periphclocks.c
+++ b/boards/arm/s32k1xx/ucans32k146/src/s32k1xx_periphclocks.c
@@ -122,6 +122,10 @@ const struct peripheral_clock_config_s g_peripheral_clockconfig0[] =
   },
 };
 
+unsigned int const num_of_peripheral_clocks_0 =
+    sizeof(g_peripheral_clockconfig0) /
+    sizeof(g_peripheral_clockconfig0[0]);
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/

--- a/boards/arm/s32k1xx/ucans32k146/src/ucans32k146.h
+++ b/boards/arm/s32k1xx/ucans32k146/src/ucans32k146.h
@@ -66,10 +66,6 @@
 
 #define GPIO_SE050_EN  (PIN_PTA6 | GPIO_LOWDRIVE)
 
-/* Count of peripheral clock user configurations */
-
-#define NUM_OF_PERIPHERAL_CLOCKS_0 12
-
 /****************************************************************************
  * Public Data
  ****************************************************************************/

--- a/boards/arm/s32k3xx/mr-canhubk3/src/mr-canhubk3.h
+++ b/boards/arm/s32k3xx/mr-canhubk3/src/mr-canhubk3.h
@@ -66,10 +66,6 @@
 #define GPIO_SW1       (PIN_EIRQ31_2 | PIN_INT_BOTH)  /* PTD15 */
 #define GPIO_SW2       (PIN_EIRQ5_2  | PIN_INT_BOTH)  /* PTA25 */
 
-/* Count of peripheral clock user configurations */
-
-#define NUM_OF_PERIPHERAL_CLOCKS_0 26
-
 /****************************************************************************
  * Public Data
  ****************************************************************************/

--- a/boards/arm/s32k3xx/mr-canhubk3/src/s32k3xx_clockconfig.c
+++ b/boards/arm/s32k3xx/mr-canhubk3/src/s32k3xx_clockconfig.c
@@ -152,7 +152,6 @@ const struct clock_configuration_s g_initial_clkconfig =
   },
   .pcc                 =
   {
-    .count             = NUM_OF_PERIPHERAL_CLOCKS_0,   /* Number of peripheral clock configurations */
     .pclks             = g_peripheral_clockconfig0,    /* Peripheral clock configurations */
   },
 };

--- a/boards/arm/s32k3xx/mr-canhubk3/src/s32k3xx_periphclocks.c
+++ b/boards/arm/s32k3xx/mr-canhubk3/src/s32k3xx_periphclocks.c
@@ -253,6 +253,10 @@ const struct peripheral_clock_config_s g_peripheral_clockconfig0[] =
   }
 };
 
+unsigned int const num_of_peripheral_clocks_0 =
+    sizeof(g_peripheral_clockconfig0) /
+    sizeof(g_peripheral_clockconfig0[0]);
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/

--- a/boards/arm/s32k3xx/s32k344evb/src/s32k344evb.h
+++ b/boards/arm/s32k3xx/s32k344evb/src/s32k344evb.h
@@ -74,10 +74,6 @@
 #define GPIO_SW0       (PIN_WKPU41 | PIN_INT_BOTH)
 #define GPIO_SW1       (PIN_WKPU38 | PIN_INT_BOTH)
 
-/* Count of peripheral clock user configurations */
-
-#define NUM_OF_PERIPHERAL_CLOCKS_0 25
-
 /****************************************************************************
  * Public Data
  ****************************************************************************/

--- a/boards/arm/s32k3xx/s32k344evb/src/s32k3xx_clockconfig.c
+++ b/boards/arm/s32k3xx/s32k344evb/src/s32k3xx_clockconfig.c
@@ -147,7 +147,6 @@ const struct clock_configuration_s g_initial_clkconfig =
   },
   .pcc                 =
   {
-    .count             = NUM_OF_PERIPHERAL_CLOCKS_0,   /* Number of peripheral clock configurations */
     .pclks             = g_peripheral_clockconfig0,    /* Peripheral clock configurations */
   },
 };

--- a/boards/arm/s32k3xx/s32k344evb/src/s32k3xx_periphclocks.c
+++ b/boards/arm/s32k3xx/s32k344evb/src/s32k3xx_periphclocks.c
@@ -245,6 +245,10 @@ const struct peripheral_clock_config_s g_peripheral_clockconfig0[] =
   },
 };
 
+unsigned int const num_of_peripheral_clocks_0 =
+    sizeof(g_peripheral_clockconfig0) /
+    sizeof(g_peripheral_clockconfig0[0]);
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/


### PR DESCRIPTION
Backport of
apache/nuttx#7866

Replaces PX4/PX4-Autopilot#20752

Corresponding PX4 PR will follow

