### PR TITLE
[BACKPORT] Multi PHY support

### DIFF
--- a/arch/arm/src/imxrt/imxrt_enet.c
+++ b/arch/arm/src/imxrt/imxrt_enet.c
@@ -199,8 +199,9 @@
 #  error "Need at least one RX buffer"
 #endif
 
-/*
- * From ref manual TDSR/RDSR description
+#define nitems(_a)    (sizeof(_a) / sizeof(0[(_a)]))
+
+/* From ref manual TDSR/RDSR description
  * For optimal performance the pointer should be 512-bit aligned, that is,
  * evenly divisible by 64.
  */
@@ -250,8 +251,25 @@
  * ...and further PHY descriptions here.
  */
 
-#if defined(CONFIG_ETH0_PHY_KSZ8081)
-#  define BOARD_PHY_NAME        "KSZ8081"
+#if defined(CONFIG_ETH0_PHY_MULTI)
+#  if !defined(BOARD_ETH0_PHY_LIST)
+#    error "CONFIG_ETH0_PHY_MULTI requires board.h to define BOARD_ETH0_PHY_LIST!"
+#  endif
+#  define BOARD_PHY_NAME        g_board_phys[priv->current_phy].name
+#  define BOARD_PHYID1          g_board_phys[priv->current_phy].id1
+#  define BOARD_PHYID2          g_board_phys[priv->current_phy].id2
+#  define BOARD_PHY_STATUS      g_board_phys[priv->current_phy].status
+#  define BOARD_PHY_ADDR        priv->current_phy_address
+#  define BOARD_PHY_10BASET(s)  (imxrt_phy_status(priv, (s), g_board_phys[priv->current_phy].mbps10) != 0)
+#  define BOARD_PHY_100BASET(s) (imxrt_phy_status(priv, (s), g_board_phys[priv->current_phy].mbps100) != 0)
+#  define BOARD_PHY_ISDUPLEX(s) (imxrt_phy_status(priv, (s), g_board_phys[priv->current_phy].duplex) != 0)
+#  define BOARD_PHY_ISCLAUSE45() (g_board_phys[priv->current_phy].clause == 45)
+#  define CLAUSE45
+#  define MMD1                  1
+#  define MMD1_PMA_STATUS1      1
+#  define MMD1_PS1_RECEIVE_LINK_STATUS (1 << 2)
+#elif defined(CONFIG_ETH0_PHY_KSZ8081)
+#  define BOARD_PHY_NAME        MII_KSZ8081_NAME
 #  define BOARD_PHYID1          MII_PHYID1_KSZ8081
 #  define BOARD_PHYID2          MII_PHYID2_KSZ8081
 #  define BOARD_PHY_STATUS      MII_KSZ8081_PHYCTRL1
@@ -260,7 +278,7 @@
 #  define BOARD_PHY_100BASET(s) (((s) & MII_PHYCTRL1_MODE_100HDX) != 0)
 #  define BOARD_PHY_ISDUPLEX(s) (((s) & MII_PHYCTRL1_MODE_DUPLEX) != 0)
 #elif defined(CONFIG_ETH0_PHY_LAN8720)
-#  define BOARD_PHY_NAME        "LAN8720"
+#  define BOARD_PHY_NAME        MII_LAN8720_NAME
 #  define BOARD_PHYID1          MII_PHYID1_LAN8720
 #  define BOARD_PHYID2          MII_PHYID2_LAN8720
 #  define BOARD_PHY_STATUS      MII_LAN8720_SCSR
@@ -269,7 +287,7 @@
 #  define BOARD_PHY_100BASET(s) (((s)&MII_LAN8720_SPSCR_100MBPS) != 0)
 #  define BOARD_PHY_ISDUPLEX(s) (((s)&MII_LAN8720_SPSCR_DUPLEX) != 0)
 #elif defined(CONFIG_ETH0_PHY_LAN8742A)
-#  define BOARD_PHY_NAME        "LAN8742A"
+#  define BOARD_PHY_NAME        MII_LAN8742A_NAME
 #  define BOARD_PHYID1          MII_PHYID1_LAN8742A
 #  define BOARD_PHYID2          MII_PHYID2_LAN8742A
 #  define BOARD_PHY_STATUS      MII_LAN8740_SCSR
@@ -278,7 +296,7 @@
 #  define BOARD_PHY_100BASET(s) (((s)&MII_LAN8720_SPSCR_100MBPS) != 0)
 #  define BOARD_PHY_ISDUPLEX(s) (((s)&MII_LAN8720_SPSCR_DUPLEX) != 0)
 #elif defined(CONFIG_ETH0_PHY_DP83825I)
-#  define BOARD_PHY_NAME        "DP83825I"
+#  define BOARD_PHY_NAME        MII_DP83825I_NAME
 #  define BOARD_PHYID1          MII_PHYID1_DP83825I
 #  define BOARD_PHYID2          MII_PHYID2_DP83825I
 #  define BOARD_PHY_STATUS      MII_DP83825I_PHYSTS
@@ -287,7 +305,7 @@
 #  define BOARD_PHY_100BASET(s) (((s) & MII_DP83825I_PHYSTS_SPEED) == 0)
 #  define BOARD_PHY_ISDUPLEX(s) (((s) & MII_DP83825I_PHYSTS_DUPLEX) != 0)
 #elif defined(CONFIG_ETH0_PHY_TJA1103)
-#  define BOARD_PHY_NAME        "TJA1103"
+#  define BOARD_PHY_NAME        MII_TJA1103_NAME
 #  define BOARD_PHYID1          MII_PHYID1_TJA1103
 #  define BOARD_PHYID2          MII_PHYID2_TJA1103
 #  define BOARD_PHY_STATUS      MII_TJA110X_BSR
@@ -299,6 +317,15 @@
 #  define MMD1                  1
 #  define MMD1_PMA_STATUS1      1
 #  define MMD1_PS1_RECEIVE_LINK_STATUS (1 << 2)
+#elif defined(CONFIG_ETH0_PHY_YT8512)
+#  define BOARD_PHY_NAME        MII_YT8512_NAME
+#  define BOARD_PHYID1          MII_PHYID1_YT8512
+#  define BOARD_PHYID2          MII_PHYID2_YT8512
+#  define BOARD_PHY_STATUS      MII_YT8512_PHYSTS
+#  define BOARD_PHY_ADDR        (0)
+#  define BOARD_PHY_10BASET(s)  (((s) & MII_YT8512_PHYSTS_SPEED) == 0)
+#  define BOARD_PHY_100BASET(s) (((s) & MII_YT8512_PHYSTS_SPEED) != 0)
+#  define BOARD_PHY_ISDUPLEX(s) (((s) & MII_YT8512_PHYSTS_DUPLEX) != 0)
 #else
 #  error "Unrecognized or missing PHY selection"
 #endif
