### PR TITLE
[BACKPORT] stm32h7: enable Ethernet for STM32H7X7XX

### DIFF
--- a/arch/arm/src/stm32h7/hardware/stm32_ethernet.h
+++ b/arch/arm/src/stm32h7/hardware/stm32_ethernet.h
@@ -31,7 +31,8 @@
  * families
  */
 
-#if defined(CONFIG_STM32H7_STM32H7X3XX)
+#if defined(CONFIG_STM32H7_STM32H7X3XX) || \
+    defined(CONFIG_STM32H7_STM32H7X7XX)
 
 /****************************************************************************
  * Pre-processor Definitions


### PR DESCRIPTION
Backport of https://github.com/apache/nuttx/pull/16209.
