### PR TITLE
Px4 firmware nuttx 10.3.0+ pr imx1170 mdio clk fix

### DIFF
--- a/arch/arm/src/imxrt/imxrt_enet.c
+++ b/arch/arm/src/imxrt/imxrt_enet.c
@@ -1598,6 +1598,10 @@ static int imxrt_ifdown(struct net_driver_s *dev)
 
   imxrt_reset(priv);
 
+  /* Configure the MII interface */
+
+  imxrt_initmii(priv);
+
   /* Mark the device "down" */
 
   priv->bifup = false;


### PR DESCRIPTION
## Summary
On imxrt1170 link status check stopped working after ifdown. This is because ifdown resets the mac including the mii interface. This patch reinitializes the mii after ifdown so that phy ioctl still work to check link status.
