### PR TITLE
[BACKPORT] s32k3: emac use semi-unique MAC address

### DIFF
--- a/arch/arm/src/s32k3xx/hardware/s32k3xx_memorymap.h
+++ b/arch/arm/src/s32k3xx/hardware/s32k3xx_memorymap.h
@@ -252,4 +252,8 @@
 #define S32K3XX_MCM_BASE         (0xe0080000) /* Miscellaneous Control Module */
 #define S32K3XX_ROMTABLE_BASE    (0xe00ff000) /* Cortex-M7 PPB ROM Table */
 
+/* UTEST (OTP) */
+#define S32K3XX_UTEST_BASE       (0x1b000000) /* UTEST */
+#define S32K3XX_UTEST_UID        (0x1b000040) /* UTEST UID OTP */
+
 #endif /* __ARCH_ARM_SRC_S32K3XX_HARDWARE_S32K3XX_MEMORYMAP_H */

--- a/arch/arm/src/s32k3xx/s32k3xx_emac.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_emac.c
@@ -3550,23 +3550,19 @@ int s32k3xx_netinitialize(int intf)
    * b1, 1st octet)
    */
 
-  /* hardcoded offset: todo: need proper header file */
-
   mac    = priv->dev.d_mac.ether.ether_addr_octet;
+  uidl   = getreg32(S32K3XX_UTEST_UID);
+  uidml  = getreg32(S32K3XX_UTEST_UID + 0x4);
+
   uidml |= 0x00000200;
   uidml &= 0x0000feff;
 
-  /* FIXME UTEST DCF records */
-
-  uidml = 0x2211;
-  uidl = 0x66554433;
-
-  mac[5] = (uidml & 0x000000ff);
-  mac[4] = (uidml & 0x0000ff00) >> 8;
-  mac[3] = (uidl &  0x000000ff);
-  mac[2] = (uidl &  0x0000ff00) >> 8;
-  mac[1] = (uidl &  0x00ff0000) >> 16;
-  mac[0] = (uidl &  0xff000000) >> 24;
+  mac[0] = (uidml & 0x0000ff00) >> 8;
+  mac[1] = (uidml & 0x000000ff);
+  mac[2] = (uidl &  0xff000000) >> 24;
+  mac[3] = (uidl &  0x00ff0000) >> 16;
+  mac[4] = (uidl &  0x0000ff00) >> 8;
+  mac[5] = (uidl &  0x000000ff);
 #endif
 
 #ifdef CONFIG_S32K3XX_ENET_PHYINIT


### PR DESCRIPTION
## Summary
Backport of semi-unique MAC address patch for S32K344