@@ -366,6 +393,10 @@ struct imxrt_driver_s
   struct enet_desc_s *txdesc;  /* A pointer to the list of TX descriptor */
   struct enet_desc_s *rxdesc;  /* A pointer to the list of RX descriptors */
 
+#if defined(CONFIG_ETH0_PHY_MULTI)
+  uint8_t  current_phy;         /* The index of the PHY being used */
+  uint8_t  current_phy_address; /* The address of the PHY being used */
+#endif
   /* This holds the information visible to the NuttX network */
 
   struct net_driver_s dev;     /* Interface understood by the network */
@@ -374,6 +405,15 @@ struct imxrt_driver_s
 /****************************************************************************
  * Private Data
  ****************************************************************************/
+
+/* BOARD_ETH0_PHY_LIST provided by the board.h for  CONFIG_ETH0_PHY_MULTI */
+
+#if defined(CONFIG_ETH0_PHY_MULTI)
+const struct phy_desc_s  g_board_phys[] =
+    {
+        BOARD_ETH0_PHY_LIST
+    };
+#endif
 
 static struct imxrt_driver_s g_enet[CONFIG_IMXRT_ENET_NETHIFS];
 
@@ -460,6 +500,13 @@ static int  imxrt_ioctl(struct net_driver_s *dev, int cmd,
 #endif
 
 /* PHY/MII support */
+
+#if defined(CONFIG_ETH0_PHY_MULTI)
+static int imxrt_phy_is(struct imxrt_driver_s *priv, const char *name);
+static int imxrt_phy_status(struct imxrt_driver_s *priv, int phydata,
+                            uint16_t mask);
+static int imxrt_determine_phy(struct imxrt_driver_s *priv);
+#endif
 
 #if defined(CONFIG_NETDEV_PHY_IOCTL) && defined(CONFIG_ARCH_PHY_INTERRUPT)
 static int imxrt_phyintenable(struct imxrt_driver_s *priv);
@@ -699,7 +746,7 @@ static int imxrt_transmit(struct imxrt_driver_s *priv)
    */
 
   txdesc->length   = imxrt_swap16(priv->dev.d_len);
-#ifdef CONFIG_IMXRT_ENETENHANCEDBD
+#ifdef CONFIG_IMXRT_ENET_ENHANCEDBD
   txdesc->bdu      = 0x00000000;
   txdesc->status2  = TXDESC_INT | TXDESC_TS; /* | TXDESC_IINS | TXDESC_PINS; */
 #endif
@@ -729,6 +776,7 @@ static int imxrt_transmit(struct imxrt_driver_s *priv)
 
 #ifdef CONFIG_ARMV7M_DCACHE_WRITETHROUGH
   /* Make sure that descriptors are flushed */
+
   ARM_DSB();
 #else
   up_clean_dcache((uintptr_t)txdesc,
@@ -1434,6 +1482,15 @@ static int imxrt_ifup_action(struct net_driver_s *dev, bool resetphy)
 
   /* Configure the PHY */
 
+#if defined(CONFIG_ETH0_PHY_MULTI)
+  ret = imxrt_determine_phy(priv);
+  if (ret < 0)
+    {
+      nerr("ERROR: Failed to determine the PHY: %d\n", ret);
+      return ret;
+    }
+#endif
+
   ret = imxrt_initphy(priv, resetphy);
   if (ret < 0)
     {
@@ -1451,7 +1508,7 @@ static int imxrt_ifup_action(struct net_driver_s *dev, bool resetphy)
 
   /* Select legacy of enhanced buffer descriptor format */
 
-#ifdef CONFIG_IMXRT_ENETENHANCEDBD
+#ifdef CONFIG_IMXRT_ENET_ENHANCEDBD
   imxrt_enet_putreg32(priv, ENET_ECR_EN1588, IMXRT_ENET_ECR_OFFSET);
 #else
   imxrt_enet_putreg32(priv, 0, IMXRT_ENET_ECR_OFFSET);
@@ -1481,6 +1538,7 @@ static int imxrt_ifup_action(struct net_driver_s *dev, bool resetphy)
 
 #ifdef CONFIG_ARMV7M_DCACHE_WRITETHROUGH
   /* Make sure that descriptors are flushed */
+
   ARM_DSB();
 #endif
 
@@ -1930,7 +1988,11 @@ static int imxrt_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg)
           struct mii_ioctl_data_s *req =
             (struct mii_ioctl_data_s *)((uintptr_t)arg);
 #if defined(CLAUSE45)
-          if (MII_MSR == req->reg_num)
+          if (
+#  if defined(CONFIG_ETH0_PHY_MULTI)
+              BOARD_PHY_ISCLAUSE45() &&
+#  endif
+              MII_MSR == req->reg_num)
             {
               ret = imxrt_readmmd(priv, req->phy_id, MMD1, MMD1_PMA_STATUS1,
                                   &req->val_out);
@@ -1985,28 +2047,59 @@ static int imxrt_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg)
 static int imxrt_phyintenable(struct imxrt_driver_s *priv)
 {
 #if defined(CONFIG_ETH0_PHY_KSZ8051) || defined(CONFIG_ETH0_PHY_KSZ8061) || \
-    defined(CONFIG_ETH0_PHY_KSZ8081) || defined(CONFIG_ETH0_PHY_DP83825I)
+    defined(CONFIG_ETH0_PHY_KSZ8081) || defined(CONFIG_ETH0_PHY_DP83825I) || \
+    defined(CONFIG_ETH0_YT8512)      || defined(CONFIG_ETH0_PHY_MULTI)
+
   uint16_t phyval;
   int ret;
+
+  /* Compile time Kzxxxx defaults */
+
+  uint16_t mask = MII_KSZ80X1_INT_LDEN | MII_KSZ80X1_INT_LUEN;
+  uint8_t  rreg = MII_KSZ8081_INT;
+  uint8_t  wreg = rreg;
+
+  /* Compile time YT8512 defaults */
+#  if defined(CONFIG_ETH0_YT8512)
+  mask = MII_YT8512_IMR_LD_EN | MII_YT8512_IMR_LU_EN;
+  rreg  = MII_YT8512_ISR;
+  wreg  = MII_YT8512_IMR;
+#  endif
+
+  /* Run time YT8512 defaults */
+#  if defined(CONFIG_ETH0_PHY_MULTI)
+  if (imxrt_phy_is(priv, MII_YT8512_NAME))
+    {
+      mask = MII_YT8512_IMR_LD_EN | MII_YT8512_IMR_LU_EN;
+      rreg  = MII_YT8512_ISR;
+      wreg  = MII_YT8512_IMR;
+    }
+  else if (!(imxrt_phy_is(priv, MII_KSZ8051_NAME) ||
+             imxrt_phy_is(priv, MII_KSZ8061_NAME) ||
+             imxrt_phy_is(priv, MII_KSZ8081_NAME) ||
+             imxrt_phy_is(priv, MII_DP83825I_NAME)))
+    {
+      return -ENOSYS;
+    }
+#  endif
 
   /* Read the interrupt status register in order to clear any pending
    * interrupts
    */
 
-  ret = imxrt_readmii(priv, priv->phyaddr, MII_KSZ8081_INT, &phyval);
+  ret = imxrt_readmii(priv, priv->phyaddr, rreg, &phyval);
   if (ret == OK)
     {
       /* Enable link up/down interrupts */
 
-      ret = imxrt_writemii(priv, priv->phyaddr, MII_KSZ8081_INT,
-                           (MII_KSZ80X1_INT_LDEN | MII_KSZ80X1_INT_LUEN));
+      ret = imxrt_writemii(priv, priv->phyaddr, wreg, mask);
     }
 
   return ret;
 #else
 #  error Unrecognized PHY
   return -ENOSYS;
-#endif
+#  endif
 }
 #endif
 
@@ -2161,6 +2254,126 @@ static int imxrt_readmii(struct imxrt_driver_s *priv, uint8_t phyaddr,
                                     ENET_MMFR_DATA_MASK);
   return OK;
 }
+
+#if defined(CONFIG_ETH0_PHY_MULTI)
+/****************************************************************************
+ * Function: imxrt_determine_phy
+ *
+ * Description:
+ *   Uses the board.h supplied PHY list to determine which PHY
+ *   is populated on this board.
+ *
+ * Input Parameters:
+ *   priv - Reference to the private ENET driver state structure
+ *
+ * Returned Value:
+ *   Zero on success, a -ENOENT errno value on failure.
+ *
+ ****************************************************************************/
+
+static int imxrt_determine_phy(struct imxrt_driver_s *priv)
+{
+  uint16_t phydata     = 0xffff;
+  uint8_t phyaddr      = 0;
+  uint8_t last_phyaddr = 0;
+  int retries;
+  int ret;
+
+  for (priv->current_phy = 0; priv->current_phy < nitems(g_board_phys);
+      priv->current_phy++)
+    {
+      priv->current_phy_address =
+          (uint8_t) g_board_phys[priv->current_phy].address_lo;
+      last_phyaddr = g_board_phys[priv->current_phy].address_high == 0xffff ?
+          priv->current_phy_address :
+          (uint8_t) g_board_phys[priv->current_phy].address_high;
+
+      for (phyaddr = priv->current_phy_address; phyaddr <= last_phyaddr;
+          phyaddr++)
+        {
+          retries = 0;
+          do
+            {
+              nxsig_usleep(100);
+              phydata = 0xffff;
+              ret = imxrt_readmii(priv, phyaddr, MII_PHYID1, &phydata);
+            }
+          while ((ret < 0 || phydata == 0xffff) && ++retries < 3);
+
+          if (retries <= 3 && ret == 0 &&
+              phydata == g_board_phys[priv->current_phy].id1)
+            {
+              do
+                {
+                  nxsig_usleep(100);
+                  phydata = 0xffff;
+                  ret = imxrt_readmii(priv, phyaddr, MII_PHYID2, &phydata);
+                }
+              while ((ret < 0 || phydata == 0xffff) && ++retries < 3);
+              if (retries <= 3 && ret == 0 &&
+                  (phydata & 0xfff0) ==
+                  (g_board_phys[priv->current_phy].id2 & 0xfff0))
+                {
+                  return OK;
+                }
+            }
+        }
+    }
+
+  return -ENOENT;
+}
+
+/****************************************************************************
+ * Function: imxrt_phy_is
+ *
+ * Description:
+ *   Compares the name with the current selected PHY's name
+ *
+ * Input Parameters:
+ *   priv - Reference to the private ENET driver state structure
+ *   name - a pointer to comapre to.
+ *
+ * Returned Value:
+ *   1 on match, a 0 on no match.
+ *
+ ****************************************************************************/
+
+static int imxrt_phy_is(struct imxrt_driver_s *priv, const char *name)
+{
+  return strcmp(g_board_phys[priv->current_phy].name, name) == 0;
+}
+
+/****************************************************************************
+ * Function: imxrt_phy_status
+ *
+ * Description:
+ *   Compares the name with the current selected PHY's name.
+ *
+ * Input Parameters:
+ *   priv    - Reference to the private ENET driver state structure
+ *   phydata - last read phy data - may be ignored if there is no
+ *             status register defined by the current PHY.
+ *   mask - A value to and with phydata if a status register is
+ *          defined. Or the value retunred if no status register is
+ *          defined.
+ *
+ * Returned Value:
+ *   mask or (phydat & mask)
+ *
+ ****************************************************************************/
+
+static int imxrt_phy_status(struct imxrt_driver_s *priv, int phydata,
+                            uint16_t mask)
+{
+  int rv = mask;
+  if (g_board_phys[priv->current_phy].status != 0xffff)
+    {
+      rv &= phydata;
+    }
+
+  return rv;
+}
+#endif
 
 #if 0
 #if defined(CLAUSE45)
@@ -2457,176 +2670,265 @@ static inline int imxrt_initphy(struct imxrt_driver_s *priv, bool renogphy)
           return -ENXIO;
         }
 
