### PR TITLE
armv7-m irq: initialize mask to avoid compiler warning/error

### DIFF
--- a/arch/arm/include/armv7-m/irq.h
+++ b/arch/arm/include/armv7-m/irq.h
@@ -359,6 +359,9 @@ static inline void raisebasepri(uint32_t basepri)
    *    effect of unconditionally re-enabling interrupts.
    */
 
+#pragma GCC diagnostic push /* primask is initialized in ASM */
+#pragma GCC diagnostic ignored "-Wuninitialized"
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
   __asm__ __volatile__
     (
      "\tmrs   %0, primask\n"
@@ -368,6 +371,7 @@ static inline void raisebasepri(uint32_t basepri)
      : "+r" (primask)
      : "r"  (basepri)
      : "memory");
+#pragma GCC diagnostic pop
 }
 #else
 #  define raisebasepri(b) setbasepri(b);


### PR DESCRIPTION
Backport of https://github.com/apache/nuttx/pull/8856
Don't merge before it's in upstream NuttX.
