### PR TITLE
IMXRT7 Add LPUART 9/10/11/12 support

### DIFF
--- a/arch/arm/src/imxrt/Kconfig
+++ b/arch/arm/src/imxrt/Kconfig
@@ -159,6 +159,10 @@ config ARCH_FAMILY_IMXRT117x
 	select IMXRT_ADC_VER2
 	select IMXRT_CLOCKCONFIG_VER2
 	select IMXRT_IOMUX_VER2
+	select IMXRT_HAVE_LPUART9
+	select IMXRT_HAVE_LPUART10
+	select IMXRT_HAVE_LPUART11
+	select IMXRT_HAVE_LPUART12
 
 config ARCH_FAMILY_IMXRT106x
 	bool
@@ -183,6 +187,22 @@ config IMXRT_FLEXIO
 	default n
 
 config IMXRT_HAVE_LPUART
+	bool
+	default n
+
+config IMXRT_HAVE_LPUART9
+	bool
+	default n
+
+config IMXRT_HAVE_LPUART10
+	bool
+	default n
+
+config IMXRT_HAVE_LPUART11
+	bool
+	default n
+
+config IMXRT_HAVE_LPUART12
 	bool
 	default n
 
@@ -460,6 +480,38 @@ config IMXRT_LPUART8
 	select LPUART8_SERIALDRIVER
 	select ARCH_HAVE_SERIAL_TERMIOS
 	select IMXRT_HAVE_LPUART
+
+config IMXRT_LPUART9
+	bool "LPUART9"
+	default n
+	select LPUART9_SERIALDRIVER
+	select ARCH_HAVE_SERIAL_TERMIOS
+	select IMXRT_HAVE_LPUART
+	depends on IMXRT_HAVE_LPUART9
+
+config IMXRT_LPUART10
+	bool "LPUART10"
+	default n
+	select LPUART10_SERIALDRIVER
+	select ARCH_HAVE_SERIAL_TERMIOS
+	select IMXRT_HAVE_LPUART
+	depends on IMXRT_HAVE_LPUART10
+
+config IMXRT_LPUART11
+	bool "LPUART11"
+	default n
+	select LPUART11_SERIALDRIVER
+	select ARCH_HAVE_SERIAL_TERMIOS
+	select IMXRT_HAVE_LPUART
+	depends on IMXRT_HAVE_LPUART11
+
+config IMXRT_LPUART12
+	bool "LPUART12"
+	default n
+	select LPUART12_SERIALDRIVER
+	select ARCH_HAVE_SERIAL_TERMIOS
+	select IMXRT_HAVE_LPUART
+	depends on IMXRT_HAVE_LPUART12
 
 endmenu # LPUART Peripherals
 

--- a/arch/arm/src/imxrt/imxrt_lowputc.c
+++ b/arch/arm/src/imxrt/imxrt_lowputc.c
@@ -97,6 +97,30 @@
 #    define IMXRT_CONSOLE_BITS     CONFIG_LPUART8_BITS
 #    define IMXRT_CONSOLE_PARITY   CONFIG_LPUART8_PARITY
 #    define IMXRT_CONSOLE_2STOP    CONFIG_LPUART8_2STOP
+#  elif defined(CONFIG_LPUART9_SERIAL_CONSOLE)
+#    define IMXRT_CONSOLE_BASE     IMXRT_LPUART9_BASE
+#    define IMXRT_CONSOLE_BAUD     CONFIG_LPUART9_BAUD
+#    define IMXRT_CONSOLE_BITS     CONFIG_LPUART9_BITS
+#    define IMXRT_CONSOLE_PARITY   CONFIG_LPUART9_PARITY
+#    define IMXRT_CONSOLE_2STOP    CONFIG_LPUART9_2STOP
+#  elif defined(CONFIG_LPUART10_SERIAL_CONSOLE)
+#    define IMXRT_CONSOLE_BASE     IMXRT_LPUART10_BASE
+#    define IMXRT_CONSOLE_BAUD     CONFIG_LPUART10_BAUD
+#    define IMXRT_CONSOLE_BITS     CONFIG_LPUART10_BITS
+#    define IMXRT_CONSOLE_PARITY   CONFIG_LPUART10_PARITY
+#    define IMXRT_CONSOLE_2STOP    CONFIG_LPUART10_2STOP
+#  elif defined(CONFIG_LPUART11_SERIAL_CONSOLE)
+#    define IMXRT_CONSOLE_BASE     IMXRT_LPUART11_BASE
+#    define IMXRT_CONSOLE_BAUD     CONFIG_LPUART11_BAUD
+#    define IMXRT_CONSOLE_BITS     CONFIG_LPUART11_BITS
+#    define IMXRT_CONSOLE_PARITY   CONFIG_LPUART11_PARITY
+#    define IMXRT_CONSOLE_2STOP    CONFIG_LPUART11_2STOP
+#  elif defined(CONFIG_LPUART12_SERIAL_CONSOLE)
+#    define IMXRT_CONSOLE_BASE     IMXRT_LPUART12_BASE
+#    define IMXRT_CONSOLE_BAUD     CONFIG_LPUART12_BAUD
+#    define IMXRT_CONSOLE_BITS     CONFIG_LPUART12_BITS
+#    define IMXRT_CONSOLE_PARITY   CONFIG_LPUART12_PARITY
+#    define IMXRT_CONSOLE_2STOP    CONFIG_LPUART12_2STOP
 #  endif
 #endif
 
@@ -185,6 +209,30 @@ void imxrt_lpuart_clock_enable (uint32_t base)
     {
       imxrt_clockall_lpuart8();
     }
+#ifdef CONFIG_IMXRT_LPUART9
+  else if (base == IMXRT_LPUART9_BASE)
+    {
+      imxrt_clockall_lpuart9();
+    }
+#endif
+#ifdef CONFIG_IMXRT_LPUART10
+  else if (base == IMXRT_LPUART10_BASE)
+    {
+      imxrt_clockall_lpuart10();
+    }
+#endif
+#ifdef CONFIG_IMXRT_LPUART11
+  else if (base == IMXRT_LPUART11_BASE)
+    {
+      imxrt_clockall_lpuart11();
+    }
+#endif
+#ifdef CONFIG_IMXRT_LPUART12
+  else if (base == IMXRT_LPUART12_BASE)
+    {
+      imxrt_clockall_lpuart12();
+    }
+#endif
 }
 
 /****************************************************************************
@@ -343,6 +391,74 @@ void imxrt_lowsetup(void)
 #endif
 #endif
 
+#ifdef CONFIG_IMXRT_LPUART9
+
+  /* Configure LPUART9 pins: RXD and TXD.
+   * Also configure RTS and CTS if flow control is enabled.
+   */
+
+  imxrt_config_gpio(GPIO_LPUART9_RX);
+  imxrt_config_gpio(GPIO_LPUART9_TX);
+#ifdef CONFIG_LPUART9_OFLOWCONTROL
+  imxrt_config_gpio(GPIO_LPUART9_CTS);
+#endif
+#if ((defined(CONFIG_SERIAL_RS485CONTROL) && defined(CONFIG_LPUART9_RS485RTSCONTROL)) || \
+     (defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_LPUART9_IFLOWCONTROL)))
+  imxrt_config_gpio(GPIO_LPUART9_RTS);
+#endif
+#endif
+
+#ifdef CONFIG_IMXRT_LPUART10
+
+  /* Configure LPUART10 pins: RXD and TXD.
+   * Also configure RTS and CTS if flow control is enabled.
+   */
+
+  imxrt_config_gpio(GPIO_LPUART10_RX);
+  imxrt_config_gpio(GPIO_LPUART10_TX);
+#ifdef CONFIG_LPUART10_OFLOWCONTROL
+  imxrt_config_gpio(GPIO_LPUART10_CTS);
+#endif
+#if ((defined(CONFIG_SERIAL_RS485CONTROL) && defined(CONFIG_LPUART10_RS485RTSCONTROL)) || \
+     (defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_LPUART10_IFLOWCONTROL)))
+  imxrt_config_gpio(GPIO_LPUART10_RTS);
+#endif
+#endif
+
+#ifdef CONFIG_IMXRT_LPUART11
+
+  /* Configure LPUART11 pins: RXD and TXD.
+   * Also configure RTS and CTS if flow control is enabled.
+   */
+
+  imxrt_config_gpio(GPIO_LPUART11_RX);
+  imxrt_config_gpio(GPIO_LPUART11_TX);
+#ifdef CONFIG_LPUART11_OFLOWCONTROL
+  imxrt_config_gpio(GPIO_LPUART11_CTS);
+#endif
+#if ((defined(CONFIG_SERIAL_RS485CONTROL) && defined(CONFIG_LPUART11_RS485RTSCONTROL)) || \
+     (defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_LPUART11_IFLOWCONTROL)))
+  imxrt_config_gpio(GPIO_LPUART11_RTS);
+#endif
+#endif
+
+#ifdef CONFIG_IMXRT_LPUART12
+
+  /* Configure LPUART12 pins: RXD and TXD.
+   * Also configure RTS and CTS if flow control is enabled.
+   */
+
+  imxrt_config_gpio(GPIO_LPUART12_RX);
+  imxrt_config_gpio(GPIO_LPUART12_TX);
+#ifdef CONFIG_LPUART12_OFLOWCONTROL
+  imxrt_config_gpio(GPIO_LPUART12_CTS);
+#endif
+#if ((defined(CONFIG_SERIAL_RS485CONTROL) && defined(CONFIG_LPUART12_RS485RTSCONTROL)) || \
+     (defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_LPUART12_IFLOWCONTROL)))
+  imxrt_config_gpio(GPIO_LPUART12_RTS);
+#endif
+#endif
+
 #ifdef HAVE_LPUART_CONSOLE
   /* Configure the serial console for initial, non-interrupt driver mode */
 