-#ifdef CONFIG_ETH0_PHY_KSZ8081
-      /* Reset PHY */
-
-      imxrt_writemii(priv, phyaddr, MII_MCR, MII_MCR_RESET);
-
-      /* Set RMII mode */
-
-      ret = imxrt_readmii(priv, phyaddr, MII_KSZ8081_PHYCTRL2, &phydata);
-      if (ret < 0)
+#if defined(CONFIG_ETH0_PHY_KSZ8081) || defined(CONFIG_ETH0_PHY_MULTI)
+#  if defined(CONFIG_ETH0_PHY_MULTI)
+      if (imxrt_phy_is(priv, MII_KSZ8081_NAME))
         {
-          nerr("ERROR: Failed to read MII_KSZ8081_PHYCTRL2\n");
-          return ret;
-        }
+#  endif
+          /* Reset PHY */
 
-      /* Indicate 50MHz clock */
+          imxrt_writemii(priv, phyaddr, MII_MCR, MII_MCR_RESET);
 
-      imxrt_writemii(priv, phyaddr, MII_KSZ8081_PHYCTRL2,
-                     (phydata | (1 << 7)));
+          /* Set RMII mode */
 
-      /* Switch off NAND Tree mode (in case it was set via pinning) */
-
-      ret = imxrt_readmii(priv, phyaddr, MII_KSZ8081_OMSO, &phydata);
-      if (ret < 0)
-        {
-          nerr("ERROR: Failed to read MII_KSZ8081_OMSO: %d\n", ret);
-          return ret;
-        }
-
-      imxrt_writemii(priv, phyaddr, MII_KSZ8081_OMSO,
-                     (phydata & ~(1 << 5)));
-
-      /* Set Ethernet led to green = activity and yellow = link and  */
-
-      ret = imxrt_readmii(priv, phyaddr, MII_KSZ8081_PHYCTRL2, &phydata);
-      if (ret < 0)
-        {
-          nerr("ERROR: Failed to read MII_KSZ8081_PHYCTRL2\n");
-          return ret;
-        }
-
-      imxrt_writemii(priv, phyaddr, MII_KSZ8081_PHYCTRL2,
-                     (phydata | (1 << 4)));
-
-      imxrt_writemii(priv, phyaddr, MII_ADVERTISE,
-                     MII_ADVERTISE_100BASETXFULL |
-                     MII_ADVERTISE_100BASETXHALF |
-                     MII_ADVERTISE_10BASETXFULL |
-                     MII_ADVERTISE_10BASETXHALF |
-                     MII_ADVERTISE_CSMA);
-
-#elif defined (CONFIG_ETH0_PHY_LAN8720) || defined (CONFIG_ETH0_PHY_LAN8742A)
-      /* Make sure that PHY comes up in correct mode when it's reset */
-
-      imxrt_writemii(priv, phyaddr, MII_LAN8720_MODES,
-                     MII_LAN8720_MODES_RESV | MII_LAN8720_MODES_ALL |
-                     MII_LAN8720_MODES_PHYAD(BOARD_PHY_ADDR));
-
-      /* ...and reset PHY */
-
-      imxrt_writemii(priv, phyaddr, MII_MCR, MII_MCR_RESET);
-
-#elif defined (CONFIG_ETH0_PHY_DP83825I)
-
-      /* Reset PHY */
-
-      imxrt_writemii(priv, phyaddr, MII_MCR, MII_MCR_RESET);
-
-      /* Set RMII mode and Indicate 50MHz clock */
-
-      imxrt_writemii(priv, phyaddr, MII_DP83825I_RCSR,
-                    MII_DP83825I_RCSC_ELAST_2 | MII_DP83825I_RCSC_RMIICS);
-
-      imxrt_writemii(priv, phyaddr, MII_ADVERTISE,
-                     MII_ADVERTISE_100BASETXFULL |
-                     MII_ADVERTISE_100BASETXHALF |
-                     MII_ADVERTISE_10BASETXFULL |
-                     MII_ADVERTISE_10BASETXHALF |
-                     MII_ADVERTISE_CSMA);
-
-#endif
-#if !defined(CONFIG_ETH0_PHY_TJA1103)
-
-      /* Start auto negotiation */
-
-      ninfo("%s: Start Autonegotiation...\n",  BOARD_PHY_NAME);
-      imxrt_writemii(priv, phyaddr, MII_MCR,
-                     (MII_MCR_ANRESTART | MII_MCR_ANENABLE));
-
-      /* Wait for auto negotiation to complete */
-
-      for (retries = 0; retries < LINK_NLOOPS; retries++)
-        {
-          ret = imxrt_readmii(priv, phyaddr, MII_MSR, &phydata);
+          ret = imxrt_readmii(priv, phyaddr, MII_KSZ8081_PHYCTRL2, &phydata);
           if (ret < 0)
             {
-              nerr("ERROR: Failed to read %s MII_MSR: %d\n",
-                    BOARD_PHY_NAME, ret);
+              nerr("ERROR: Failed to read MII_KSZ8081_PHYCTRL2\n");
               return ret;
+            }
+
+          /* Indicate 50MHz clock */
+
+          imxrt_writemii(priv, phyaddr, MII_KSZ8081_PHYCTRL2,
+                         (phydata | (1 << 7)));
+
+          /* Switch off NAND Tree mode (in case it was set via pinning) */
+
+          ret = imxrt_readmii(priv, phyaddr, MII_KSZ8081_OMSO, &phydata);
+          if (ret < 0)
+            {
+              nerr("ERROR: Failed to read MII_KSZ8081_OMSO: %d\n", ret);
+              return ret;
+            }
+
+          imxrt_writemii(priv, phyaddr, MII_KSZ8081_OMSO,
+                         (phydata & ~(1 << 5)));
+
+          /* Set Ethernet led to green = activity and yellow = link and  */
+
+          ret = imxrt_readmii(priv, phyaddr, MII_KSZ8081_PHYCTRL2, &phydata);
+          if (ret < 0)
+            {
+              nerr("ERROR: Failed to read MII_KSZ8081_PHYCTRL2\n");
+              return ret;
+            }
+
+          imxrt_writemii(priv, phyaddr, MII_KSZ8081_PHYCTRL2,
+                         (phydata | (1 << 4)));
+
+          imxrt_writemii(priv, phyaddr, MII_ADVERTISE,
+                         MII_ADVERTISE_100BASETXFULL |
+                         MII_ADVERTISE_100BASETXHALF |
+                         MII_ADVERTISE_10BASETXFULL |
+                         MII_ADVERTISE_10BASETXHALF |
+                         MII_ADVERTISE_CSMA);
+#  if defined(CONFIG_ETH0_PHY_MULTI)
+        }
+
+#  endif
+#endif
+#if defined (CONFIG_ETH0_PHY_LAN8720)  || \
+    defined (CONFIG_ETH0_PHY_LAN8742A) || \
+    defined (CONFIG_ETH0_PHY_MULTI)
+
+#  if defined(CONFIG_ETH0_PHY_MULTI)
+      if (imxrt_phy_is(priv, MII_LAN8720_NAME) ||
+          imxrt_phy_is(priv, MII_LAN8742A_NAME))
+        {
+#  endif
+
+          /* Make sure that PHY comes up in correct mode when it's reset */
+
+          imxrt_writemii(priv, phyaddr, MII_LAN8720_MODES,
+                         MII_LAN8720_MODES_RESV | MII_LAN8720_MODES_ALL |
+                         MII_LAN8720_MODES_PHYAD(BOARD_PHY_ADDR));
+
+          /* ...and reset PHY */
+
+          imxrt_writemii(priv, phyaddr, MII_MCR, MII_MCR_RESET);
+
+#  if defined(CONFIG_ETH0_PHY_MULTI)
+        }
+#  endif
+#endif
+#if defined (CONFIG_ETH0_PHY_DP83825I) || defined (CONFIG_ETH0_PHY_MULTI)
+
+#if defined(CONFIG_ETH0_PHY_MULTI)
+      if (imxrt_phy_is(priv, MII_DP83825I_NAME))
+        {
+#endif
+
+          /* Reset PHY */
+
+          imxrt_writemii(priv, phyaddr, MII_MCR, MII_MCR_RESET);
+
+          /* Set RMII mode and Indicate 50MHz clock */
+
+          imxrt_writemii(priv, phyaddr, MII_DP83825I_RCSR,
+                        MII_DP83825I_RCSC_ELAST_2 |
+                        MII_DP83825I_RCSC_RMIICS);
+
+          imxrt_writemii(priv, phyaddr, MII_ADVERTISE,
+                         MII_ADVERTISE_100BASETXFULL |
+                         MII_ADVERTISE_100BASETXHALF |
+                         MII_ADVERTISE_10BASETXFULL |
+                         MII_ADVERTISE_10BASETXHALF |
+                         MII_ADVERTISE_CSMA);
+
+#  if defined(CONFIG_ETH0_PHY_MULTI)
+        }
+#  endif
+#endif
+
+#if defined(CONFIG_ETH0_PHY_YT8512) || defined(CONFIG_ETH0_PHY_MULTI)
+#  if defined(CONFIG_ETH0_PHY_MULTI)
+      if (!imxrt_phy_is(priv, MII_YT8512_NAME))
+        {
+#  endif
+          /* Reset PHY */
+
+          imxrt_writemii(priv, phyaddr, MII_MCR, MII_MCR_RESET);
+
+          /* Config LEDs */
+
+          imxrt_writemii(priv, phyaddr, MII_YT8512_DEBUG_ADDR_OFFSET,
+                         MII_YT8512_LED0);
+
+          imxrt_readmii(priv, phyaddr, MII_YT8512_DEBUG_DATA, &phydata);
+
+          imxrt_writemii(priv, phyaddr, MII_YT8512_DEBUG_ADDR_OFFSET,
+                         MII_YT8512_LED0);
+
+          imxrt_writemii(priv, phyaddr, MII_YT8512_DEBUG_DATA, 0x331);
+
+          imxrt_writemii(priv, phyaddr, MII_YT8512_DEBUG_ADDR_OFFSET,
+                         MII_YT8512_LED1);
+
+          imxrt_readmii(priv, phyaddr, MII_YT8512_DEBUG_DATA, &phydata);
+
+          imxrt_writemii(priv, phyaddr, MII_YT8512_DEBUG_ADDR_OFFSET,
+                         MII_YT8512_LED1);
+
+          imxrt_writemii(priv, phyaddr, MII_YT8512_DEBUG_DATA, 0x30);
+
+          /* Set negotiation */
+
+          imxrt_writemii(priv, phyaddr, MII_ADVERTISE,
+                         MII_ADVERTISE_100BASETXFULL |
+                         MII_ADVERTISE_100BASETXHALF |
+                         MII_ADVERTISE_10BASETXFULL |
+                         MII_ADVERTISE_10BASETXHALF |
+                         MII_ADVERTISE_CSMA);
+
+#  if defined(CONFIG_ETH0_PHY_MULTI)
+        }
+#  endif
+#endif
+
+#if !defined(CONFIG_ETH0_PHY_TJA1103)
+#if defined(CONFIG_ETH0_PHY_MULTI)
+      if (!imxrt_phy_is(priv, MII_TJA1103_NAME))
+        {
+#endif
+          /* Start auto negotiation */
+
+          ninfo("%s: Start Autonegotiation...\n",  BOARD_PHY_NAME);
+          imxrt_writemii(priv, phyaddr, MII_MCR,
+                         (MII_MCR_ANRESTART | MII_MCR_ANENABLE));
+
+          /* Wait for auto negotiation to complete */
+
+          for (retries = 0; retries < LINK_NLOOPS; retries++)
+            {
+              ret = imxrt_readmii(priv, phyaddr, MII_MSR, &phydata);
+              if (ret < 0)
+                {
+                  nerr("ERROR: Failed to read %s MII_MSR: %d\n",
+                        BOARD_PHY_NAME, ret);
+                  return ret;
+                }
+
+              if (phydata & MII_MSR_ANEGCOMPLETE)
+                {
+                  break;
+                }
+
+              nxsig_usleep(LINK_WAITUS);
             }
 
           if (phydata & MII_MSR_ANEGCOMPLETE)
             {
-              break;
+              ninfo("%s: Autonegotiation complete\n",  BOARD_PHY_NAME);
+              ninfo("%s: MII_MSR: %04x\n", BOARD_PHY_NAME, phydata);
             }
+          else
+            {
+              /* TODO: Autonegotiation has right now failed. Maybe the Eth
+               * cable is not connected.  PHY chip have mechanisms to
+               * configure link OK. We should leave autconf on, and find a
+               * way to re-configure MCU whenever the link is ready.
+               */
 
-          nxsig_usleep(LINK_WAITUS);
+              ninfo("%s: Autonegotiation failed [%d] (is cable plugged-in ?)"
+                    ", default to 10Mbs mode\n",
+                    BOARD_PHY_NAME, retries);
+
+              /* Stop auto negotiation */
+
+              imxrt_writemii(priv, phyaddr, MII_MCR, 0);
+            }
+#  if defined(CONFIG_ETH0_PHY_MULTI)
         }
