### PR TITLE
Px4 firmware nuttx 10.3.0+ pr imx1170 tcm

### DIFF
--- a/arch/arm/src/imxrt/hardware/rt117x/imxrt117x_ccm.h
+++ b/arch/arm/src/imxrt/hardware/rt117x/imxrt117x_ccm.h
@@ -256,6 +256,7 @@
                                                     /* Bits 4-15:  Reserved */
 #define CCM_CG_CTRL_RSTDIV_SHIFT          (16)      /* Bits 16-23: Clock group global restart count (RSTDIV) */
 #define CCM_CG_CTRL_RSTDIV_MASK           (0xff << CCM_CG_CTRL_RSTDIV_SHIFT)
+#  define CCM_CG_CTRL_RSTDIV(n)           (((n)-1) << CCM_CG_CTRL_RSTDIV_SHIFT) /* Divide selected clock by n */
 #define CCM_CG_CTRL_OFF                   (1 << 24) /* Bit 24:     Shutdown all clocks in clock group (OFF) */
                                                     /* Bits 25-31: Reserved */
 

--- a/arch/arm/src/imxrt/imxrt117x_mpuinit.c
+++ b/arch/arm/src/imxrt/imxrt117x_mpuinit.c
@@ -84,9 +84,9 @@
   mpu_configure_region(IMXRT_ITCM_BASE, 256 * 1024,
                                            /* Instruction access Enabled */
                        MPU_RASR_AP_RWRW  | /* P:RW   U:RW                */
-                       MPU_RASR_TEX_SO   | /* Strongly Ordered           */
-                       MPU_RASR_C        | /* Cacheable                  */
-                       MPU_RASR_B          /* Bufferable                 */
+                       MPU_RASR_TEX_NOR    /* Normal                     */
+                                           /* Not Cacheable              */
+                                           /* Not Bufferable             */
                                            /* Not Shareable              */
                                            /* No Subregion disable       */
                        );
@@ -94,9 +94,9 @@
   mpu_configure_region(IMXRT_DTCM_BASE, 256 * 1024,
                                            /* Instruction access Enabled */
                        MPU_RASR_AP_RWRW  | /* P:RW   U:RW                */
-                       MPU_RASR_TEX_SO   | /* Strongly Ordered           */
-                       MPU_RASR_C        | /* Cacheable                  */
-                       MPU_RASR_B          /* Bufferable                 */
+                       MPU_RASR_TEX_NOR    /* Normal                     */
+                                           /* Not Cacheable              */
+                                           /* Not Bufferable             */
                                            /* Not Shareable              */
                                            /* No Subregion disable       */
                        );

--- a/arch/arm/src/imxrt/imxrt_clockconfig_ver2.c
+++ b/arch/arm/src/imxrt/imxrt_clockconfig_ver2.c
@@ -125,6 +125,10 @@ static void imxrt_oscsetup(void)
   reg |= CCM_CR_CTRL_MUX_SRCSEL(M7_CLK_ROOT_OSC_RC_48M_DIV2);
   reg |= CCM_CR_CTRL_DIV(1);
   putreg32(reg, IMXRT_CCM_CR_CTRL(8));
+
+  /* FlexRAM AXI CLK ROOT */
+  putreg32(CCM_CG_CTRL_RSTDIV(1) | CCM_CG_CTRL_DIV0(1), IMXRT_CCM_CG_CTRL(0));
+
 }
 
 /****************************************************************************


### PR DESCRIPTION
TCM MPU mapping don't cache, normal ordered

CCM set FlexRAM clock div0 to 1