@@ -433,6 +549,34 @@ int imxrt_lpuart_configure(uint32_t base,
   else if (base == IMXRT_LPUART8_BASE)
     {
       if (imxrt_get_rootclock(CCM_CR_LPUART8, &lpuart_freq) != OK)
+        {
+          return ERROR;
+        }
+    }
+  else if (base == IMXRT_LPUART9_BASE)
+    {
+      if (imxrt_get_rootclock(CCM_CR_LPUART9, &lpuart_freq) != OK)
+        {
+          return ERROR;
+        }
+    }
+  else if (base == IMXRT_LPUART10_BASE)
+    {
+      if (imxrt_get_rootclock(CCM_CR_LPUART10, &lpuart_freq) != OK)
+        {
+          return ERROR;
+        }
+    }
+  else if (base == IMXRT_LPUART11_BASE)
+    {
+      if (imxrt_get_rootclock(CCM_CR_LPUART11, &lpuart_freq) != OK)
+        {
+          return ERROR;
+        }
+    }
+  else if (base == IMXRT_LPUART12_BASE)
+    {
+      if (imxrt_get_rootclock(CCM_CR_LPUART12, &lpuart_freq) != OK)
         {
           return ERROR;
         }

--- a/arch/arm/src/imxrt/imxrt_periphclks.h
+++ b/arch/arm/src/imxrt/imxrt_periphclks.h
@@ -134,6 +134,12 @@
 #define imxrt_clockoff_lpuart6()          imxrt_periphclk_configure(CCM_CCGR_LPUART6, CCM_CG_OFF)
 #define imxrt_clockoff_lpuart7()          imxrt_periphclk_configure(CCM_CCGR_LPUART7, CCM_CG_OFF)
 #define imxrt_clockoff_lpuart8()          imxrt_periphclk_configure(CCM_CCGR_LPUART8, CCM_CG_OFF)
+#ifdef CONFIG_ARCH_FAMILY_IMXRT117x
+#  define imxrt_clockoff_lpuart9()        imxrt_periphclk_configure(CCM_CCGR_LPUART9, CCM_CG_OFF)
+#  define imxrt_clockoff_lpuart10()       imxrt_periphclk_configure(CCM_CCGR_LPUART10, CCM_CG_OFF)
+#  define imxrt_clockoff_lpuart11()       imxrt_periphclk_configure(CCM_CCGR_LPUART11, CCM_CG_OFF)
+#  define imxrt_clockoff_lpuart12()       imxrt_periphclk_configure(CCM_CCGR_LPUART12, CCM_CG_OFF)
+#endif
 #define imxrt_clockoff_mqs()              imxrt_periphclk_configure(CCM_CCGR_MQS, CCM_CG_OFF)
 #define imxrt_clockoff_ocotp_ctrl()       imxrt_periphclk_configure(CCM_CCGR_OCOTP_CTRL, CCM_CG_OFF)
 #define imxrt_clockoff_ocram()            imxrt_periphclk_configure(CCM_CCGR_OCRAM, CCM_CG_OFF)
@@ -278,6 +284,12 @@
 #define imxrt_clockrun_lpuart6()          imxrt_periphclk_configure(CCM_CCGR_LPUART6, CCM_CG_RUN)
 #define imxrt_clockrun_lpuart7()          imxrt_periphclk_configure(CCM_CCGR_LPUART7, CCM_CG_RUN)
 #define imxrt_clockrun_lpuart8()          imxrt_periphclk_configure(CCM_CCGR_LPUART8, CCM_CG_RUN)
+#ifdef CONFIG_ARCH_FAMILY_IMXRT117x
+#  define imxrt_clockrun_lpuart9()        imxrt_periphclk_configure(CCM_CCGR_LPUART9, CCM_CG_RUN)
+#  define imxrt_clockrun_lpuart10()       imxrt_periphclk_configure(CCM_CCGR_LPUART10, CCM_CG_RUN)
+#  define imxrt_clockrun_lpuart11()       imxrt_periphclk_configure(CCM_CCGR_LPUART11, CCM_CG_RUN)
+#  define imxrt_clockrun_lpuart12()       imxrt_periphclk_configure(CCM_CCGR_LPUART12, CCM_CG_RUN)
+#endif
 #define imxrt_clockrun_mqs()              imxrt_periphclk_configure(CCM_CCGR_MQS, CCM_CG_RUN)
 #define imxrt_clockrun_ocotp_ctrl()       imxrt_periphclk_configure(CCM_CCGR_OCOTP_CTRL, CCM_CG_RUN)
 #define imxrt_clockrun_ocram()            imxrt_periphclk_configure(CCM_CCGR_OCRAM, CCM_CG_RUN)
@@ -422,6 +434,12 @@
 #define imxrt_clockall_lpuart6()          imxrt_periphclk_configure(CCM_CCGR_LPUART6, CCM_CG_ALL)
 #define imxrt_clockall_lpuart7()          imxrt_periphclk_configure(CCM_CCGR_LPUART7, CCM_CG_ALL)
 #define imxrt_clockall_lpuart8()          imxrt_periphclk_configure(CCM_CCGR_LPUART8, CCM_CG_ALL)
+#ifdef CONFIG_ARCH_FAMILY_IMXRT117x
+#  define imxrt_clockall_lpuart9()        imxrt_periphclk_configure(CCM_CCGR_LPUART9, CCM_CG_ALL)
+#  define imxrt_clockall_lpuart10()       imxrt_periphclk_configure(CCM_CCGR_LPUART10, CCM_CG_ALL)
+#  define imxrt_clockall_lpuart11()       imxrt_periphclk_configure(CCM_CCGR_LPUART11, CCM_CG_ALL)
+#  define imxrt_clockall_lpuart12()       imxrt_periphclk_configure(CCM_CCGR_LPUART12, CCM_CG_ALL)
+#endif
 #define imxrt_clockall_mqs()              imxrt_periphclk_configure(CCM_CCGR_MQS, CCM_CG_ALL)
 #define imxrt_clockall_ocotp_ctrl()       imxrt_periphclk_configure(CCM_CCGR_OCOTP_CTRL, CCM_CG_ALL)
 #define imxrt_clockall_ocram()            imxrt_periphclk_configure(CCM_CCGR_OCRAM, CCM_CG_ALL)

--- a/arch/arm/src/imxrt/imxrt_serial.c
+++ b/arch/arm/src/imxrt/imxrt_serial.c
@@ -192,6 +192,38 @@
 #  define LPUART8_TXBUFSIZE_ALGN TXDMA_BUF_ALIGN
 #endif
 
+#if !defined(CONFIG_LPUART9_TXDMA)
+#  define LPUART9_TXBUFSIZE_ADJUSTED  CONFIG_LPUART9_TXBUFSIZE
+#  define LPUART9_TXBUFSIZE_ALGN
+#else
+#  define LPUART9_TXBUFSIZE_ADJUSTED TXDMA_BUF_SIZE(CONFIG_LPUART9_TXBUFSIZE)
+#  define LPUART9_TXBUFSIZE_ALGN TXDMA_BUF_ALIGN
+#endif
+
+#if !defined(CONFIG_LPUART10_TXDMA)
+#  define LPUART10_TXBUFSIZE_ADJUSTED  CONFIG_LPUART10_TXBUFSIZE
+#  define LPUART10_TXBUFSIZE_ALGN
+#else
+#  define LPUART10_TXBUFSIZE_ADJUSTED TXDMA_BUF_SIZE(CONFIG_LPUART10_TXBUFSIZE)
+#  define LPUART10_TXBUFSIZE_ALGN TXDMA_BUF_ALIGN
+#endif
+
+#if !defined(CONFIG_LPUART11_TXDMA)
+#  define LPUART11_TXBUFSIZE_ADJUSTED  CONFIG_LPUART11_TXBUFSIZE
+#  define LPUART11_TXBUFSIZE_ALGN
+#else
+#  define LPUART11_TXBUFSIZE_ADJUSTED TXDMA_BUF_SIZE(CONFIG_LPUART11_TXBUFSIZE)
+#  define LPUART11_TXBUFSIZE_ALGN TXDMA_BUF_ALIGN
+#endif
+
+#if !defined(CONFIG_LPUART12_TXDMA)
+#  define LPUART12_TXBUFSIZE_ADJUSTED  CONFIG_LPUART12_TXBUFSIZE
+#  define LPUART12_TXBUFSIZE_ALGN
+#else
+#  define LPUART12_TXBUFSIZE_ADJUSTED TXDMA_BUF_SIZE(CONFIG_LPUART12_TXBUFSIZE)
+#  define LPUART12_TXBUFSIZE_ALGN TXDMA_BUF_ALIGN
+#endif
+
 /* Which LPUART with be tty0/console and which tty1-7?  The console will
  * always be ttyS0.  If there is no console then will use the lowest
  * numbered UART.
@@ -279,6 +311,46 @@
 #  if defined(CONFIG_LPUART9_TXDMA)
 #    define SERIAL_HAVE_CONSOLE_TXDMA 1
 #  endif
+#elif defined(CONFIG_LPUART9_SERIAL_CONSOLE)
+#  define CONSOLE_DEV         g_lpuart9priv /* LPUART9 is console */
+#  define TTYS0_DEV           g_lpuart9priv /* LPUART9 is ttyS0 */
+#  define LPUART9_ASSIGNED    1
+#  if defined(CONFIG_LPUART9_RXDMA)
+#    define SERIAL_HAVE_CONSOLE_RXDMA 1
+#  endif
+#  if defined(CONFIG_LPUART9_TXDMA)
+#    define SERIAL_HAVE_CONSOLE_TXDMA 1
+#  endif
+#elif defined(CONFIG_LPUART10_SERIAL_CONSOLE)
+#  define CONSOLE_DEV         g_lpuart10priv /* LPUART10 is console */
+#  define TTYS0_DEV           g_lpuart10priv /* LPUART10 is ttyS0 */
+#  define LPUART10_ASSIGNED   1
+#  if defined(CONFIG_LPUART10_RXDMA)
+#    define SERIAL_HAVE_CONSOLE_RXDMA 1
+#  endif
+#  if defined(CONFIG_LPUART10_TXDMA)
+#    define SERIAL_HAVE_CONSOLE_TXDMA 1
+#  endif
+#elif defined(CONFIG_LPUART11_SERIAL_CONSOLE)
+#  define CONSOLE_DEV         g_lpuart11priv /* LPUART11 is console */
+#  define TTYS0_DEV           g_lpuart11priv /* LPUART11 is ttyS0 */
+#  define LPUART11_ASSIGNED   1
+#  if defined(CONFIG_LPUART11_RXDMA)
+#    define SERIAL_HAVE_CONSOLE_RXDMA 1
+#  endif
+#  if defined(CONFIG_LPUART11_TXDMA)
+#    define SERIAL_HAVE_CONSOLE_TXDMA 1
+#  endif
+#elif defined(CONFIG_LPUART12_SERIAL_CONSOLE)
+#  define CONSOLE_DEV         g_lpuart12priv /* LPUART12 is console */
+#  define TTYS0_DEV           g_lpuart12priv /* LPUART12 is ttyS0 */
+#  define LPUART12_ASSIGNED   1
+#  if defined(CONFIG_LPUART12_RXDMA)
+#    define SERIAL_HAVE_CONSOLE_RXDMA 1
+#  endif
+#  if defined(CONFIG_LPUART12_TXDMA)
+#    define SERIAL_HAVE_CONSOLE_TXDMA 1
+#  endif
 #else
 #  undef CONSOLE_DEV                      /* No console */
 #  if defined(CONFIG_IMXRT_LPUART1)
@@ -305,6 +377,18 @@
 #  elif defined(CONFIG_IMXRT_LPUART8)
 #    define TTYS0_DEV         g_lpuart8priv /* LPUART8 is ttyS0 */
 #    define UART8_ASSIGNED    1
+#  elif defined(CONFIG_IMXRT_LPUART9)
+#    define TTYS0_DEV         g_lpuart9priv /* LPUART9 is ttyS0 */
+#    define LPUART9_ASSIGNED  1
+#  elif defined(CONFIG_IMXRT_LPUART10)
+#    define TTYS0_DEV         g_lpuart10priv /* LPUART10 is ttyS0 */
+#    define LPUART10_ASSIGNED 1
+#  elif defined(CONFIG_IMXRT_LPUART11)
+#    define TTYS0_DEV         g_lpuart11priv /* LPUART11 is ttyS0 */
+#    define LPUART11_ASSIGNED 1
+#  elif defined(CONFIG_IMXRT_LPUART12)
+#    define TTYS0_DEV         g_lpuart12priv /* LPUART12 is ttyS0 */
+#    define LPUART12_ASSIGNED 1
 #  endif
 #endif
 
@@ -312,8 +396,8 @@
 #  define SERIAL_HAVE_CONSOLE_DMA
 #endif
 
-/* Pick ttys1.  This could be any of UART1-8 excluding the console UART.
- * One of UART1-8 could be the console; one of UART1-8 has already been
+/* Pick ttys1.  This could be any of UART1-12 excluding the console UART.
+ * One of UART1-12 could be the console; one of UART1-12 has already been
  * assigned to ttys0.
  */
 
@@ -340,12 +424,24 @@
 #  define LPUART7_ASSIGNED    1
 #elif defined(CONFIG_IMXRT_LPUART8) && !defined(LPUART8_ASSIGNED)
 #  define TTYS1_DEV           g_lpuart8priv /* LPUART8 is ttyS1 */
-#  define LPUART8_ASSIGNED    1
+#  define LPUART8_ASSIGNED    11
+#elif defined(CONFIG_IMXRT_LPUART9) && !defined(LPUART9_ASSIGNED)
+#  define TTYS1_DEV           g_lpuart9priv /* LPUART9 is ttyS1 */
+#  define LPUART9_ASSIGNED    1
+#elif defined(CONFIG_IMXRT_LPUART10) && !defined(LPUART10_ASSIGNED)
+#  define TTYS1_DEV           g_lpuart10priv /* LPUART10 is ttyS1 */
+#  define LPUART10_ASSIGNED   1
+#elif defined(CONFIG_IMXRT_LPUART11) && !defined(LPUART11_ASSIGNED)
+#  define TTYS1_DEV           g_lpuart11priv /* LPUART11 is ttyS1 */
+#  define LPUART11_ASSIGNED   1
+#elif defined(CONFIG_IMXRT_LPUART12) && !defined(LPUART12_ASSIGNED)
+#  define TTYS1_DEV           g_lpuart12priv /* LPUART12 is ttyS1 */
+#  define LPUART12_ASSIGNED   1
 #endif
 
-/* Pick ttys2.  This could be one of UART2-8. It can't be UART1 because that
- * was either assigned as ttyS0 or ttys1.  One of UART 1-8 could be the
- * console.  One of UART2-8 has already been assigned to ttys0 or ttyS1.
+/* Pick ttys2.  This could be one of UART2-12. It can't be UART1 because that
+ * was either assigned as ttyS0 or ttys1.  One of UART 1-12 could be the
+ * console.  One of UART2-12 has already been assigned to ttys0 or ttyS1.
  */
 
 #if defined(CONFIG_IMXRT_LPUART2) && !defined(LPUART2_ASSIGNED)
@@ -369,11 +465,23 @@
 #elif defined(CONFIG_IMXRT_LPUART8) && !defined(LPUART8_ASSIGNED)
 #  define TTYS2_DEV           g_lpuart8priv /* LPUART8 is ttyS2 */
 #  define LPUART8_ASSIGNED    1
+#elif defined(CONFIG_IMXRT_LPUART9) && !defined(LPUART9_ASSIGNED)
+#  define TTYS2_DEV           g_lpuart9priv /* LPUART9 is ttyS2 */
+#  define LPUART9_ASSIGNED    1
+#elif defined(CONFIG_IMXRT_LPUART10) && !defined(LPUART10_ASSIGNED)
+#  define TTYS2_DEV           g_lpuart10priv /* LPUART10 is ttyS2 */
+#  define LPUART10_ASSIGNED   1
+#elif defined(CONFIG_IMXRT_LPUART11) && !defined(LPUART11_ASSIGNED)
+#  define TTYS2_DEV           g_lpuart11priv /* LPUART11 is ttyS2 */
+#  define LPUART11_ASSIGNED   1
+#elif defined(CONFIG_IMXRT_LPUART12) && !defined(LPUART12_ASSIGNED)
+#  define TTYS2_DEV           g_lpuart12priv /* LPUART12 is ttyS2 */
+#  define LPUART12_ASSIGNED   1
 #endif
 
-/* Pick ttys3. This could be one of UART3-8. It can't be UART1-2 because
+/* Pick ttys3. This could be one of UART3-12. It can't be UART1-2 because
  * those have already been assigned to ttsyS0, 1, or 2.  One of
- * UART3-8 could also be the console.  One of UART3-8 has already
+ * UART3-12 could also be the console.  One of UART3-12 has already
  * been assigned to ttys0, 1, or 3.
  */
 
@@ -395,11 +503,23 @@
 #elif defined(CONFIG_IMXRT_LPUART8) && !defined(LPUART8_ASSIGNED)
 #  define TTYS3_DEV           g_lpuart8priv /* LPUART8 is ttyS3 */
 #  define LPUART8_ASSIGNED    1
+#elif defined(CONFIG_IMXRT_LPUART9) && !defined(LPUART9_ASSIGNED)
+#  define TTYS3_DEV           g_lpuart9priv /* LPUART9 is ttyS3 */
+#  define LPUART9_ASSIGNED    1
+#elif defined(CONFIG_IMXRT_LPUART10) && !defined(LPUART10_ASSIGNED)
+#  define TTYS3_DEV           g_lpuart10priv /* LPUART10 is ttyS3 */
+#  define LPUART10_ASSIGNED   1
+#elif defined(CONFIG_IMXRT_LPUART11) && !defined(LPUART11_ASSIGNED)
+#  define TTYS3_DEV           g_lpuart11priv /* LPUART11 is ttyS3 */
+#  define LPUART11_ASSIGNED   1
+#elif defined(CONFIG_IMXRT_LPUART12) && !defined(LPUART12_ASSIGNED)
+#  define TTYS3_DEV           g_lpuart12priv /* LPUART12 is ttyS3 */
+#  define LPUART12_ASSIGNED   1
 #endif
 
 /* Pick ttys4. This could be one of UART4-8. It can't be UART1-3 because
  * those have already been assigned to ttsyS0, 1, 2 or 3.  One of
- * UART 4-8 could be the console.  One of UART4-8 has already been
+ * UART 4-12 could be the console.  One of UART4-12 has already been
  * assigned to ttys0, 1, 3, or 4.
  */
 
@@ -418,11 +538,23 @@
 #elif defined(CONFIG_IMXRT_LPUART8) && !defined(LPUART8_ASSIGNED)
 #  define TTYS4_DEV           g_lpuart8priv /* LPUART8 is ttyS4 */
 #  define LPUART8_ASSIGNED    1
+#elif defined(CONFIG_IMXRT_LPUART9) && !defined(LPUART9_ASSIGNED)
+#  define TTYS4_DEV           g_lpuart9priv /* LPUART9 is ttyS4 */
+#  define LPUART9_ASSIGNED    1
+#elif defined(CONFIG_IMXRT_LPUART10) && !defined(LPUART10_ASSIGNED)
+#  define TTYS4_DEV           g_lpuart10priv /* LPUART10 is ttyS4 */
+#  define LPUART10_ASSIGNED   1
+#elif defined(CONFIG_IMXRT_LPUART11) && !defined(LPUART11_ASSIGNED)
+#  define TTYS4_DEV           g_lpuart11priv /* LPUART11 is ttyS4 */
+#  define LPUART11_ASSIGNED   1
+#elif defined(CONFIG_IMXRT_LPUART12) && !defined(LPUART12_ASSIGNED)
+#  define TTYS4_DEV           g_lpuart12priv /* LPUART12 is ttyS4 */
+#  define LPUART12_ASSIGNED   1
 #endif
 
-/* Pick ttys5. This could be one of UART5-8. It can't be UART1-4 because
+/* Pick ttys5. This could be one of UART5-12. It can't be UART1-4 because
  * those have already been assigned to ttsyS0, 1, 2, 3 or 4.  One of
- * UART 5-8 could be the console.  One of UART5-8 has already been
+ * UART 5-12 could be the console.  One of UART5-12 has already been
  * assigned to ttys0, 1, 2, 3, or 4.
  */
 
@@ -438,37 +570,147 @@
 #elif defined(CONFIG_IMXRT_LPUART8) && !defined(LPUART8_ASSIGNED)
 #  define TTYS5_DEV           g_lpuart8priv /* LPUART8 is ttyS5 */
 #  define LPUART8_ASSIGNED    1
+#elif defined(CONFIG_IMXRT_LPUART9) && !defined(LPUART9_ASSIGNED)
+#  define TTYS5_DEV           g_lpuart9priv /* LPUART9 is ttyS5 */
+#  define LPUART9_ASSIGNED    1
+#elif defined(CONFIG_IMXRT_LPUART10) && !defined(LPUART10_ASSIGNED)
+#  define TTYS5_DEV           g_lpuart10priv /* LPUART10 is ttyS5 */
+#  define LPUART10_ASSIGNED   1
+#elif defined(CONFIG_IMXRT_LPUART11) && !defined(LPUART11_ASSIGNED)
+#  define TTYS5_DEV           g_lpuart11priv /* LPUART11 is ttyS5 */
+#  define LPUART11_ASSIGNED   1
+#elif defined(CONFIG_IMXRT_LPUART12) && !defined(LPUART12_ASSIGNED)
+#  define TTYS5_DEV           g_lpuart12priv /* LPUART12 is ttyS5 */
+#  define LPUART12_ASSIGNED   1
 #endif
 
-/* Pick ttys6. This could be one of UART6-8. It can't be UART1-5 because
+/* Pick ttys6. This could be one of UART6-12. It can't be UART1-5 because
  * those have already been assigned to ttsyS0, 1, 2, 3, 4 or 5.  One of
- * UART 6-8 could be the console.  One of UART6-8 has already been
+ * UART 6-12 could be the console.  One of UART6-12 has already been
  * assigned to ttys0, 1, 2, 3, 4 or 5.
  */
 
 #if defined(CONFIG_IMXRT_LPUART6) && !defined(LPUART6_ASSIGNED)
-#  define TTYS6_DEV           g_lpuart6priv /* LPUART6 is ttyS5 */
+#  define TTYS6_DEV           g_lpuart6priv /* LPUART6 is ttyS6 */
 #  define LPUART6_ASSIGNED    1
 #elif defined(CONFIG_IMXRT_LPUART7) && !defined(LPUART7_ASSIGNED)
-#  define TTYS6_DEV           g_lpuart7priv /* LPUART7 is ttyS5 */
+#  define TTYS6_DEV           g_lpuart7priv /* LPUART7 is ttyS6 */
 #  define LPUART7_ASSIGNED    1
 #elif defined(CONFIG_IMXRT_LPUART8) && !defined(LPUART8_ASSIGNED)
-#  define TTYS6_DEV           g_lpuart8priv /* LPUART8 is ttyS5 */
+#  define TTYS6_DEV           g_lpuart8priv /* LPUART8 is ttyS6 */
 #  define LPUART8_ASSIGNED    1
+#elif defined(CONFIG_IMXRT_LPUART9) && !defined(LPUART9_ASSIGNED)
+#  define TTYS6_DEV           g_lpuart9priv /* LPUART9 is ttyS6 */
+#  define LPUART9_ASSIGNED    1
+#elif defined(CONFIG_IMXRT_LPUART10) && !defined(LPUART10_ASSIGNED)
+#  define TTYS6_DEV           g_lpuart10priv /* LPUART10 is ttyS6 */
+#  define LPUART10_ASSIGNED   1
+#elif defined(CONFIG_IMXRT_LPUART11) && !defined(LPUART11_ASSIGNED)
+#  define TTYS6_DEV           g_lpuart11priv /* LPUART11 is ttyS6 */
+#  define LPUART11_ASSIGNED   1
+#elif defined(CONFIG_IMXRT_LPUART12) && !defined(LPUART12_ASSIGNED)
+#  define TTYS6_DEV           g_lpuart12priv /* LPUART12 is ttyS6 */
+#  define LPUART12_ASSIGNED   1
 #endif
 
-/* Pick ttys7. This could be one of UART7-8. It can't be UART1-6 because
+/* Pick ttys7. This could be one of UART7-12. It can't be UART1-6 because
  * those have already been assigned to ttsyS0, 1, 2, 3, 4, 5 or 6.  One of
- * UART 7-8 could be the console.  One of UART7-8 has already been
+ * UART 7-12 could be the console.  One of UART7-12 has already been
  * assigned to ttys0, 1, 2, 3, 4, 5 or 6.
  */
 
 #if defined(CONFIG_IMXRT_LPUART7) && !defined(LPUART7_ASSIGNED)
-#  define TTYS7_DEV           g_lpuart7priv /* LPUART7 is ttyS5 */
+#  define TTYS7_DEV           g_lpuart7priv /* LPUART7 is ttyS7 */
 #  define LPUART7_ASSIGNED    1
 #elif defined(CONFIG_IMXRT_LPUART8) && !defined(LPUART8_ASSIGNED)
-#  define TTYS7_DEV           g_lpuart8port /* LPUART8 is ttyS5 */
+#  define TTYS7_DEV           g_lpuart8port /* LPUART8 is ttyS7 */
 #  define LPUART8_ASSIGNED    1
+#elif defined(CONFIG_IMXRT_LPUART9) && !defined(LPUART9_ASSIGNED)
+#  define TTYS7_DEV           g_lpuart9priv /* LPUART9 is ttyS7 */
+#  define LPUART9_ASSIGNED    1
+#elif defined(CONFIG_IMXRT_LPUART10) && !defined(LPUART10_ASSIGNED)
+#  define TTYS7_DEV           g_lpuart10priv /* LPUART10 is ttyS7 */
+#  define LPUART10_ASSIGNED   1
+#elif defined(CONFIG_IMXRT_LPUART11) && !defined(LPUART11_ASSIGNED)
+#  define TTYS7_DEV           g_lpuart11priv /* LPUART11 is ttyS7 */
+#  define LPUART11_ASSIGNED   1
+#elif defined(CONFIG_IMXRT_LPUART12) && !defined(LPUART12_ASSIGNED)
+#  define TTYS7_DEV           g_lpuart12priv /* LPUART12 is ttyS7 */
+#  define LPUART12_ASSIGNED   1
+#endif
+
+/* Pick ttys8. This could be one of UART8-12. It can't be UART1-9 because
+ * those have already been assigned to ttsyS0, 1, 2, 3, 4, 5 or 6.  One of
+ * UART 8-12 could be the console.  One of UART8-12 has already been
+ * assigned to ttys0, 1, 2, 3, 4, 5, 6 or 7.
+ */
+
+#if defined(CONFIG_IMXRT_LPUART8) && !defined(LPUART8_ASSIGNED)
+#  define TTYS8_DEV           g_lpuart8port /* LPUART8 is ttyS8 */
+#  define LPUART8_ASSIGNED    1
+#elif defined(CONFIG_IMXRT_LPUART9) && !defined(LPUART9_ASSIGNED)
+#  define TTYS8_DEV           g_lpuart9priv /* LPUART9 is ttyS8 */
+#  define LPUART9_ASSIGNED    1
+#elif defined(CONFIG_IMXRT_LPUART10) && !defined(LPUART10_ASSIGNED)
+#  define TTYS8_DEV           g_lpuart10priv /* LPUART10 is ttyS8 */
+#  define LPUART10_ASSIGNED   1
+#elif defined(CONFIG_IMXRT_LPUART11) && !defined(LPUART11_ASSIGNED)
+#  define TTYS8_DEV           g_lpuart11priv /* LPUART11 is ttyS8 */
+#  define LPUART11_ASSIGNED   1
+#elif defined(CONFIG_IMXRT_LPUART12) && !defined(LPUART12_ASSIGNED)
+#  define TTYS8_DEV           g_lpuart12priv /* LPUART12 is ttyS8 */
+#  define LPUART12_ASSIGNED   1
+#endif
+
+/* Pick ttys9. This could be one of UART9-12. It can't be UART1-10 because
+ * those have already been assigned to ttsyS0, 1, 2, 3, 4, 5, 6 or 7.  One of
+ * UART 9-12 could be the console.  One of UART9-12 has already been
+ * assigned to ttys0, 1, 2, 3, 4, 5, 6, 7 or 8.
+ */
+
+#if defined(CONFIG_IMXRT_LPUART9) && !defined(LPUART9_ASSIGNED)
+#  define TTYS9_DEV           g_lpuart9priv /* LPUART9 is ttyS9 */
+#  define LPUART9_ASSIGNED    1
+#elif defined(CONFIG_IMXRT_LPUART10) && !defined(LPUART10_ASSIGNED)
+#  define TTYS9_DEV           g_lpuart10priv /* LPUART10 is ttyS9 */
+#  define LPUART10_ASSIGNED   1
+#elif defined(CONFIG_IMXRT_LPUART11) && !defined(LPUART11_ASSIGNED)
+#  define TTYS9_DEV           g_lpuart11priv /* LPUART11 is ttyS9 */
+#  define LPUART11_ASSIGNED   1
+#elif defined(CONFIG_IMXRT_LPUART12) && !defined(LPUART12_ASSIGNED)
+#  define TTYS9_DEV           g_lpuart12priv /* LPUART12 is ttyS9 */
+#  define LPUART12_ASSIGNED   1
+#endif
+
+/* Pick ttys10. This could be one of UART10-12. It can't be UART1-10 because
+ * those have already been assigned to ttsyS0, 1, 2, 3, 4, 5, 6, 7 or 8.
+ * One of UART 10-12 could be the console. One of UART10-12 has already been
+ * assigned to ttys0, 1, 2, 3, 4, 5, 6, 7, 8 or 9.
+ */
+
+#if defined(CONFIG_IMXRT_LPUART10) && !defined(LPUART10_ASSIGNED)
+#  define TTYS10_DEV          g_lpuart10priv /* LPUART10 is ttyS10 */
+#  define LPUART10_ASSIGNED   1
+#elif defined(CONFIG_IMXRT_LPUART11) && !defined(LPUART11_ASSIGNED)
+#  define TTYS10_DEV          g_lpuart11priv /* LPUART11 is ttyS10 */
+#  define LPUART11_ASSIGNED   1
+#elif defined(CONFIG_IMXRT_LPUART12) && !defined(LPUART12_ASSIGNED)
+#  define TTYS10_DEV          g_lpuart12priv /* LPUART12 is ttyS10 */
+#  define LPUART12_ASSIGNED   1
+#endif
+
+/* Pick ttys11. This could be one of UART11-12. It can't be UART1-11 because
+ * those have already been assigned to ttsyS0, 1, 2, 3, 4, 5, 6, 7, 8 or 9.
+ * One of UART 11-12 could be the console. One of UART11-12 has already been
+ * assigned to ttys0, 1, 2, 3, 4, 5, 6, 7, 8, 9 or 10.
+ */
+
+#if defined(CONFIG_IMXRT_LPUART11) && !defined(LPUART11_ASSIGNED)
+#  define TTYS11_DEV          g_lpuart11priv /* LPUART11 is ttyS11 */
+#  define LPUART11_ASSIGNED   1
+#elif defined(CONFIG_IMXRT_LPUART12) && !defined(LPUART12_ASSIGNED)
+#  define TTYS11_DEV          g_lpuart12priv /* LPUART12 is ttyS11 */
+#  define LPUART12_ASSIGNED   1
 #endif
 
 /* UART, if available, should have been assigned to ttyS0-7. */
@@ -745,6 +987,26 @@ static char g_lpuart8rxfifo[RXDMA_BUFFER_SIZE]
   aligned_data(ARMV7M_DCACHE_LINESIZE);
 #endif
 
+#ifdef CONFIG_LPUART9_RXDMA
+static char g_lpuart9rxfifo[RXDMA_BUFFER_SIZE]
+  aligned_data(ARMV7M_DCACHE_LINESIZE);
+#endif
+
+#ifdef CONFIG_LPUART10_RXDMA
+static char g_lpuart10rxfifo[RXDMA_BUFFER_SIZE]
+  aligned_data(ARMV7M_DCACHE_LINESIZE);
+#endif
+
+#ifdef CONFIG_LPUART11_RXDMA
+static char g_lpuart11rxfifo[RXDMA_BUFFER_SIZE]
+  aligned_data(ARMV7M_DCACHE_LINESIZE);
+#endif
+
+#ifdef CONFIG_LPUART12_RXDMA
+static char g_lpuart12rxfifo[RXDMA_BUFFER_SIZE]
+  aligned_data(ARMV7M_DCACHE_LINESIZE);
+#endif
+
 /* Receive/Transmit buffers */
 
 #ifdef CONFIG_IMXRT_LPUART1
@@ -793,6 +1055,30 @@ static char g_lpuart7txbuffer[LPUART7_TXBUFSIZE_ADJUSTED] \
 static char g_lpuart8rxbuffer[CONFIG_LPUART8_RXBUFSIZE];
 static char g_lpuart8txbuffer[LPUART8_TXBUFSIZE_ADJUSTED] \
   LPUART8_TXBUFSIZE_ALGN;
+#endif
+  
+#ifdef CONFIG_IMXRT_LPUART9
+static char g_lpuart9rxbuffer[CONFIG_LPUART9_RXBUFSIZE];
+static char g_lpuart9txbuffer[LPUART9_TXBUFSIZE_ADJUSTED]
+  LPUART9_TXBUFSIZE_ALGN;
+#endif
+
+#ifdef CONFIG_IMXRT_LPUART10
+static char g_lpuart10rxbuffer[CONFIG_LPUART10_RXBUFSIZE];
+static char g_lpuart10txbuffer[LPUART10_TXBUFSIZE_ADJUSTED]
+  LPUART10_TXBUFSIZE_ALGN;
+#endif
+
+#ifdef CONFIG_IMXRT_LPUART11
+static char g_lpuart11rxbuffer[CONFIG_LPUART11_RXBUFSIZE];
+static char g_lpuart11txbuffer[LPUART11_TXBUFSIZE_ADJUSTED]
+  LPUART11_TXBUFSIZE_ALGN;
+#endif
+
+#ifdef CONFIG_IMXRT_LPUART12
+static char g_lpuart12rxbuffer[CONFIG_LPUART12_RXBUFSIZE];
+static char g_lpuart12txbuffer[LPUART12_TXBUFSIZE_ADJUSTED]
+  LPUART12_TXBUFSIZE_ALGN;
 #endif
 
 /* This describes the state of the IMXRT lpuart1 port. */
@@ -1324,6 +1610,270 @@ static struct imxrt_uart_s g_lpuart8priv =
 #ifdef CONFIG_LPUART8_RXDMA
   .dma_rxreqsrc = IMXRT_DMACHAN_LPUART8_RX,
   .rxfifo        = g_lpuart8rxfifo,
+#endif
+};
+#endif
+
+#ifdef CONFIG_IMXRT_LPUART9
+static struct imxrt_uart_s g_lpuart9priv =
+{
+  .dev =
+    {
+      .recv         =
+      {
+        .size       = CONFIG_LPUART9_RXBUFSIZE,
+        .buffer     = g_lpuart9rxbuffer,
+      },
+      .xmit         =
+      {
+        .size       = CONFIG_LPUART9_TXBUFSIZE,
+        .buffer     = g_lpuart9txbuffer,
+      },
+    #if defined(CONFIG_LPUART9_RXDMA) && defined(CONFIG_LPUART9_TXDMA)
+        .ops       = &g_lpuart_rxtxdma_ops,
+    #elif defined(CONFIG_LPUART9_RXDMA) && !defined(CONFIG_LPUART9_TXDMA)
+        .ops       = &g_lpuart_rxdma_ops,
+    #elif !defined(CONFIG_LPUART9_RXDMA) && defined(CONFIG_LPUART9_TXDMA)
+        .ops       = &g_lpuart_txdma_ops,
+    #else
+        .ops       = &g_lpuart_ops,
+    #endif
+      .priv         = &g_lpuart9priv,
+    },
+
+  .uartbase     = IMXRT_LPUART9_BASE,
+  .baud         = CONFIG_LPUART9_BAUD,
+  .irq          = IMXRT_IRQ_LPUART9,
+  .parity       = CONFIG_LPUART9_PARITY,
+  .bits         = CONFIG_LPUART9_BITS,
+  .stopbits2    = CONFIG_LPUART9_2STOP,
+#if defined(CONFIG_SERIAL_OFLOWCONTROL) && defined(CONFIG_LPUART9_OFLOWCONTROL)
+  .oflow        = 1,
+  .cts_gpio     = GPIO_LPUART9_CTS,
+#endif
+#if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_LPUART9_IFLOWCONTROL)
+  .iflow        = 1,
+#endif
+# if ((defined(CONFIG_SERIAL_RS485CONTROL) && defined(CONFIG_LPUART9_RS485RTSCONTROL)) \
+   || (defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_LPUART9_IFLOWCONTROL)))
+  .rts_gpio     = GPIO_LPUART9_RTS,
+#endif
+#ifdef CONFIG_IMXRT_LPUART_SINGLEWIRE
+  .tx_gpio      = GPIO_LPUART9_TX,
+#endif
+#if (((defined(CONFIG_SERIAL_RS485CONTROL) || defined(CONFIG_SERIAL_IFLOWCONTROL))) \
+    && defined(CONFIG_LPUART9_INVERTIFLOWCONTROL))
+  .inviflow     = 1,
+#endif
+
+#if defined(CONFIG_SERIAL_RS485CONTROL) && defined(CONFIG_LPUART9_RS485RTSCONTROL)
+  .rs485mode    = 1,
+#endif
+
+#ifdef CONFIG_LPUART9_TXDMA
+  .dma_txreqsrc = IMXRT_DMACHAN_LPUART9_TX,
+#endif
+#ifdef CONFIG_LPUART9_RXDMA
+  .dma_rxreqsrc = IMXRT_DMACHAN_LPUART9_RX,
+  .rxfifo        = g_lpuart9rxfifo,
+#endif
+};
+#endif
+
+#ifdef CONFIG_IMXRT_LPUART10
+static struct imxrt_uart_s g_lpuart10priv =
+{
+  .dev =
+    {
+      .recv         =
+      {
+        .size       = CONFIG_LPUART10_RXBUFSIZE,
+        .buffer     = g_lpuart10rxbuffer,
+      },
+      .xmit         =
+      {
+        .size       = CONFIG_LPUART10_TXBUFSIZE,
+        .buffer     = g_lpuart10txbuffer,
+      },
+    #if defined(CONFIG_LPUART10_RXDMA) && defined(CONFIG_LPUART10_TXDMA)
+        .ops       = &g_lpuart_rxtxdma_ops,
+    #elif defined(CONFIG_LPUART10_RXDMA) && !defined(CONFIG_LPUART10_TXDMA)
+        .ops       = &g_lpuart_rxdma_ops,
+    #elif !defined(CONFIG_LPUART10_RXDMA) && defined(CONFIG_LPUART10_TXDMA)
+        .ops       = &g_lpuart_txdma_ops,
+    #else
+        .ops       = &g_lpuart_ops,
+    #endif
+      .priv         = &g_lpuart10priv,
+    },
+
+  .uartbase     = IMXRT_LPUART10_BASE,
+  .baud         = CONFIG_LPUART10_BAUD,
+  .irq          = IMXRT_IRQ_LPUART10,
+  .parity       = CONFIG_LPUART10_PARITY,
+  .bits         = CONFIG_LPUART10_BITS,
+  .stopbits2    = CONFIG_LPUART10_2STOP,
+#if defined(CONFIG_SERIAL_OFLOWCONTROL) && defined(CONFIG_LPUART10_OFLOWCONTROL)
+  .oflow        = 1,
+  .cts_gpio     = GPIO_LPUART10_CTS,
+#endif
+#if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_LPUART10_IFLOWCONTROL)
+  .iflow        = 1,
+#endif
+# if ((defined(CONFIG_SERIAL_RS485CONTROL) && defined(CONFIG_LPUART10_RS485RTSCONTROL)) \
+   || (defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_LPUART10_IFLOWCONTROL)))
+  .rts_gpio     = GPIO_LPUART10_RTS,
+#endif
+#ifdef CONFIG_IMXRT_LPUART_SINGLEWIRE
+  .tx_gpio      = GPIO_LPUART10_TX,
+#endif
+#if (((defined(CONFIG_SERIAL_RS485CONTROL) || defined(CONFIG_SERIAL_IFLOWCONTROL))) \
+    && defined(CONFIG_LPUART10_INVERTIFLOWCONTROL))
+  .inviflow     = 1,
+#endif
+
+#if defined(CONFIG_SERIAL_RS485CONTROL) && defined(CONFIG_LPUART10_RS485RTSCONTROL)
+  .rs485mode    = 1,
+#endif
+
+#ifdef CONFIG_LPUART10_TXDMA
+  .dma_txreqsrc = IMXRT_DMACHAN_LPUART10_TX,
+#endif
+#ifdef CONFIG_LPUART10_RXDMA
+  .dma_rxreqsrc = IMXRT_DMACHAN_LPUART10_RX,
+  .rxfifo        = g_lpuart10rxfifo,
+#endif
+};
+#endif
+
+#ifdef CONFIG_IMXRT_LPUART11
+static struct imxrt_uart_s g_lpuart11priv =
+{
+  .dev =
+    {
+      .recv         =
+      {
+        .size       = CONFIG_LPUART11_RXBUFSIZE,
+        .buffer     = g_lpuart11rxbuffer,
+      },
+      .xmit         =
+      {
+        .size       = CONFIG_LPUART11_TXBUFSIZE,
+        .buffer     = g_lpuart11txbuffer,
+      },
+    #if defined(CONFIG_LPUART11_RXDMA) && defined(CONFIG_LPUART11_TXDMA)
+        .ops       = &g_lpuart_rxtxdma_ops,
+    #elif defined(CONFIG_LPUART11_RXDMA) && !defined(CONFIG_LPUART11_TXDMA)
+        .ops       = &g_lpuart_rxdma_ops,
+    #elif !defined(CONFIG_LPUART11_RXDMA) && defined(CONFIG_LPUART11_TXDMA)
+        .ops       = &g_lpuart_txdma_ops,
+    #else
+        .ops       = &g_lpuart_ops,
+    #endif
+      .priv         = &g_lpuart11priv,
+    },
+
+  .uartbase     = IMXRT_LPUART11_BASE,
+  .baud         = CONFIG_LPUART11_BAUD,
+  .irq          = IMXRT_IRQ_LPUART11,
+  .parity       = CONFIG_LPUART11_PARITY,
+  .bits         = CONFIG_LPUART11_BITS,
+  .stopbits2    = CONFIG_LPUART11_2STOP,
+#if defined(CONFIG_SERIAL_OFLOWCONTROL) && defined(CONFIG_LPUART11_OFLOWCONTROL)
+  .oflow        = 1,
+  .cts_gpio     = GPIO_LPUART11_CTS,
+#endif
+#if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_LPUART11_IFLOWCONTROL)
+  .iflow        = 1,
+#endif
+# if ((defined(CONFIG_SERIAL_RS485CONTROL) && defined(CONFIG_LPUART11_RS485RTSCONTROL)) \
+   || (defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_LPUART11_IFLOWCONTROL)))
+  .rts_gpio     = GPIO_LPUART11_RTS,
+#endif
+#ifdef CONFIG_IMXRT_LPUART_SINGLEWIRE
+  .tx_gpio      = GPIO_LPUART11_TX,
+#endif
+#if (((defined(CONFIG_SERIAL_RS485CONTROL) || defined(CONFIG_SERIAL_IFLOWCONTROL))) \
+    && defined(CONFIG_LPUART11_INVERTIFLOWCONTROL))
+  .inviflow     = 1,
+#endif
+
+#if defined(CONFIG_SERIAL_RS485CONTROL) && defined(CONFIG_LPUART11_RS485RTSCONTROL)
+  .rs485mode    = 1,
+#endif
+
+#ifdef CONFIG_LPUART11_TXDMA
+  .dma_txreqsrc = IMXRT_DMACHAN_LPUART11_TX,
+#endif
+#ifdef CONFIG_LPUART11_RXDMA
+  .dma_rxreqsrc = IMXRT_DMACHAN_LPUART11_RX,
+  .rxfifo        = g_lpuart11rxfifo,
+#endif
+};
+#endif
+
+#ifdef CONFIG_IMXRT_LPUART12
+static struct imxrt_uart_s g_lpuart12priv =
+{
+  .dev =
+    {
+      .recv         =
+      {
+        .size       = CONFIG_LPUART12_RXBUFSIZE,
+        .buffer     = g_lpuart12rxbuffer,
+      },
+      .xmit         =
+      {
+        .size       = CONFIG_LPUART12_TXBUFSIZE,
+        .buffer     = g_lpuart12txbuffer,
+      },
+    #if defined(CONFIG_LPUART12_RXDMA) && defined(CONFIG_LPUART12_TXDMA)
+        .ops       = &g_lpuart_rxtxdma_ops,
+    #elif defined(CONFIG_LPUART12_RXDMA) && !defined(CONFIG_LPUART12_TXDMA)
+        .ops       = &g_lpuart_rxdma_ops,
+    #elif !defined(CONFIG_LPUART12_RXDMA) && defined(CONFIG_LPUART12_TXDMA)
+        .ops       = &g_lpuart_txdma_ops,
+    #else
+        .ops       = &g_lpuart_ops,
+    #endif
+      .priv         = &g_lpuart12priv,
+    },
+
+  .uartbase     = IMXRT_LPUART12_BASE,
+  .baud         = CONFIG_LPUART12_BAUD,
+  .irq          = IMXRT_IRQ_LPUART12,
+  .parity       = CONFIG_LPUART12_PARITY,
+  .bits         = CONFIG_LPUART12_BITS,
+  .stopbits2    = CONFIG_LPUART12_2STOP,
+#if defined(CONFIG_SERIAL_OFLOWCONTROL) && defined(CONFIG_LPUART12_OFLOWCONTROL)
+  .oflow        = 1,
+  .cts_gpio     = GPIO_LPUART12_CTS,
+#endif
+#if defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_LPUART12_IFLOWCONTROL)
+  .iflow        = 1,
+#endif
+# if ((defined(CONFIG_SERIAL_RS485CONTROL) && defined(CONFIG_LPUART12_RS485RTSCONTROL)) \
+   || (defined(CONFIG_SERIAL_IFLOWCONTROL) && defined(CONFIG_LPUART12_IFLOWCONTROL)))
+  .rts_gpio     = GPIO_LPUART12_RTS,
+#endif
+#ifdef CONFIG_IMXRT_LPUART_SINGLEWIRE
+  .tx_gpio      = GPIO_LPUART12_TX,
+#endif
+#if (((defined(CONFIG_SERIAL_RS485CONTROL) || defined(CONFIG_SERIAL_IFLOWCONTROL))) \
+    && defined(CONFIG_LPUART12_INVERTIFLOWCONTROL))
+  .inviflow     = 1,
+#endif
+
+#if defined(CONFIG_SERIAL_RS485CONTROL) && defined(CONFIG_LPUART12_RS485RTSCONTROL)
+  .rs485mode    = 1,
+#endif
+
+#ifdef CONFIG_LPUART12_TXDMA
+  .dma_txreqsrc = IMXRT_DMACHAN_LPUART12_TX,
+#endif
+#ifdef CONFIG_LPUART12_RXDMA
+  .dma_rxreqsrc = IMXRT_DMACHAN_LPUART12_RX,
+  .rxfifo        = g_lpuart12rxfifo,
 #endif
 };
 #endif