-
-      if (phydata & MII_MSR_ANEGCOMPLETE)
-        {
-          ninfo("%s: Autonegotiation complete\n",  BOARD_PHY_NAME);
-          ninfo("%s: MII_MSR: %04x\n", BOARD_PHY_NAME, phydata);
-        }
-      else
-        {
-          /* TODO: Autonegotiation has right now failed. Maybe the Eth cable
-           * is not connected.  PHY chip have mechanisms to configure link
-           * OK. We should leave autconf on, and find a way to re-configure
-           * MCU whenever the link is ready.
-           */
-
-          ninfo("%s: Autonegotiation failed [%d] (is cable plugged-in ?), "
-                "default to 10Mbs mode\n", \
-                BOARD_PHY_NAME, retries);
-
-          /* Stop auto negotiation */
-
-          imxrt_writemii(priv, phyaddr, MII_MCR, 0);
-        }
+#  endif
 #endif
     }
 
 #if !defined(CONFIG_ETH0_PHY_TJA1103)
-  /* When we get here we have a (negotiated) speed and duplex. This is also
-   * the point we enter if renegotiation is turned off, so have multiple
-   * attempts at reading the status register in case the PHY isn't awake
-   * properly.
-   */
-
-  retries = 0;
-  do
+#  if defined(CONFIG_ETH0_PHY_MULTI)
+  if (!imxrt_phy_is(priv, MII_TJA1103_NAME))
     {
-      phydata = 0xffff;
-      ret = imxrt_readmii(priv, phyaddr, BOARD_PHY_STATUS, &phydata);
-    }
-  while ((ret < 0 || phydata == 0xffff) && ++retries < 3);
+#  endif
+      /* When we get here we have a (negotiated) speed and duplex. This
+       * is also the point we enter if renegotiation is turned off, so have
+       * multiple attempts at reading the status register in case the PHY
+       * isn't awake properly.
+       */
 
