### PR TITLE
BACKPORT NXP I2C non-DMA end only on stop with end of packet #11012

### DIFF
--- a/arch/arm/src/imxrt/imxrt_lpi2c.c
+++ b/arch/arm/src/imxrt/imxrt_lpi2c.c
@@ -1564,31 +1564,39 @@ static int imxrt_lpi2c_isr_process(struct imxrt_lpi2c_priv_s *priv)
                                     LPI2C_MSR_FEF | LPI2C_MSR_EPF)));
     }
 
-  /* Check for endof packet */
+  /* Check for endof packet or Stop */
 
   if ((status & (LPI2C_MSR_EPF | LPI2C_MSR_SDF)) != 0)
     {
+      /* Reset either or both */
+
       imxrt_lpi2c_putreg(priv, IMXRT_LPI2C_MSR_OFFSET, status &
                          (LPI2C_MSR_EPF | LPI2C_MSR_SDF));
 
-#ifndef CONFIG_I2C_POLLED
-      if (priv->intstate == INTSTATE_WAITING)
+      /* Was it both End of packet and Stop */
+
+      if ((status & (LPI2C_MSR_EPF | LPI2C_MSR_SDF)) ==
+          (LPI2C_MSR_EPF | LPI2C_MSR_SDF))
         {
-          /* inform the thread that transfer is complete
-           * and wake it up
-           */
+#ifndef CONFIG_I2C_POLLED
+          if (priv->intstate == INTSTATE_WAITING)
+            {
+              /* inform the thread that transfer is complete
+               * and wake it up
+               */
 
-          priv->intstate = INTSTATE_DONE;
+              priv->intstate = INTSTATE_DONE;
 
-          imxrt_lpi2c_modifyreg(priv, IMXRT_LPI2C_MIER_OFFSET,
-                               LPI2C_MIER_TDIE | LPI2C_MIER_RDIE |
-                               LPI2C_MIER_NDIE | LPI2C_MIER_ALIE |
-                               LPI2C_MIER_SDIE | LPI2C_MIER_EPIE, 0);
-          nxsem_post(&priv->sem_isr);
-        }
+              imxrt_lpi2c_modifyreg(priv, IMXRT_LPI2C_MIER_OFFSET,
+                                   LPI2C_MIER_TDIE | LPI2C_MIER_RDIE |
+                                   LPI2C_MIER_NDIE | LPI2C_MIER_ALIE |
+                                   LPI2C_MIER_SDIE | LPI2C_MIER_EPIE, 0);
+              nxsem_post(&priv->sem_isr);
+            }
 #else
-      priv->intstate = INTSTATE_DONE;
+          priv->intstate = INTSTATE_DONE;
 #endif
+        }
     }
 
   return OK;

--- a/arch/arm/src/s32k1xx/s32k1xx_lpi2c.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_lpi2c.c
@@ -1521,31 +1521,39 @@ static int s32k1xx_lpi2c_isr_process(struct s32k1xx_lpi2c_priv_s *priv)
                                       LPI2C_MSR_FEF | LPI2C_MSR_EPF)));
     }
 
