### PR TITLE
[PENDING] imxrt:gpio disable imxrt_gpio_select for the 1170

### DIFF
--- a/arch/arm/src/imxrt/imxrt_gpio.c
+++ b/arch/arm/src/imxrt/imxrt_gpio.c
@@ -265,7 +265,7 @@ static inline bool imxrt_gpio_getinput(int port, int pin)
 
 static inline int imxrt_gpio_select(int port, int pin)
 {
-#if IMXRT_GPIO_NPORTS > 5
+#if IMXRT_GPIO_NPORTS > 5 && defined(CONFIG_IMXRT_IOMUX_VER1)
   uint32_t gpr = port;
   uint32_t setbits = 1 << pin;
   uint32_t clearbits = 1 << pin;


### PR DESCRIPTION
   The 1170 usage of the GPR registers is to select the
   between GPIO{2|3} or CM7_GPIO{2|3} where as the 1060
   it selected ports between 1-6,2-7..4-9 and uses
   different GPR registers.

   For the 1170 we are defaulting to GPIO{2|3} and not
   supporting the swtich to CM7_GPIO{2|3}.

## Summary

## Impact

## Testing