@@ -2932,6 +3482,18 @@ void arm_serialinit(void)
 #endif
 #ifdef TTYS7_DEV
   uart_register("/dev/ttyS7", &TTYS7_DEV.dev);
+#endif
+#ifdef TTYS8_DEV
+  uart_register("/dev/ttyS8", &TTYS8_DEV.dev);
+#endif
+#ifdef TTYS9_DEV
+  uart_register("/dev/ttyS9", &TTYS9_DEV.dev);
+#endif
+#ifdef TTYS10_DEV
+  uart_register("/dev/ttyS10", &TTYS10_DEV.dev);
+#endif
+#ifdef TTYS11_DEV
+  uart_register("/dev/ttyS11", &TTYS11_DEV.dev);
 #endif
 }
 

--- a/arch/arm/src/imxrt/imxrt_serial.h
+++ b/arch/arm/src/imxrt/imxrt_serial.h
@@ -67,6 +67,14 @@
 #  undef CONFIG_LPUART7_TXDMA
 #  undef CONFIG_LPUART8_RXDMA
 #  undef CONFIG_LPUART8_TXDMA
+#  undef CONFIG_LPUART9_RXDMA
+#  undef CONFIG_LPUART9_TXDMA
+#  undef CONFIG_LPUART10_RXDMA
+#  undef CONFIG_LPUART10_TXDMA
+#  undef CONFIG_LPUART11_RXDMA
+#  undef CONFIG_LPUART11_TXDMA
+#  undef CONFIG_LPUART12_RXDMA
+#  undef CONFIG_LPUART12_TXDMA
 #endif
 
 /* Disable the DMA configuration on all unused LPUARTs */