-  /* Check for endof packet */
+  /* Check for endof packet or Stop */
 
   if ((status & (LPI2C_MSR_EPF | LPI2C_MSR_SDF)) != 0)
     {
+      /* Reset either or both */
+
       s32k1xx_lpi2c_putreg(priv, S32K1XX_LPI2C_MSR_OFFSET, status &
                            (LPI2C_MSR_EPF | LPI2C_MSR_SDF));
 
-#ifndef CONFIG_I2C_POLLED
-      if (priv->intstate == INTSTATE_WAITING)
+      /* Was it both End of packet and Stop */
+
+      if ((status & (LPI2C_MSR_EPF | LPI2C_MSR_SDF)) ==
+          (LPI2C_MSR_EPF | LPI2C_MSR_SDF))
         {
-          /* inform the thread that transfer is complete
-           * and wake it up
-           */
+#ifndef CONFIG_I2C_POLLED
+          if (priv->intstate == INTSTATE_WAITING)
+            {
+              /* inform the thread that transfer is complete
+               * and wake it up
+               */
 
-          priv->intstate = INTSTATE_DONE;
+              priv->intstate = INTSTATE_DONE;
 
-          s32k1xx_lpi2c_modifyreg(priv, S32K1XX_LPI2C_MIER_OFFSET,
-                               LPI2C_MIER_TDIE | LPI2C_MIER_RDIE |
-                               LPI2C_MIER_NDIE | LPI2C_MIER_ALIE |
-                               LPI2C_MIER_SDIE | LPI2C_MIER_EPIE, 0);
-          nxsem_post(&priv->sem_isr);
-        }
+              s32k1xx_lpi2c_modifyreg(priv, S32K1XX_LPI2C_MIER_OFFSET,
+                                      LPI2C_MIER_TDIE | LPI2C_MIER_RDIE |
+                                      LPI2C_MIER_NDIE | LPI2C_MIER_ALIE |
+                                      LPI2C_MIER_SDIE | LPI2C_MIER_EPIE, 0);
+              nxsem_post(&priv->sem_isr);
+            }
 #else
-      priv->intstate = INTSTATE_DONE;
+          priv->intstate = INTSTATE_DONE;
 #endif
+        }
     }
 
   return OK;

--- a/arch/arm/src/s32k3xx/s32k3xx_lpi2c.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_lpi2c.c
@@ -1495,31 +1495,39 @@ static int s32k3xx_lpi2c_isr_process(struct s32k3xx_lpi2c_priv_s *priv)
                                       LPI2C_MSR_FEF | LPI2C_MSR_EPF)));
     }
 
-  /* Check for endof packet */
+  /* Check for endof packet or Stop */
 
   if ((status & (LPI2C_MSR_EPF | LPI2C_MSR_SDF)) != 0)
     {
+      /* Reset either or both */
+
       s32k3xx_lpi2c_putreg(priv, S32K3XX_LPI2C_MSR_OFFSET, status &
                            (LPI2C_MSR_EPF | LPI2C_MSR_SDF));
 
-#ifndef CONFIG_I2C_POLLED
-      if (priv->intstate == INTSTATE_WAITING)
+      /* Was it both End of packet and Stop */
+
+      if ((status & (LPI2C_MSR_EPF | LPI2C_MSR_SDF)) ==
+          (LPI2C_MSR_EPF | LPI2C_MSR_SDF))
         {
-          /* inform the thread that transfer is complete
-           * and wake it up
-           */
+#ifndef CONFIG_I2C_POLLED
+          if (priv->intstate == INTSTATE_WAITING)
+            {
+              /* inform the thread that transfer is complete
+               * and wake it up
+               */
 
-          priv->intstate = INTSTATE_DONE;
+              priv->intstate = INTSTATE_DONE;
 
-          s32k3xx_lpi2c_modifyreg(priv, S32K3XX_LPI2C_MIER_OFFSET,
-                               LPI2C_MIER_TDIE | LPI2C_MIER_RDIE |
-                               LPI2C_MIER_NDIE | LPI2C_MIER_ALIE |
-                               LPI2C_MIER_SDIE | LPI2C_MIER_EPIE, 0);
-          nxsem_post(&priv->sem_isr);
-        }
+              s32k3xx_lpi2c_modifyreg(priv, S32K3XX_LPI2C_MIER_OFFSET,
+                                   LPI2C_MIER_TDIE | LPI2C_MIER_RDIE |
+                                   LPI2C_MIER_NDIE | LPI2C_MIER_ALIE |
+                                   LPI2C_MIER_SDIE | LPI2C_MIER_EPIE, 0);
+              nxsem_post(&priv->sem_isr);
+            }
 #else
-      priv->intstate = INTSTATE_DONE;
+          priv->intstate = INTSTATE_DONE;
 #endif
+        }
     }
 
   return OK;


### PR DESCRIPTION
## Summary

Addresses https://github.com/apache/nuttx/issues/10853 as reported by @thebolt

Non DMA version of the ISR was terminating on end of packet (EOP) or STOP but the sequences is EOP->STOP so we must acknowledge either but end on EOP and STOP.

## Impact

Non DMA driver was Broken

## Testing

imx1170 px4 nxp_fmurt1170-v1
