### PR TITLE
[BACKPORT] S32K FlexCAN don't use a blocking wait in tx avail

### DIFF
--- a/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
@@ -502,9 +502,6 @@ static void s32k1xx_setfreeze(uint32_t base, uint32_t freeze);
 static uint32_t s32k1xx_waitmcr_change(uint32_t base,
                                        uint32_t mask,
                                        uint32_t target_state);
-static uint32_t s32k1xx_waitesr2_change(uint32_t base,
-                                       uint32_t mask,
-                                       uint32_t target_state);
 
 /* Interrupt handling */
 
@@ -1219,26 +1216,6 @@ static void s32k1xx_setenable(uint32_t base, uint32_t enable)
   s32k1xx_waitmcr_change(base, CAN_MCR_LPMACK, 1);
 }
 
-static uint32_t s32k1xx_waitesr2_change(uint32_t base, uint32_t mask,
-                                       uint32_t target_state)
-{
-  const uint32_t timeout = 1000;
-  uint32_t wait_ack;
-
-  for (wait_ack = 0; wait_ack < timeout; wait_ack++)
-    {
-      uint32_t state = (getreg32(base + S32K1XX_CAN_ESR2_OFFSET) & mask);
-      if (state == target_state)
-        {
-          return true;
-        }
-
-      up_udelay(10);
-    }
-
-  return false;
-}
-
 static void s32k1xx_setfreeze(uint32_t base, uint32_t freeze)
 {
   uint32_t regval;
@@ -1398,9 +1375,7 @@ static void s32k1xx_txavail_work(void *arg)
        * packet.
        */
 
-      if (s32k1xx_waitesr2_change(priv->base,
-                             (CAN_ESR2_IMB | CAN_ESR2_VPS),
-                             (CAN_ESR2_IMB | CAN_ESR2_VPS)))
+      if (!s32k1xx_txringfull(priv))
         {
           /* No, there is space for another transfer.  Poll the network for
            * new XMIT data.

--- a/arch/arm/src/s32k3xx/s32k3xx_flexcan.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_flexcan.c
@@ -670,9 +670,6 @@ static void s32k3xx_setfreeze(uint32_t base, uint32_t freeze);
 static uint32_t s32k3xx_waitmcr_change(uint32_t base,
                                        uint32_t mask,
                                        uint32_t target_state);
-static uint32_t s32k3xx_waitesr2_change(uint32_t base,
-                                       uint32_t mask,
-                                       uint32_t target_state);
 
 /* Interrupt handling */
 
@@ -1382,26 +1379,6 @@ static void s32k3xx_setenable(uint32_t base, uint32_t enable)
   s32k3xx_waitmcr_change(base, CAN_MCR_LPMACK, 1);
 }
 
-static uint32_t s32k3xx_waitesr2_change(uint32_t base, uint32_t mask,
-                                       uint32_t target_state)
-{
-  const uint32_t timeout = 1000;
-  uint32_t wait_ack;
-
-  for (wait_ack = 0; wait_ack < timeout; wait_ack++)
-    {
-      uint32_t state = (getreg32(base + S32K3XX_CAN_ESR2_OFFSET) & mask);
-      if (state == target_state)
-        {
-          return true;
-        }
-
-      up_udelay(10);
-    }
-
-  return false;
-}
-
 static void s32k3xx_setfreeze(uint32_t base, uint32_t freeze)
 {
   uint32_t regval;
@@ -1593,9 +1570,7 @@ static void s32k3xx_txavail_work(void *arg)
        * packet.
        */
 
-      if (s32k3xx_waitesr2_change(priv->base,
-                             (CAN_ESR2_IMB | CAN_ESR2_VPS),
-                             (CAN_ESR2_IMB | CAN_ESR2_VPS)))
+      if (!s32k3xx_txringfull(priv))
         {
           /* No, there is space for another transfer.  Poll the network for
            * new XMIT data.


### PR DESCRIPTION
apache/nuttx#7879

## Summary
Fixes unresponsiveness when using sendmsg with MSG_DONTWAIT by not blocking on tx_avail()

## Impact
S32K1/S32K3

## Testing
Tested on MR-CANHUBK3 and UCANS32K146 with DroneCAN