@@ -111,22 +119,46 @@
 #  undef CONFIG_LPUART8_TXDMA
 #endif
 
+#ifndef CONFIG_IMXRT_LPUART9
+#  undef CONFIG_LPUART9_RXDMA
+#  undef CONFIG_LPUART9_TXDMA
+#endif
+
+#ifndef CONFIG_IMXRT_LPUART10
+#  undef CONFIG_LPUART10_RXDMA
+#  undef CONFIG_LPUART10_TXDMA
+#endif
+
+#ifndef CONFIG_IMXRT_LPUART11
+#  undef CONFIG_LPUART11_RXDMA
+#  undef CONFIG_LPUART11_TXDMA
+#endif
+
+#ifndef CONFIG_IMXRT_LPUART12
+#  undef CONFIG_LPUART12_RXDMA
+#  undef CONFIG_LPUART12_TXDMA
+#endif
+
 /* Is RX DMA available on any (enabled) LPUART? */
 
 #undef SERIAL_HAVE_RXDMA
-#if defined(CONFIG_LPUART1_RXDMA) || defined(CONFIG_LPUART2_RXDMA) || \
-    defined(CONFIG_LPUART3_RXDMA) || defined(CONFIG_LPUART4_RXDMA) || \
-    defined(CONFIG_LPUART5_RXDMA) || defined(CONFIG_LPUART6_RXDMA) || \
-    defined(CONFIG_LPUART7_RXDMA) || defined(CONFIG_LPUART8_RXDMA)
+#if defined(CONFIG_LPUART1_RXDMA)  || defined(CONFIG_LPUART2_RXDMA)  || \
+    defined(CONFIG_LPUART3_RXDMA)  || defined(CONFIG_LPUART4_RXDMA)  || \
+    defined(CONFIG_LPUART5_RXDMA)  || defined(CONFIG_LPUART6_RXDMA)  || \
+    defined(CONFIG_LPUART7_RXDMA)  || defined(CONFIG_LPUART8_RXDMA)  || \
+    defined(CONFIG_LPUART9_RXDMA)  || defined(CONFIG_LPUART10_RXDMA) || \
+    defined(CONFIG_LPUART11_RXDMA) || defined(CONFIG_LPUART12_RXDMA)
 #  define SERIAL_HAVE_RXDMA 1
 #endif
 
 /* Is TX DMA available on any (enabled) LPUART? */
 #undef SERIAL_HAVE_TXDMA
