### PR TITLE
Backport of nxp lpi2c calculated timeout can not be 0 #11000

### DIFF
--- a/arch/arm/src/imxrt/imxrt_lpi2c.c
+++ b/arch/arm/src/imxrt/imxrt_lpi2c.c
@@ -587,8 +587,9 @@ imxrt_lpi2c_sem_wait_noncancelable(struct imxrt_lpi2c_priv_s *priv)
 #ifdef CONFIG_IMXRT_LPI2C_DYNTIMEO
 static uint32_t imxrt_lpi2c_toticks(int msgc, struct i2c_msg_s *msgs)
 {
-  size_t bytecount = 0;
   int i;
+  size_t bytecount = 0;
+  uint32_t tick    = 0;
 
   /* Count the number of bytes left to process */
 
@@ -601,7 +602,13 @@ static uint32_t imxrt_lpi2c_toticks(int msgc, struct i2c_msg_s *msgs)
    * factor.
    */
 
-  return USEC2TICK(CONFIG_IMXRT_LPI2C_DYNTIMEO_USECPERBYTE * bytecount);
+  tick = USEC2TICK(CONFIG_IMXRT_LPI2C_DYNTIMEO_USECPERBYTE * bytecount);
+  if (tick == 0)
+    {
+      tick = 1;
+    }
+
+  return tick;
 }
 #endif
 

--- a/arch/arm/src/s32k1xx/s32k1xx_lpi2c.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_lpi2c.c
@@ -470,8 +470,9 @@ s32k1xx_lpi2c_sem_wait(struct s32k1xx_lpi2c_priv_s *priv)
 #ifdef CONFIG_S32K1XX_LPI2C_DYNTIMEO
 static uint32_t s32k1xx_lpi2c_toticks(int msgc, struct i2c_msg_s *msgs)
 {
-  size_t bytecount = 0;
   int i;
+  size_t bytecount = 0;
+  uint32_t tick    = 0;
 
   /* Count the number of bytes left to process */
 
@@ -481,10 +482,16 @@ static uint32_t s32k1xx_lpi2c_toticks(int msgc, struct i2c_msg_s *msgs)
     }
 
   /* Then return a number of microseconds based on a user provided scaling
-   * factor.
+   * factor. It must not be 0.
    */
 
-  return USEC2TICK(CONFIG_S32K1XX_LPI2C_DYNTIMEO_USECPERBYTE * bytecount);
+  tick = USEC2TICK(CONFIG_S32K1XX_LPI2C_DYNTIMEO_USECPERBYTE * bytecount);
+  if (tick == 0)
+    {
+      tick = 1;
+    }
+
+  return tick;
 }
 #endif
 

--- a/arch/arm/src/s32k3xx/s32k3xx_lpi2c.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_lpi2c.c
@@ -476,8 +476,9 @@ static inline int s32k3xx_lpi2c_sem_wait(struct s32k3xx_lpi2c_priv_s *priv)
 #ifdef CONFIG_S32K3XX_I2C_DYNTIMEO
 static uint32_t s32k3xx_lpi2c_toticks(int msgc, struct i2c_msg_s *msgs)
 {
-  size_t bytecount = 0;
   int i;
+  size_t bytecount = 0;
+  uint32_t tick    = 0;
 
   /* Count the number of bytes left to process */
 
@@ -490,7 +491,13 @@ static uint32_t s32k3xx_lpi2c_toticks(int msgc, struct i2c_msg_s *msgs)
    * factor.
    */
 
-  return USEC2TICK(CONFIG_S32K3XX_I2C_DYNTIMEO_USECPERBYTE * bytecount);
+  tick = USEC2TICK(CONFIG_S32K3XX_I2C_DYNTIMEO_USECPERBYTE * bytecount);
+  if (tick == 0)
+    {
+      tick = 1;
+    }
+
+  return tick;
 }
 #endif
 


### PR DESCRIPTION
## Summary
Use 1 tick if the calculated timeout is 0. Rounding of USEC2TICK with small calculated timeout could be 0. This results is a wait for completion of 0 causing all transactions to fail.

## Impact

System tick set to 10 ms. with a 1 ms CONFIG_xxxx_LPI2C_DYNTIMEO_USECPERBYTE would fail.

## Testing

S32K1XX in px4 on nxp_ucans32k146