### PR TITLE
imxrt backport and Remove restriction to use nxsem_trywait from ISR backport

### DIFF
--- a/arch/arm/src/imxrt/imxrt_serial.c
+++ b/arch/arm/src/imxrt/imxrt_serial.c
@@ -1734,6 +1734,7 @@ static int imxrt_interrupt(int irq, void *context, void *arg)
 {
   struct imxrt_uart_s *priv = (struct imxrt_uart_s *)arg;
   uint32_t usr;
+  uint32_t lsr;
   int passes = 0;
   bool handled;
 
@@ -1759,30 +1760,45 @@ static int imxrt_interrupt(int irq, void *context, void *arg)
        */
 
       usr  = imxrt_serialin(priv, IMXRT_LPUART_STAT_OFFSET);
+
+      /* Removed all W1C from the last sr */
+
+      lsr  = usr & ~(LPUART_STAT_LBKDIF | LPUART_STAT_RXEDGIF |
+                     LPUART_STAT_IDLE   | LPUART_STAT_OR      |
+                     LPUART_STAT_NF     | LPUART_STAT_FE      |
+                     LPUART_STAT_PF     | LPUART_STAT_MA1F    |
+                     LPUART_STAT_MA2F);
+
+      /* Keep what we will service */
+
       usr &= (LPUART_STAT_RDRF | LPUART_STAT_TDRE | LPUART_STAT_OR |
-              LPUART_STAT_FE | LPUART_STAT_NF | LPUART_STAT_PF |
+              LPUART_STAT_FE   | LPUART_STAT_NF   | LPUART_STAT_PF |
               LPUART_STAT_IDLE);
 
       /* Clear serial overrun, parity and framing errors */
 
       if ((usr & LPUART_STAT_OR) != 0)
         {
-          imxrt_serialout(priv, IMXRT_LPUART_STAT_OFFSET, LPUART_STAT_OR);
+          imxrt_serialout(priv, IMXRT_LPUART_STAT_OFFSET,
+                          lsr | LPUART_STAT_OR);
         }
 
       if ((usr & LPUART_STAT_NF) != 0)
         {
-          imxrt_serialout(priv, IMXRT_LPUART_STAT_OFFSET, LPUART_STAT_NF);
+          imxrt_serialout(priv, IMXRT_LPUART_STAT_OFFSET,
+                          lsr | LPUART_STAT_NF);
         }
 
       if ((usr & LPUART_STAT_PF) != 0)
         {
-          imxrt_serialout(priv, IMXRT_LPUART_STAT_OFFSET, LPUART_STAT_PF);
+          imxrt_serialout(priv, IMXRT_LPUART_STAT_OFFSET,
+                          lsr | LPUART_STAT_PF);
         }
 
       if ((usr & LPUART_STAT_FE) != 0)
         {
-          imxrt_serialout(priv, IMXRT_LPUART_STAT_OFFSET, LPUART_STAT_FE);
+          imxrt_serialout(priv, IMXRT_LPUART_STAT_OFFSET,
+                          lsr | LPUART_STAT_FE);
         }
 
       if ((usr & (LPUART_STAT_FE | LPUART_STAT_PF | LPUART_STAT_NF)) != 0)
@@ -1797,7 +1813,8 @@ static int imxrt_interrupt(int irq, void *context, void *arg)
 
       if ((usr & LPUART_STAT_IDLE) != 0)
         {
-          imxrt_serialout(priv, IMXRT_LPUART_STAT_OFFSET, LPUART_STAT_IDLE);
+          imxrt_serialout(priv, IMXRT_LPUART_STAT_OFFSET,
+                          lsr | LPUART_STAT_IDLE);
           imxrt_dma_rxcallback(priv->rxdma, priv, false, LPUART_STAT_IDLE);
         }
 #endif
@@ -2711,12 +2728,10 @@ static void imxrt_dma_rxcallback(DMACH_HANDLE handle, void *arg, bool done,
 
   sr = imxrt_serialin(priv, IMXRT_LPUART_STAT_OFFSET);
 
-  if ((sr & (LPUART_STAT_OR | LPUART_STAT_NF | LPUART_STAT_FE)) != 0)
+  if ((sr & (LPUART_STAT_OR | LPUART_STAT_NF | LPUART_STAT_FE |
+      LPUART_STAT_PF)) != 0)
     {
-      imxrt_serialout(priv, IMXRT_LPUART_STAT_OFFSET,
-                      sr & (LPUART_STAT_OR |
-                            LPUART_STAT_NF |
-                            LPUART_STAT_FE));
+      imxrt_serialout(priv, IMXRT_LPUART_STAT_OFFSET, sr);
     }
 }
 #endif

--- a/sched/semaphore/sem_trywait.c
+++ b/sched/semaphore/sem_trywait.c
@@ -70,10 +70,11 @@ int nxsem_trywait(FAR sem_t *sem)
   irqstate_t flags;
   int ret;
 
-  /* This API should not be called from interrupt handlers & idleloop */
+  /* This API should not be called from the idleloop */
 
-  DEBUGASSERT(sem != NULL && up_interrupt_context() == false);
-  DEBUGASSERT(!OSINIT_IDLELOOP() || !sched_idletask());
+  DEBUGASSERT(sem != NULL);
+  DEBUGASSERT(!OSINIT_IDLELOOP() || !sched_idletask() ||
+              up_interrupt_context());
 
   if (sem != NULL)
     {


### PR DESCRIPTION
## Summary

## Impact

## Testing

