### PR TITLE
[BACKPORT] fs/fat: Fix undefined behavior in signed integer overflow …

### DIFF
--- a/fs/fat/fs_fat32.c
+++ b/fs/fat/fs_fat32.c
@@ -45,6 +45,16 @@
 #include "fs_fat32.h"
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#if defined(CONFIG_FS_LARGEFILE)
+#  define OFF_MAX INT64_MAX
+#else
+#  define OFF_MAX INT32_MAX
+#endif
+
+/****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/
 
@@ -764,7 +774,7 @@ static ssize_t fat_write(FAR struct file *filep, FAR const char *buffer,
 
   /* Check if the file size would exceed the range of off_t */
 
-  if (ff->ff_size + buflen < ff->ff_size)
+  if (buflen > OFF_MAX || ff->ff_size > OFF_MAX - (off_t)buflen)
     {
       ret = -EFBIG;
       goto errout_with_semaphore;


### PR DESCRIPTION
…check
Resolves https://github.com/PX4/PX4-Autopilot/issues/22336#issuecomment-1805778504 

Testing for overflow by adding a value to a variable to see if it "wraps around" works only for unsigned integer values, because signed overflow has undefined behavior according to the C and C++ standards.

## Summary

## Impact

## Testing

