### PR TITLE
[BACKPORT] arch/arm: Fix crash when using memcpy/memset as RAMFUNCS

### DIFF
--- a/arch/arm/src/imx6/imx_boot.c
+++ b/arch/arm/src/imx6/imx_boot.c
@@ -365,6 +365,7 @@ static inline void imx_wdtdisable(void)
  *
  ****************************************************************************/
 
+osentry_function
 void arm_boot(void)
 {
 #if defined(CONFIG_ARCH_RAMFUNCS)

--- a/arch/arm/src/imxrt/imxrt_start.c
+++ b/arch/arm/src/imxrt/imxrt_start.c
@@ -143,6 +143,7 @@ static inline void imxrt_tcmenable(void)
  *
  ****************************************************************************/
 
+osentry_function
 void __start(void)
 {
   const register uint32_t *src;

--- a/arch/arm/src/kinetis/kinetis_start.c
+++ b/arch/arm/src/kinetis/kinetis_start.c
@@ -100,6 +100,7 @@ void __start(void) noinstrument_function;
  *
  ****************************************************************************/
 
+osentry_function
 void __start(void)
 {
   const uint32_t *src;

--- a/arch/arm/src/lc823450/lc823450_start.c
+++ b/arch/arm/src/lc823450/lc823450_start.c
@@ -134,6 +134,7 @@ extern uint32_t _svect;
  *
  ****************************************************************************/
 
+osentry_function
 void __start(void)
 {
   const uint32_t *src;

--- a/arch/arm/src/s32k1xx/s32k1xx_start.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_start.c
@@ -182,6 +182,7 @@ static inline void s32k1xx_mpu_config(void)
  *
  ****************************************************************************/
 
+osentry_function
 void __start(void)
 {
 #ifdef CONFIG_BOOT_RUNFROMFLASH

--- a/arch/arm/src/s32k3xx/s32k3xx_start.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_start.c
@@ -133,6 +133,7 @@ extern uint8_t FLASH_END_ADDR[];
  *
  ****************************************************************************/
 
+osentry_function
 void s32k3xx_start(void)
 {
   register uint64_t *src;

--- a/arch/arm/src/sam34/sam_start.c
+++ b/arch/arm/src/sam34/sam_start.c
@@ -107,6 +107,7 @@ void __start(void) noinstrument_function;
  *
  ****************************************************************************/
 
+osentry_function
 void __start(void)
 {
   const uint32_t *src;

--- a/arch/arm/src/sama5/sam_boot.c
+++ b/arch/arm/src/sama5/sam_boot.c
@@ -366,6 +366,7 @@ static inline void sam_wdtdisable(void)
  *
  ****************************************************************************/
 
+osentry_function
 void arm_boot(void)
 {
 #ifdef CONFIG_ARCH_RAMFUNCS

--- a/arch/arm/src/samd5e5/sam_start.c
+++ b/arch/arm/src/samd5e5/sam_start.c
@@ -113,6 +113,7 @@ void __start(void) noinstrument_function;
  *
  ****************************************************************************/
 
+osentry_function
 void __start(void)
 {
 #if defined(CONFIG_BOOT_RUNFROMFLASH) || defined(CONFIG_ARCH_RAMFUNCS)

--- a/arch/arm/src/samv7/sam_start.c
+++ b/arch/arm/src/samv7/sam_start.c
@@ -149,6 +149,7 @@ static inline void sam_tcmenable(void)
  *
  ****************************************************************************/
 
+osentry_function
 void __start(void)
 {
   const uint32_t *src;

--- a/arch/arm/src/stm32f7/stm32_start.c
+++ b/arch/arm/src/stm32f7/stm32_start.c
@@ -169,6 +169,7 @@ static inline void stm32_tcmenable(void)
  *
  ****************************************************************************/
 
+osentry_function
 void __start(void)
 {
   const uint32_t *src;

--- a/arch/arm/src/stm32h7/stm32_start.c
+++ b/arch/arm/src/stm32h7/stm32_start.c
@@ -170,6 +170,7 @@ static inline void stm32_tcmenable(void)
  *
  ****************************************************************************/
 
+osentry_function
 void __start(void)
 {
   const uint32_t *src;

--- a/arch/arm/src/xmc4/xmc4_start.c
+++ b/arch/arm/src/xmc4/xmc4_start.c
@@ -163,6 +163,7 @@ static inline void xmc4_flash_waitstates(void)
  *
  ****************************************************************************/
 
+osentry_function
 void __start(void)
 {
   const uint32_t *src;

--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -791,6 +791,14 @@
 
 #endif
 
+/* Decorators */
+
+#ifdef CONFIG_ARCH_RAMFUNCS
+#  define osentry_function no_builtin("memcpy") no_builtin("memset")
+#else
+#  define osentry_function
+#endif
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/


### PR DESCRIPTION
Backport of https://github.com/apache/nuttx/pull/16019
> Add no_builtin for memcpy/memset to the startup code of boards
with CONFIG_ARCH_RAMFUNCS, because certain compilers call memcpy/memset
instead of the explicit for loop. This will cause a crash if memcpy/memset
are mapped to RAM because the function that copies them to RAM is called later,
resulting in undefined code being executed.

Will be used in this PR: https://github.com/PX4/PX4-Autopilot/pull/24621