### PR TITLE
[BACKPORT] stm32l4: Fix typo in stm32l4_rcc for NuttX v10.3.0

### DIFF
--- a/arch/arm/src/stm32l4/stm32l4_rcc.h
+++ b/arch/arm/src/stm32l4/stm32l4_rcc.h
@@ -53,7 +53,7 @@
 #define EXTERN extern "C"
 extern "C"
 {
-#elseO
+#else
 #define EXTERN extern
 #endif
 


### PR DESCRIPTION
## Summary
Would it be please possible, to commit this fix to branch px4_firmware_nuttx-10.3.0-v1.14

## Impact

It will be possible to compile the file.

## Testing
Tested on STM32L4, it's working :}