-#if defined(CONFIG_LPUART1_TXDMA) || defined(CONFIG_LPUART2_TXDMA) || \
-    defined(CONFIG_LPUART3_TXDMA) || defined(CONFIG_LPUART4_TXDMA) || \
-    defined(CONFIG_LPUART5_TXDMA) || defined(CONFIG_LPUART6_TXDMA) || \
-    defined(CONFIG_LPUART7_TXDMA) || defined(CONFIG_LPUART8_TXDMA)
+#if defined(CONFIG_LPUART1_TXDMA)  || defined(CONFIG_LPUART2_TXDMA)  || \
+    defined(CONFIG_LPUART3_TXDMA)  || defined(CONFIG_LPUART4_TXDMA)  || \
+    defined(CONFIG_LPUART5_TXDMA)  || defined(CONFIG_LPUART6_TXDMA)  || \
+    defined(CONFIG_LPUART7_TXDMA)  || defined(CONFIG_LPUART8_TXDMA)  || \
+    defined(CONFIG_LPUART9_RXDMA)  || defined(CONFIG_LPUART10_RXDMA) || \
+    defined(CONFIG_LPUART11_RXDMA) || defined(CONFIG_LPUART12_RXDMA)
 #  define SERIAL_HAVE_TXDMA 1
 #endif
 
