### PR TITLE
[BACKPORT] fs/cromfs: Fix faulty DEBUGASSERT() check

### DIFF
--- a/fs/cromfs/fs_cromfs.c
+++ b/fs/cromfs/fs_cromfs.c
@@ -1152,7 +1152,7 @@ static int cromfs_fstat(FAR const struct file *filep, FAR struct stat *buf)
 
   /* Sanity checks */
 
-  DEBUGASSERT(filep->f_priv == NULL && filep->f_inode != NULL);
+  DEBUGASSERT(filep->f_priv != NULL && filep->f_inode != NULL);
 
   /* Get the mountpoint inode reference from the file structure and the
    * volume private data from the inode structure


### PR DESCRIPTION
## Summary
Fixes faulty assertion crash, which would happen when arming with assertions enabled.
