### PR TITLE
[BACKPORT] stm32h7:serial make TX DMA busy when there are an outstand…

### DIFF
--- a/arch/arm/src/stm32h7/stm32_serial.c
+++ b/arch/arm/src/stm32h7/stm32_serial.c
@@ -3368,13 +3368,17 @@ static void up_dma_txcallback(DMA_HANDLE handle, uint8_t status, void *arg)
 static void up_dma_txavailable(struct uart_dev_s *dev)
 {
   struct up_dev_s *priv = (struct up_dev_s *)dev->priv;
+  irqstate_t flags =  enter_critical_section();
 
   /* Only send when the DMA is idle */
 
-  if (stm32_dmaresidual(priv->txdma) == 0)
+  if ((priv->dev.dmatx.length && priv->dev.dmatx.nlength) == 0 &&
+      stm32_dmaresidual(priv->txdma) == 0)
     {
       uart_xmitchars_dma(dev);
     }
+
+  leave_critical_section(flags);
 }
 #endif
 


### PR DESCRIPTION
…ing transaction

    If a TX DMA completion interrups a forground write.
    The TX DMA completion can start a dma_send and it will
    then followed by the forground write's dma_send
    stoping the,then in progress DMA.

    By atomicaly marking the tx dma busy, the forground
    write will not perform the dma_send, and will only
    enqueue the data. At the next TX dma completion any
    data pending in the tx queue will be sent

## Summary

## Impact

## Testing

