### PR TITLE
[BACKPORT] stm32h7: add SMPS PWR option for STM32H7X7

### DIFF
--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -149,6 +149,7 @@ config ARCH_CHIP_STM32H747XI
 	select STM32H7_IO_CONFIG_X
 	select STM32H7_HAVE_FDCAN1
 	select STM32H7_HAVE_FDCAN2
+	select STM32H7_HAVE_SMPS
 	---help---
 		Dual core STM32 H7 Cortex M7+M4, 2048 Kb FLASH, 1024K Kb SRAM
 		TFBGA240
@@ -216,6 +217,15 @@ config ARCH_CHIP_STM32H753ZI
 		with cryptographic accelerator, LQFP144
 
 endchoice # STM32 H7 Chip Selection
+
+config STM32H7_HAVE_SMPS
+	bool
+	default n
+
+config STM32H7_PWR_DIRECT_SMPS_SUPPLY
+	bool "Use direct SMPS supply mode"
+	depends on STM32H7_HAVE_SMPS
+	default n
 
 config STM32H7_IO_CONFIG_A
 	bool

--- a/arch/arm/src/stm32h7/hardware/stm32h7x3xx_pwr.h
+++ b/arch/arm/src/stm32h7/hardware/stm32h7x3xx_pwr.h
@@ -124,6 +124,16 @@
 #define STM32_PWR_CR3_BYPASS        (1 << 0)  /* Bit 0: Power management unit bypass */
 #define STM32_PWR_CR3_LDOEN         (1 << 1)  /* Bit 1: Low drop-out regulator enable */
 #define STM32_PWR_CR3_LDOESCUEN     (1 << 2)  /* Bit 2: Supply configuration update enable */
+#ifdef CONFIG_STM32H7_HAVE_SMPS
+#define STM32_PWR_CR3_SMPSEXTHP             (1 << 3)  /* Bit 3: SMPS step-down converter external power delivery selection */
+#define STM32_PWR_CR3_SMPSLEVEL_SHIFT       (4)       /* BitS 4-5: SMPS step-down converter voltage output level selection */
+#  define STM32_PWR_CR3_SMPSLEVEL_MASK      (3 << STM32_PWR_CR3_SMPSLEVEL_SHIFT)
+#  define STM32_PWR_CR3_SMPSLEVEL_R         (0 << STM32_PWR_CR3_SMPSLEVEL_SHIFT) /* 00: */
+#  define STM32_PWR_CR3_SMPSLEVEL_1V8       (1 << STM32_PWR_CR3_SMPSLEVEL_SHIFT) /* 01 */
+#  define STM32_PWR_CR3_SMPSLEVEL_2V5       (2 << STM32_PWR_CR3_SMPSLEVEL_SHIFT) /* 10: */
+#  define STM32_PWR_CR3_SMPSLEVEL_2V5B      (3 << STM32_PWR_CR3_SMPSLEVEL_SHIFT) /* 11: */
+#endif
+
                                               /* Bits 3-7: Reserved */
 #define STM32_PWR_CR3_VBE           (1 << 8)  /* Bit 8: VBAT charging enable */
 #define STM32_PWR_CR3_VBRS          (1 << 9)  /* Bit 9: VBAT charging resistor selection */

--- a/arch/arm/src/stm32h7/hardware/stm32h7x3xx_spi.h
+++ b/arch/arm/src/stm32h7/hardware/stm32h7x3xx_spi.h
@@ -27,7 +27,7 @@
 
 #include <nuttx/config.h>
 
-#if defined(CONFIG_STM32H7_STM32H7X3XX)
+#if defined(CONFIG_STM32H7_STM32H7X3XX) || defined(CONFIG_STM32H7_STM32H7X7XX)
 
 /****************************************************************************
  * Pre-processor Definitions

--- a/arch/arm/src/stm32h7/stm32h7x7xx_rcc.c
+++ b/arch/arm/src/stm32h7/stm32h7x7xx_rcc.c
@@ -826,9 +826,17 @@ void stm32_stdclockconfig(void)
        * N.B. The system shall be power cycled before writing a new value.
        */
 
+#if defined(CONFIG_STM32H7_PWR_DIRECT_SMPS_SUPPLY)
+      regval = getreg32(STM32_PWR_CR3);
+      regval &= ~(STM32_PWR_CR3_BYPASS | STM32_PWR_CR3_LDOEN |
+          STM32_PWR_CR3_SMPSEXTHP | STM32_PWR_CR3_SMPSLEVEL_MASK);
+      regval |= STM32_PWR_CR3_LDOESCUEN;
+      putreg32(regval, STM32_PWR_CR3);
+#else
       regval = getreg32(STM32_PWR_CR3);
       regval |= STM32_PWR_CR3_LDOEN | STM32_PWR_CR3_LDOESCUEN;
       putreg32(regval, STM32_PWR_CR3);
+#endif
 
       /* Set the voltage output scale */
 


### PR DESCRIPTION
The dual core STM32H747 / STM32H757 there is an additional option to select SMPS rather than LDO as the power selection.

This commit adds this option to the STM32H747 config and the stm32h7x7xx source.

Backporting the commit required manually:
- Adding the config for Kconfig
- Adding the defines to stm32h7x3xx_pwr.h

Replaces #195.

Backport of https://github.com/apache/nuttx/pull/8124