-  /* If we didn't successfully read anything and we haven't tried a physical
-   * renegotiation then lets do that
-   */
-
-  if (retries >= 3)
-    {
-      if (renogphy == false)
+      retries = 0;
+      do
         {
-          /* Give things one more chance with renegotiation turned on */
-
-          return imxrt_initphy(priv, true);
+          phydata = 0xffff;
+          ret = imxrt_readmii(priv, phyaddr, BOARD_PHY_STATUS, &phydata);
         }
-      else
+      while ((ret < 0 || phydata == 0xffff) && ++retries < 3);
+
+      /* If we didn't successfully read anything and we haven't tried
+       * a physical renegotiation then lets do that
+       */
+
+      if (retries >= 3)
         {
-          /* That didn't end well, just give up */
+          if (renogphy == false)
+            {
+              /* Give things one more chance with renegotiation turned on */
 
-          nerr("ERROR: Failed to read %s BOARD_PHY_STATUS[%02x]: %d\n",
-               BOARD_PHY_NAME, BOARD_PHY_STATUS, ret);
-          return ret;
+              return imxrt_initphy(priv, true);
+            }
+          else
+            {
+              /* That didn't end well, just give up */
+
+              nerr("ERROR: Failed to read %s BOARD_PHY_STATUS[%02x]: %d\n",
+                   BOARD_PHY_NAME, BOARD_PHY_STATUS, ret);
+              return ret;
+            }
         }
-    }
 
