### PR TITLE
DNM stm32h7: allow Ethernet MAC without PHY

### DIFF
--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -5249,6 +5249,10 @@ config STM32H7_ETHMAC_REGDEBUG
 		Enable very low-level register access debug.  Depends on
 		CONFIG_DEBUG_FEATURES.
 
+config STM32H7_NO_PHY
+	bool "MAC has no PHY"
+	default n
+
 endmenu # Ethernet MAC configuration
 
 menu "QEncoder Driver"

--- a/arch/arm/src/stm32h7/stm32_ethernet.c
+++ b/arch/arm/src/stm32h7/stm32_ethernet.c
@@ -754,7 +754,7 @@ static void stm32_rxdescinit(struct stm32_ethmac_s *priv,
                              union stm32_desc_u *rxtable, uint8_t *rxbuffer);
 
 /* PHY Initialization */
-
+#ifndef CONFIG_STM32H7_NO_PHY
 #if defined(CONFIG_NETDEV_PHY_IOCTL) && defined(CONFIG_ARCH_PHY_INTERRUPT)
 static int  stm32_phyintenable(struct stm32_ethmac_s *priv);
 #endif
@@ -768,6 +768,7 @@ static inline int stm32_dm9161(struct stm32_ethmac_s *priv);
 static int  stm32_phyinit(struct stm32_ethmac_s *priv);
 #ifdef CONFIG_STM32H7_ETHMAC_REGDEBUG
 static void  stm32_phyregdump(void);
+#endif
 #endif
 
 /* MAC/DMA Initialization */
@@ -2996,6 +2997,7 @@ static void stm32_rxdescinit(struct stm32_ethmac_s *priv,
 #ifdef CONFIG_NETDEV_PHY_IOCTL
 static int stm32_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg)
 {
+#ifndef CONFIG_STM32H7_NO_PHY
 #ifdef CONFIG_ARCH_PHY_INTERRUPT
   struct stm32_ethmac_s *priv = (struct stm32_ethmac_s *)dev->d_private;
 #endif
@@ -3053,9 +3055,13 @@ static int stm32_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg)
     }
 
   return ret;
+#else
+  return -EIO;
+#endif
 }
 #endif /* CONFIG_NETDEV_PHY_IOCTL */
 
+#ifndef CONFIG_STM32H7_NO_PHY
 /****************************************************************************
  * Function: stm32_phyintenable
  *
@@ -3575,6 +3581,8 @@ static int stm32_phyinit(struct stm32_ethmac_s *priv)
 
   return OK;
 }
+
+#endif
 
 /****************************************************************************
  * Name: stm32_selectmii
@@ -4222,6 +4230,19 @@ static int stm32_ethconfig(struct stm32_ethmac_s *priv)
 
   /* Initialize the PHY */
 
+#ifdef CONFIG_STM32H7_NO_PHY
+  ninfo("MAC without PHY\n");
+#ifdef CONFIG_STM32H7_ETHFD
+  priv->fduplex = 1;
+#else
+  priv->fduplex = 0;
+#endif
+#ifdef CONFIG_STM32H7_ETH100MBPS
+  priv->mbps100 = 1;
+#else
+  priv->mbps100 = 0;
+#endif
+#else
   ninfo("Initialize the PHY\n");
   ret = stm32_phyinit(priv);
   if (ret < 0)
@@ -4229,6 +4250,7 @@ static int stm32_ethconfig(struct stm32_ethmac_s *priv)
       return ret;
     }
 
+#endif
   /* Initialize the MAC and DMA */
 
   ninfo("Initialize the MAC and DMA\n");


### PR DESCRIPTION
## Summary
- In some cases, an operational Ethernet MAC may have no PHY, for example when the system has a direct RMII MAC-to-MAC link.
- New config option STM32H7_NO_PHY
- With this option, PHY-specific code in the ethernet driver is not built
- This option is inherently incompatible with autonegotiation and speed and duplex settings must be compiled in

## Impact
- With STM32H7_NO_PHY, a MAC-to-MAC link without any PHY can be used.  Without STM32H7_NO_PHY, no impact.

## Testing
- Tested with STM32H7_NO_PHY with px4_fmu-v6s and an RMII MAC-to-MAC link
- Without STM32H7_NO_PHY - which is the default - it is reasonable to determine by inspection that this PR does not change the code from before the introduction of the option.

