### PR TITLE
[BACKPORT] imxrt:serial Ensure the cache is updated if the DMA has up…

### DIFF
--- a/arch/arm/src/imxrt/imxrt_serial.c
+++ b/arch/arm/src/imxrt/imxrt_serial.c
@@ -1363,6 +1363,7 @@ static inline void imxrt_serialout(struct imxrt_uart_s *priv,
 static int imxrt_dma_nextrx(struct imxrt_uart_s *priv)
 {
   int dmaresidual = imxrt_dmach_getcount(priv->rxdma);
+  DEBUGASSERT(dmaresidual <= RXDMA_BUFFER_SIZE);
 
   return RXDMA_BUFFER_SIZE - dmaresidual;
 }
@@ -2333,14 +2334,26 @@ static bool imxrt_rxflowcontrol(struct uart_dev_s *dev,
 #ifdef SERIAL_HAVE_RXDMA
 static int imxrt_dma_receive(struct uart_dev_s *dev, unsigned int *status)
 {
-  struct imxrt_uart_s *priv = (struct imxrt_uart_s *)dev;
-  uint32_t nextrx = imxrt_dma_nextrx(priv);
-  int c = 0;
+  struct imxrt_uart_s *priv   = (struct imxrt_uart_s *)dev;
+  static uint32_t last_nextrx = -1;
+  uint32_t nextrx             = imxrt_dma_nextrx(priv);
+  int c                       = 0;
 
   /* Check if more data is available */
 
   if (nextrx != priv->rxdmanext)
     {
+      /* Now we must ensure the cache is updated if the DMA has
+       * updated again.
+       */
+
+      if (last_nextrx != nextrx)
+        {
+          up_invalidate_dcache((uintptr_t)priv->rxfifo,
+                               (uintptr_t)priv->rxfifo + RXDMA_BUFFER_SIZE);
+          last_nextrx = nextrx;
+        }
+
       /* Now read from the DMA buffer */
 
       c = priv->rxfifo[priv->rxdmanext];
@@ -2708,9 +2721,6 @@ static void imxrt_dma_rxcallback(DMACH_HANDLE handle, void *arg, bool done,
 {
   struct imxrt_uart_s *priv = (struct imxrt_uart_s *)arg;
   uint32_t sr;
-
-  up_invalidate_dcache((uintptr_t)priv->rxfifo,
-                       (uintptr_t)priv->rxfifo + RXDMA_BUFFER_SIZE);
 
   if (priv->rxenable && imxrt_dma_rxavailable(&priv->dev))
     {


### PR DESCRIPTION
…dated again

   The DMA can bring in more rx data, than the number of
   DMA completions call backs. The call back happen on
   idle, 1/2 and full events. But in between these events
   the DMA can write more data to the buffers memory that
   need to be brought in to the cache. (invalidate)

   We do the invalidate on the reads from the fifo memory
   if the the DMA as commited since the last read.

## Summary

## Impact

## Testing