-  ninfo("%s: BOARD_PHY_STATUS: %04x\n", BOARD_PHY_NAME, phydata);
+      ninfo("%s: BOARD_PHY_STATUS: %04x\n", BOARD_PHY_NAME, phydata);
+#  if defined(CONFIG_ETH0_PHY_MULTI)
+    }
+#  endif
 #endif
 
   /* Set up the transmit and receive control registers based on the
@@ -2741,7 +3043,7 @@ static void imxrt_initbuffers(struct imxrt_driver_s *priv)
       priv->txdesc[i].status1 = 0;
       priv->txdesc[i].length  = 0;
       priv->txdesc[i].data    = (uint8_t *)imxrt_swap32((uint32_t)addr);
-#ifdef CONFIG_IMXRT_ENETENHANCEDBD
+#ifdef CONFIG_IMXRT_ENET_ENHANCEDBD
       priv->txdesc[i].status2 = TXDESC_IINS | TXDESC_PINS;
 #endif
       addr                   += ALIGNED_BUFSIZE;
@@ -2754,7 +3056,7 @@ static void imxrt_initbuffers(struct imxrt_driver_s *priv)
       priv->rxdesc[i].status1 = RXDESC_E;
       priv->rxdesc[i].length  = 0;
       priv->rxdesc[i].data    = (uint8_t *)imxrt_swap32((uint32_t)addr);
-#ifdef CONFIG_IMXRT_ENETENHANCEDBD
+#ifdef CONFIG_IMXRT_ENET_ENHANCEDBD
       priv->rxdesc[i].bdu     = 0;
       priv->rxdesc[i].status2 = RXDESC_INT;
 #endif

--- a/drivers/net/Kconfig
+++ b/drivers/net/Kconfig
@@ -386,8 +386,18 @@ choice
 config ETH0_PHY_NONE
 	bool "No PHY support"
 
+config ETH0_PHY_MULTI
+	bool "Multiple PHYs are supported"
+	---help---
+		The Board will provide a list of PHYs to probe for.
+		The first one found on the bpard will be used.
+		This setting is not supported by all Ethernet drivers.
+
 config ETH0_PHY_AM79C874
 	bool "AMD Am79C874 PHY"
+
+config ETH0_PHY_AR8031
+	bool "Atheros AR8031 PHY"
 
 config ETH0_PHY_KS8721
 	bool "Micrel KS8721 PHY"
@@ -439,6 +449,9 @@ config ETH0_PHY_LAN8742A
 
 config ETH0_PHY_DM9161
 	bool "Davicom DM9161 PHY"
+
+config ETH0_PHY_YT8512
+	bool "Motorcomm YT8512 PHY"
 
 endchoice
 

--- a/include/nuttx/net/mii.h
+++ b/include/nuttx/net/mii.h
@@ -21,11 +21,14 @@
 #ifndef __INCLUDE_NUTTX_NET_MII_H
 #define __INCLUDE_NUTTX_NET_MII_H
 
+#ifndef __ASSEMBLY__
+
 /****************************************************************************
  * Included Files
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <stdint.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -53,16 +56,23 @@
 #define MII_PSECONTROL               0x0b      /* PSE control register */
 #define MII_PSESTATUS                0x0c      /* PSE status register */
 #define MII_MMDCONTROL               0x0d      /* MMD access control register */
+#define MII_MMDADDRDATA              0x0e      /* MMD access address data register */
 #define MII_ESTATUS                  0x0f      /* Extended status register */
 
 /* Extended Registers: Registers 16-31 may be used for vendor specific
  * abilities
  */
 
+/* AR8031: */
+
+#define MII_AR8031_NAME             "AR8031"
+#define MII_AR8031_PSSR              0x11      /* Phy-Specific Status Register */
+
 /* National Semiconductor DP83840: 0x07-0x11, 0x14, 0x1a, 0x1d-0x1f
  * reserved
  */
 
+#define MII_DP83840_NAME             "DP83840"
 #define MII_DP83840_COUNTER          0x12      /* Disconnect counter */
 #define MII_DP83840_FCSCOUNTER       0x13      /* False carrier sense counter */
 #define MII_DP83840_NWAYTEST         0x14      /* N-way auto-neg test reg */
@@ -75,6 +85,7 @@
 
 /* Am79c874: 0x08-0x0f, 0x14, 0x16, 0x19-0x1f reserved */
 
+#define MII_AM79C874_NAME            "AM79C874"
 #define MII_AM79C874_NPADVERTISE     0x07      /* Auto-negotiation next page advertisement */
 #define MII_AM79C874_MISCFEATURES    0x10      /* Miscellaneous features reg */
 #define MII_AM79C874_INTCS           0x11      /* Interrupt control/status */
@@ -86,6 +97,7 @@
 
 /* Luminary LM3S6918 built-in PHY: 0x07-0x0f, 0x14-0x16, 0x19-0x1f reserved */
 
+#define MII_LM3S6918_NAME            "LM3S6918"
 #define MII_LM_VSPECIFIC             0x10      /* Vendor-Specific */
 #define MII_LM_INTCS                 0x11      /* Interrupt control/status */
 #define MII_LM_DIAGNOSTIC            0x12      /* Diagnostic */
@@ -95,12 +107,14 @@
 
 /* Micrel KS8721: 0x15, 0x1b, and 0x1f */
 
+#define MII_KS8721_NAME              "KS8721"
 #define MII_KS8721_RXERCOUNTER       0x15      /* RXER counter */
 #define MII_KS8721_INTCS             0x1b      /* Interrupt control/status register */
 #define MII_KS8721_10BTCR            0x1f      /* 10BASE-TX PHY control register */
 
 /* Micrel KSZ8041:  0x15, 0x1b, 0x1e-0x1f */
 
