### PR TITLE
[BACKPORT] fs/procfs: fix potential null pointer access in procfs_opendir

### DIFF
--- a/fs/procfs/fs_procfs.c
+++ b/fs/procfs/fs_procfs.c
@@ -619,8 +619,12 @@ static int procfs_opendir(FAR struct inode *mountpt, FAR const char *relpath,
                * derived from struct procfs_dir_priv_s as dir.
                */
 
-              DEBUGASSERT(g_procfs_entries[x].ops != NULL &&
-                          g_procfs_entries[x].ops->opendir != NULL);
+              DEBUGASSERT(g_procfs_entries[x].ops != NULL);
+
+              if (g_procfs_entries[x].ops->opendir == NULL)
+                {
+                  return -ENOENT;
+                }
 
               ret = g_procfs_entries[x].ops->opendir(relpath, dir);
 


### PR DESCRIPTION
Some entries have the opendir function set to NULL, for example g_mount_operations.

A null pointer dereference can be triggered by an
opendir("/proc/fs/blocks") for example.

Upstream: https://github.com/apache/nuttx/pull/16164

It was possible to trigger this via MAVLink FTP, e.g. `mavftp_client udp://0.0.0.0:14550 1 dir /proc/fs/blocks`