### PR TITLE
Backport of NXP lpi2c DMA transaction only need the status conditioned #11033

### DIFF
--- a/arch/arm/src/imxrt/imxrt_lpi2c.c
+++ b/arch/arm/src/imxrt/imxrt_lpi2c.c
@@ -1322,12 +1322,12 @@ static int imxrt_lpi2c_isr_process(struct imxrt_lpi2c_priv_s *priv)
 #ifdef CONFIG_IMXRT_LPI2C_DMA
   uint32_t current_status = status;
 
-  /* Condition the status with only the enabled interrupts */
-
-  status &= imxrt_lpi2c_getenabledints(priv);
-
   if (priv->dma != NULL)
     {
+      /* Condition the status with only the enabled interrupts */
+
+      status &= imxrt_lpi2c_getenabledints(priv);
+
       /* Is there an Error condition */
 
       if (current_status & LPI2C_MSR_LIMITED_ERROR_MASK)

--- a/arch/arm/src/s32k1xx/s32k1xx_lpi2c.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_lpi2c.c
@@ -1276,12 +1276,12 @@ static int s32k1xx_lpi2c_isr_process(struct s32k1xx_lpi2c_priv_s *priv)
 #ifdef CONFIG_S32K1XX_LPI2C_DMA
   uint32_t current_status = status;
 
-  /* Condition the status with only the enabled interrupts */
-
-  status &= s32k1xx_lpi2c_getenabledints(priv);
-
   if (priv->rxdma != NULL || priv->txdma != NULL)
     {
+      /* Condition the status with only the enabled interrupts */
+
+      status &= s32k1xx_lpi2c_getenabledints(priv);
+
       /* Is there an Error condition */
 
       if (current_status & LPI2C_MSR_LIMITED_ERROR_MASK)

--- a/arch/arm/src/s32k3xx/s32k3xx_lpi2c.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_lpi2c.c
@@ -1252,12 +1252,12 @@ static int s32k3xx_lpi2c_isr_process(struct s32k3xx_lpi2c_priv_s *priv)
 #ifdef CONFIG_S32K3XX_LPI2C_DMA
   uint32_t current_status = status;
 
-  /* Condition the status with only the enabled interrupts */
-
-  status &= s32k3xx_lpi2c_getenabledints(priv);
-
   if (priv->rxdma != NULL || priv->txdma != NULL)
     {
+      /* Condition the status with only the enabled interrupts */
+
+      status &= s32k3xx_lpi2c_getenabledints(priv);
+
       /* Is there an Error condition */
 
       if (current_status & LPI2C_MSR_LIMITED_ERROR_MASK)


### PR DESCRIPTION

## Summary

Related to https://github.com/apache/nuttx/issues/10853 & https://github.com/apache/nuttx/pull/11012

With DMA enabled on some I2C channels but not all the Non DMA channels were failing.

The cause was condition the status with only the enabled interrupts on non DMA chennels. This conditioning needs to only happen in DMA enabled channels


## Impact

Without this fix: With DMA enabled on some I2C channels but not all the Non DMA channels were failing.

## Testing

imx1170 PX4 nxp_fmurt1170-v1 (with I2C DMA on 1,2,3 and no DMA on 6)