+#define MII_KSZ8041_NAME             "KSZ8041"
 #define MII_KSZ8041_RXERR            0x15      /* RXERR Counter */
 #define MII_KSZ8041_INT              0x1b      /* Interrupt Control/Status */
 #define MII_KSZ8041_PHYCTRL1         0x1e      /* PHY Control 1 */
@@ -108,6 +122,7 @@
 
 /* Micrel KSZ8051:  0x11, 0x15-0x18, 0x1b, 0x1d-0x1f */
 
+#define MII_KSZ8051_NAME             "KSZ8051"
 #define MII_KSZ8051_AFEC1            0x11      /* AFE Control 1 */
 #define MII_KSZ8051_RXERR            0x15      /* RXERR Counter */
 #define MII_KSZ8051_OMSO             0x16      /* Operation Mode Strap Override */
@@ -119,6 +134,8 @@
 #define MII_KSZ8051_PHYCTRL2         0x1f      /* PHY Control 2 */
 
 /* Micrel KSZ8061:  0x10-0x18, 0x1b, 0x1c-0x1f */
+
+#define MII_KSZ8061_NAME               "KSZ8061"
 #define MII_KSZ8061_DIG_CTRL           0x10   /* Digital Control */
 #define MII_KSZ8061_AFE_CTRL_0         0x11   /* AFE Control 0 */
 #define MII_KSZ8061_AFE_CTRL_1         0x12   /* AFE Control 1 */
@@ -136,6 +153,7 @@
 
 /* Micrel KSZ8081:  0x10-0x11, 0x15-0x18, 0x1b, 0x1d-0x1f */
 
+#define MII_KSZ8081_NAME             "KSZ8081"
 #define MII_KSZ8081_DRCTRL           0x10      /* Digital Reserve Control */
 #define MII_KSZ8081_AFEC1            0x11      /* AFE Control 1 */
 #define MII_KSZ8081_RXERR            0x15      /* RXERR Counter */
@@ -151,6 +169,7 @@
  * 0x8-0x15, 0x13, 0x1c reserved
  */
 
+#define MII_DP83848C_NAME            "DP83848C"
 #define MII_DP83848C_STS             0x10      /* RO PHY Status Register */
 #define MII_DP83848C_MICR            0x11      /* RW MII Interrupt Control Register */
 #define MII_DP83848C_MISR            0x12      /* RO MII Interrupt Status Register */
@@ -166,6 +185,7 @@
 
 /* Texas Instruments DP83825I PHY Extended Registers. */
 
+#define MII_DP83825I_NAME            "DP83825I"
 #define MII_DP83825I_PHYSTS          0x10      /* RO PHY Status Register */
 #define MII_DP83825I_PHYSCR          0x11      /* RW PHY Specific Control Register */
 #define MII_DP83825I_MISR1           0x12      /* RO MII Interrupt Status Register 1 */
@@ -184,6 +204,7 @@
 
 /* SMSC LAN8720 PHY Extended Registers */
 
+#define MII_LAN8720_NAME             "LAN8720"
 #define MII_LAN8720_REV              0x10      /* Silicon Revision Register */
 #define MII_LAN8720_MCSR             0x11      /* Mode Control/Status Register */
 #define MII_LAN8720_MODES            0x12      /* Special modes */
@@ -196,6 +217,8 @@
 
 /* SMSC LAN8740/LAN8742A PHY Extended Registers */
 
+#define MII_LAN8740_NAME             "LAN8740"
+#define MII_LAN8742A_NAME            "LAN8742A"
 #define MII_LAN8740_CONFIG           0x10      /* EDPD NDL/Crossover Timer/EEE Configuration */
 #define MII_LAN8740_MCSR             0x11      /* Mode Control/Status Register */
 #define MII_LAN8740_MODES            0x12      /* Special modes */
@@ -207,6 +230,21 @@
 #define MII_LAN8740_ISR              0x1d      /* Interrupt Source Register */
 #define MII_LAN8740_IMR              0x1e      /* Interrupt Mask Register */
 #define MII_LAN8740_SCSR             0x1f      /* PHY Special Control/Status Register */
+
+/* Motorcomm YT8512C/YT8512H Extended Registers */
+
+#define MII_YT8512_NAME             "YT8512"
+#define MII_YT8512_PHYSFC            0x10      /* PHY Function conrtol Register */
+#define MII_YT8512_PHYSTS            0x11      /* PHY Status Register */
+#define MII_YT8512_IMR               0x12      /* Interrupt Mask Register */
+#define MII_YT8512_ISR               0x13      /* Interrupt Source Register */
+#define MII_YT8512_SADC              0x14      /* Speed auto downgrade control Register */
+#define MII_YT8512_REC               0x15      /* Rx Error Counter Register */
+#define MII_YT8512_DEBUG_ADDR_OFFSET 0x1E      /* Debug Register's Address Offset Register */
+#define MII_YT8512_DEBUG_DATA        0x1F      /* Debug Register's Data Register */
+
+#define MII_YT8512_LED0              0x40c0    /* LED0 control */
+#define MII_YT8512_LED1              0x40c3    /* LED1 control */
 
 /* MII register bit settings ************************************************/
 
@@ -615,6 +653,9 @@
 #define MII_PHYID1_KSZ8051           0x0022    /* ID1 value for Micrel KSZ8051 */
 #define MII_PHYID2_KSZ8051           0x1550    /* ID2 value for Micrel KSZ8051 */
 
+#define MII_PHYID1_KSZ8061           0x0022    /* ID1 value for Micrel KSZ8061 */
+#define MII_PHYID2_KSZ8061           0x1573    /* ID2 value for Micrel KSZ8061 */
+
 #define MII_PHYID1_KSZ8081           0x0022    /* ID1 value for Micrel KSZ8081 */
 #define MII_PHYID2_KSZ8081           0x1560    /* ID2 value for Micrel KSZ8081 */
 
@@ -624,7 +665,7 @@
 #define KSZ8081_DRCTRL_PLLOFF        (1 << 4)  /* Bit 4: Turn PLL off in EDPD mode */
                                                /* Bits 0-3: Reserved */
 
-/* KSZ8041/51/81 Register 0x1b: Interrupt control/status */
+/* KSZ8041/51/61/81 Register 0x1b: Interrupt control/status */
 
 #define MII_KSZ80X1_INT_JEN          (1 << 15) /* Jabber interrupt enable */
 #define MII_KSZ80X1_INT_REEN         (1 << 14) /* Receive error interrupt enable */
@@ -643,6 +684,18 @@
 #define MII_KSZ80X1_INT_LD           (1 << 2)  /* Link down fault interrupt */
 #define MII_KSZ80X1_INT_RF           (1 << 1)  /* Remote fault interrupt */
 #define MII_KSZ80X1_INT_LU           (1 << 0)  /* Link up interrupt */