@@ -149,6 +181,14 @@
 #  undef SERIAL_HAVE_ONLY_RXDMA
 #elif defined(CONFIG_IMXRT_LPUART8) && !defined(CONFIG_LPUART8_RXDMA)
 #  undef SERIAL_HAVE_ONLY_RXDMA
+#elif defined(CONFIG_IMXRT_LPUART9) && !defined(CONFIG_LPUART9_RXDMA)
+#  undef SERIAL_HAVE_ONLY_RXDMA
+#elif defined(CONFIG_IMXRT_LPUART10) && !defined(CONFIG_LPUART10_RXDMA)
+#  undef SERIAL_HAVE_ONLY_RXDMA
+#elif defined(CONFIG_IMXRT_LPUART11) && !defined(CONFIG_LPUART11_RXDMA)
+#  undef SERIAL_HAVE_ONLY_RXDMA
+#elif defined(CONFIG_IMXRT_LPUART12) && !defined(CONFIG_LPUART12_RXDMA)
+#  undef SERIAL_HAVE_ONLY_RXDMA
 #endif
 
 /* Is TX DMA used on all (enabled) LPUARTs */
@@ -169,6 +209,14 @@
 #elif defined(CONFIG_IMXRT_LPUART7) && !defined(CONFIG_LPUART7_TXDMA)
 #  undef SERIAL_HAVE_ONLY_TXDMA
 #elif defined(CONFIG_IMXRT_LPUART8) && !defined(CONFIG_LPUART8_TXDMA)
