### PR TITLE
[BACKPORT] stm32h7/serial: Do not wait on TXDMA semaphore

### DIFF
--- a/arch/arm/src/stm32h7/stm32_serial.c
+++ b/arch/arm/src/stm32h7/stm32_serial.c
@@ -3376,9 +3376,11 @@ static void up_dma_txavailable(struct uart_dev_s *dev)
 
   /* Only send when the DMA is idle */
 
-  nxsem_wait(&priv->txdmasem);
-
-  uart_xmitchars_dma(dev);
+  int rv = nxsem_trywait(&priv->txdmasem);
+  if (rv == OK)
+    {
+      uart_xmitchars_dma(dev);
+    }
 }
 #endif
 


### PR DESCRIPTION
If using flow control with a high CTS the thread may be blocked forever on the second transmit attempt due to waiting on the txdma semaphore. The calling thread can then never make progress and release any resources it has taken, thus may cause a deadlock in other parts of the system.

The implementation differs in behavior from interrupt-driven TX and the STM32F7 TXDMA . It should not implicitly wait on a taken semaphore but return immediately and let the upper layers decide on what to do next.