+
+/* KSZ8061 Register 0x1e: PHY Control 1 */
+
+#define MII_KSZ8061_PC2_PE           (1 << 9)  /* Enable pause (flow control) */
+#define MII_KSZ8061_PC2_LS           (1 << 8)  /* Link status */
+#define MII_KSZ8061_PC2_PS           (1 << 7)  /* Polarity status */
+#define MII_KSZ8061_PC2_XS           (1 << 5)  /* MID/MDI-X Status */
+#define MII_KSZ8061_PC2_ED           (1 << 4)  /* Energy detect */
+#define MII_KSZ8061_PC2_PI           (1 << 3)  /* PHY isolate */
+#define MII_KSZ8061_PC2_FD           (1 << 2)  /* Full duplex */
+#define MII_KSZ8061_PC2_100T         (1 << 1)  /* 100base-tx speed */
+#define MII_KSZ8061_PC2_10T          (1 << 0)  /* 10base-t speed */
 
 /* KSZ8041 Register 0x1e: PHY Control 1 -- To be provided */
 
@@ -671,7 +724,7 @@
 #define MII_PHYCTRL2_SEQTEST         (1 << 1)  /* Bit 1:  Enable SQE test */
 #define MII_PHYCTRL2_DISDS           (1 << 0)  /* Bit 1:  Disable data scrambling */
 
-/* KSZ8051/81 Register 0x1e: PHY Control 1 */
+/* KSZ8051/61/81 Register 0x1e: PHY Control 1 */
 
                                                /* Bits 10-15: Reserved */
 #define MII_PHYCTRL1_ENPAUSE         (1 << 9)  /* Bit 9:  Enable pause */
@@ -694,12 +747,15 @@
 
 /* TJA110X MII ID1/2 register bits */
 
+#define MII_TJA1100_NAME                  "TJA1100"
 #define MII_PHYID1_TJA1100                0x0180  /* ID1 value for NXP TJA1100 */
 #define MII_PHYID2_TJA1100                0xdc40  /* ID2 value for NXP TJA1100 */
 
+#define MII_TJA1101_NAME                  "TJA1101"
 #define MII_PHYID1_TJA1101                0x0180  /* ID1 value for NXP TJA1101 */
 #define MII_PHYID2_TJA1101                0xdd00  /* ID2 value for NXP TJA1101 */
 
+#define MII_TJA1103_NAME                  "TJA1103"
 #define MII_PHYID1_TJA1103                0x01b   /* ID1 value for NXP TJA1103 */
 #define MII_PHYID2_TJA1103                0xB013  /* ID2 value for NXP TJA1103 */
 
@@ -841,9 +897,61 @@
 #define MII_DP83848C_FHF_INT_EN       (1 << 1)  /* Enable Interrupt on False Carrier Counter Register half-full event. */
 #define MII_DP83848C_RHF_INT_EN       (1 << 0)  /* Enable Interrupt on Receive Error Counter Register half-full event. */
 
+/* Atheros AR8031 MII ID1/2 register bits */
+
+#define MII_PHYID1_AR8031             0x004d     /* ID1 value for AR8031 */
+#define MII_PHYID2_AR8031             0xd074     /* ID2 value for AR8031 */
+
+#define MII_AR8031_PSSR_SPEEDMASK     (3 << 14)  /* Bit 14-15: Speed */
+#define MII_AR8031_PSSR_10MBPS        (0 << 14)
+#define MII_AR8031_PSSR_100MBPS       (1 << 14)
+#define MII_AR8031_PSSR_1000MBPS      (2 << 14)
+#define MII_AR8031_PSSR_DUPLEX        (1 << 13)  /* Bit 13:  Full duplex mode */
+
+/* YT8512 register bit settings *********************************************/
+
+/* YT8512 MII ID1/2 register bits */
+
+#define MII_PHYID1_YT8512             0x0000    /* ID1 value for YT8512 */
+#define MII_PHYID2_YT8512             0x0128    /* ID2 value for YT8512 */
+
+/* YT8512 Register 0x10: Specific function control register */
+
+/* YT8512 Register 0x11: Specific status */
+
+#define MII_YT8512_PHYSTS_SPEED       (1 << 14)
+#define MII_YT8512_PHYSTS_DUPLEX      (1 << 13)
+/* YT8512 Register 0x12: Interrupt mask */
+#define MII_YT8512_IMR_SPD_EN         (1 << 14)
+#define MII_YT8512_IMR_DUP_EN         (1 << 13)
+#define MII_YT8512_IMR_LD_EN          (1 << 11)
+#define MII_YT8512_IMR_LU_EN          (1 << 10)
+
+/* YT8512 Register 0x13: Interrupt status */
+
+/* YT8512 Register 0x14: Speed auto downgrade control */
+
+/* YT8512 Register 0x15: Rx error counter */
+
 /****************************************************************************
  * Type Definitions
  ****************************************************************************/
+
+struct phy_desc_s
+{
+  char      name[16];       /* The name of the PHY */
+  uint16_t  id1;            /* The MII_PHYID1 registers value */
+  uint16_t  id2;            /* The MII_PHYID2 registers value */
+  uint16_t  status;         /* The Phys status register or 0xffff */
+  uint16_t  address_lo;     /* The lowest address to check for the PHY */
+  uint16_t  address_high;   /* The highest address to check for the PHY or
+                             * 0xffff uses only the address_lo (one address)
+                             */
+  uint16_t  mbps10;         /* The bit mask for 10MBP if status is not 0xffff */
+  uint16_t  mbps100;        /* The bit mask for 100MBP if status is not 0xffff */
+  uint16_t  duplex;         /* The bit mask for DUPLEX if status is not 0xffff */
+  uint16_t  clause;         /* The PHY clause supported. 22 or 45 */
+};
 
 /****************************************************************************
  * Public Function Prototypes
@@ -862,4 +970,5 @@ extern "C"
 }
 #endif
 
+#endif /* __ASSEMBLY__ */
 #endif /* __INCLUDE_NUTTX_NET_MII_H */


### PR DESCRIPTION
## Summary
Support runtime phy selection based on a list
   supplied by board.h
   For Example:
```
   #define BOARD_ETH0_PHY_LIST                   \
	{                                        \
		"LAN8742A",                      \
		MII_PHYID1_LAN8742A,             \
		MII_PHYID2_LAN8742A,             \
		MII_LAN8740_SCSR,                \
		0,                               \
		0xffff,                          \
		MII_LAN8720_SPSCR_10MBPS,        \
		MII_LAN8720_SPSCR_100MBPS,       \
		MII_LAN8720_SPSCR_DUPLEX,        \
		22                               \
	},                                       \
	{                                        \
		"TJA1103",                       \
		MII_PHYID1_TJA1103,              \
		MII_PHYID2_TJA1103,              \
		0xffff,                          \
		18,                              \
		0xffff,                          \
		0                       ,        \
		MII_LAN8720_SPSCR_100MBPS,       \
		MII_LAN8720_SPSCR_DUPLEX,        \
		45,                              \
	},                                       \
```
## Impact

## Testing