+#  undef SERIAL_HAVE_ONLY_TXDMA
+#elif defined(CONFIG_IMXRT_LPUART9) && !defined(CONFIG_LPUART9_TXDMA)
+#  undef SERIAL_HAVE_ONLY_TXDMA
+#elif defined(CONFIG_IMXRT_LPUART10) && !defined(CONFIG_LPUART10_TXDMA)
+#  undef SERIAL_HAVE_ONLY_TXDMA
+#elif defined(CONFIG_IMXRT_LPUART11) && !defined(CONFIG_LPUART11_TXDMA)
+#  undef SERIAL_HAVE_ONLY_TXDMA
+#elif defined(CONFIG_IMXRT_LPUART12) && !defined(CONFIG_LPUART12_TXDMA)
 #  undef SERIAL_HAVE_ONLY_TXDMA
 #endif
 
@@ -191,14 +239,18 @@
  * lack of testing.
  */
 
-#  if (defined(CONFIG_LPUART1_RXDMA) && defined(CONFIG_LPUART1_RS485)) || \
-      (defined(CONFIG_LPUART2_RXDMA) && defined(CONFIG_LPUART2_RS485)) || \
-      (defined(CONFIG_LPUART3_RXDMA) && defined(CONFIG_LPUART3_RS485)) || \
-      (defined(CONFIG_LPUART4_RXDMA) && defined(CONFIG_LPUART4_RS485)) || \
-      (defined(CONFIG_LPUART5_RXDMA) && defined(CONFIG_LPUART5_RS485)) || \
-      (defined(CONFIG_LPUART6_RXDMA) && defined(CONFIG_LPUART6_RS485)) || \
-      (defined(CONFIG_LPUART7_RXDMA) && defined(CONFIG_LPUART7_RS485)) || \
-      (defined(CONFIG_LPUART8_RXDMA) && defined(CONFIG_LPUART8_RS485))
+#  if (defined(CONFIG_LPUART1_RXDMA)  && defined(CONFIG_LPUART1_RS485))  || \
+      (defined(CONFIG_LPUART2_RXDMA)  && defined(CONFIG_LPUART2_RS485))  || \
+      (defined(CONFIG_LPUART3_RXDMA)  && defined(CONFIG_LPUART3_RS485))  || \
+      (defined(CONFIG_LPUART4_RXDMA)  && defined(CONFIG_LPUART4_RS485))  || \
+      (defined(CONFIG_LPUART5_RXDMA)  && defined(CONFIG_LPUART5_RS485))  || \
+      (defined(CONFIG_LPUART6_RXDMA)  && defined(CONFIG_LPUART6_RS485))  || \
+      (defined(CONFIG_LPUART7_RXDMA)  && defined(CONFIG_LPUART7_RS485))  || \
+      (defined(CONFIG_LPUART8_RXDMA)  && defined(CONFIG_LPUART8_RS485))  || \
+      (defined(CONFIG_LPUART9_RXDMA)  && defined(CONFIG_LPUART9_RS485))  || \
+      (defined(CONFIG_LPUART10_RXDMA) && defined(CONFIG_LPUART10_RS485)) || \
+      (defined(CONFIG_LPUART11_RXDMA) && defined(CONFIG_LPUART11_RS485)) || \
+      (defined(CONFIG_LPUART12_RXDMA) && defined(CONFIG_LPUART12_RS485))
 #    error "RXDMA and RS-485 cannot be enabled at the same time for the same LPUART"
 #  endif
 #endif /* SERIAL_HAVE_RXDMA */
