### PR TITLE
Px4 firmware nuttx 10.3.0+ pr imx1170 i2c dma fix

### DIFF
--- a/arch/arm/src/imxrt/imxrt_lpi2c.c
+++ b/arch/arm/src/imxrt/imxrt_lpi2c.c
@@ -2249,6 +2249,13 @@ static int imxrt_lpi2c_transfer(struct i2c_master_s *dev,
 
   if (imxrt_lpi2c_sem_waitdone(priv) < 0)
     {
+#ifdef CONFIG_IMXRT_LPI2C_DMA
+      if (priv->dma)
+        {
+          imxrt_dmach_stop(priv->dma);
+        }
+
+#endif
       ret = -ETIMEDOUT;
       i2cerr("ERROR: Timed out: MSR: status: 0x0%" PRIx32 "\n",
              priv->status);

--- a/arch/arm/src/s32k1xx/s32k1xx_lpi2c.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_lpi2c.c
@@ -1982,6 +1982,18 @@ static int s32k1xx_lpi2c_transfer(struct i2c_master_s *dev,
 
   if (s32k1xx_lpi2c_sem_waitdone(priv) < 0)
     {
+#ifdef CONFIG_S32K1XX_LPI2C_DMA
+    if (priv->rxdma != NULL)
+      {
+        s32k1xx_dmach_stop(priv->rxdma);
+      }
+
+    if (priv->txdma != NULL)
+      {
+        s32k1xx_dmach_stop(priv->txdma);
+      }
+
+#endif
       ret = -ETIMEDOUT;
       i2cerr("ERROR: Timed out: MCR: status: 0x%" PRIx32 "\n", priv->status);
     }

--- a/arch/arm/src/s32k3xx/s32k3xx_lpi2c.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_lpi2c.c
@@ -1953,6 +1953,18 @@ static int s32k3xx_lpi2c_transfer(struct i2c_master_s *dev,
 
   if (s32k3xx_lpi2c_sem_waitdone(priv) < 0)
     {
+#ifdef CONFIG_S32K3XX_LPI2C_DMA
+    if (priv->rxdma != NULL)
+      {
+        s32k3xx_dmach_stop(priv->rxdma);
+      }
+
+    if (priv->txdma != NULL)
+      {
+        s32k3xx_dmach_stop(priv->txdma);
+      }
+
+#endif
       ret = -ETIMEDOUT;
       i2cerr("ERROR: Timed out: MCR: status: 0x%" PRIx32 "\n", priv->status);
     }


### PR DESCRIPTION
## Summary
In the case of transfer timeout we should stop the dma to avoid chaining.
