### PR TITLE
[BACKPORT] littlefs: Get and return the current error status before R…

### DIFF
--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -1354,8 +1354,14 @@ static int littlefs_mkdir(FAR struct inode *mountpt, FAR const char *relpath,
 static int littlefs_rmdir(FAR struct inode *mountpt, FAR const char *relpath)
 {
   struct stat buf;
+  int ret;
 
-  littlefs_stat(mountpt, relpath, &buf);
+  ret = littlefs_stat(mountpt, relpath, &buf);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   if (S_ISDIR(buf.st_mode))
     {
       return littlefs_unlink(mountpt, relpath);


### PR DESCRIPTION
## Summary
MAVFTP returns unexpected error codes when using littlefs and trying to remove a directory that does not exist. The expected errno value is ENOENT in this case, however ENOTDIR will be returned.

This was also detected in upstream NuttX and fixed here: https://github.com/apache/nuttx/commit/8b95b7ca5bcac0834c5318d6487c7964ab5105b6#diff-af28a1a91fbcb4d67a8450fec1ee0f3d2a11775374330df68a465188f864f7feR1330

## Testing
Was tested with a Skynode that uses littlefs. With the patch the expected errno value is set.