@@ -207,14 +259,18 @@
  * lack of testing.
  */
 
-#if (defined(CONFIG_LPUART1_TXDMA) && defined(CONFIG_LPUART1_RS485)) || \
-    (defined(CONFIG_LPUART2_TXDMA) && defined(CONFIG_LPUART2_RS485)) || \
-    (defined(CONFIG_LPUART3_TXDMA) && defined(CONFIG_LPUART3_RS485)) || \
-    (defined(CONFIG_LPUART4_TXDMA) && defined(CONFIG_LPUART4_RS485)) || \
-    (defined(CONFIG_LPUART5_TXDMA) && defined(CONFIG_LPUART5_RS485)) || \
-    (defined(CONFIG_LPUART6_TXDMA) && defined(CONFIG_LPUART6_RS485)) || \
-    (defined(CONFIG_LPUART7_TXDMA) && defined(CONFIG_LPUART7_RS485)) || \
-    (defined(CONFIG_LPUART8_TXDMA) && defined(CONFIG_LPUART8_RS485))
+#if (defined(CONFIG_LPUART1_TXDMA)  && defined(CONFIG_LPUART1_RS485))  || \
+    (defined(CONFIG_LPUART2_TXDMA)  && defined(CONFIG_LPUART2_RS485))  || \
+    (defined(CONFIG_LPUART3_TXDMA)  && defined(CONFIG_LPUART3_RS485))  || \
+    (defined(CONFIG_LPUART4_TXDMA)  && defined(CONFIG_LPUART4_RS485))  || \
+    (defined(CONFIG_LPUART5_TXDMA)  && defined(CONFIG_LPUART5_RS485))  || \
+    (defined(CONFIG_LPUART6_TXDMA)  && defined(CONFIG_LPUART6_RS485))  || \
+    (defined(CONFIG_LPUART7_TXDMA)  && defined(CONFIG_LPUART7_RS485))  || \
+    (defined(CONFIG_LPUART8_TXDMA)  && defined(CONFIG_LPUART8_RS485))  || \
+    (defined(CONFIG_LPUART9_TXDMA)  && defined(CONFIG_LPUART9_RS485))  || \
+    (defined(CONFIG_LPUART10_TXDMA) && defined(CONFIG_LPUART10_RS485)) || \
+    (defined(CONFIG_LPUART11_TXDMA) && defined(CONFIG_LPUART11_RS485)) || \
+    (defined(CONFIG_LPUART12_TXDMA) && defined(CONFIG_LPUART12_RS485))
 #  error "TXDMA and RS-485 cannot be enabled at the same time for the same LPUART"
 #endif
 


### PR DESCRIPTION
## Summary
IMXRT7 Add LPUART 9/10/11/12 support
Derived from S32K3XX LPUART not tested on RT7
Compiles with enabling LPUART10/11 on RT7.

