### PR TITLE
Backport of IMXRT 106X MPU fix and ramvector in ITCM

### DIFF
--- a/arch/arm/src/imxrt/imxrt_irq.c
+++ b/arch/arm/src/imxrt/imxrt_irq.c
@@ -488,7 +488,7 @@ void up_irqinitialize(void)
    * vector table that requires special initialization.
    */
 
-  arm_ramvec_initialize();
+  putreg32((uint32_t)g_ram_vectors, NVIC_VECTAB);
 #endif
 
   /* Set all interrupts (and exceptions) to the default priority */

--- a/arch/arm/src/imxrt/imxrt_mpuinit.c
+++ b/arch/arm/src/imxrt/imxrt_mpuinit.c
@@ -130,6 +130,9 @@ void imxrt_mpu_initialize(void)
 #  if defined(CONFIG_ARCH_FAMILY_IMXRT117x)
 #     include "imxrt117x_mpuinit.c"
 #  else
+
+  mpu_reset();
+
   mpu_configure_region(0xc0000000, 512 * 1024 * 1024,
                        MPU_RASR_TEX_DEV  | /* Device
                                             * Not Cacheable
@@ -154,15 +157,15 @@ void imxrt_mpu_initialize(void)
                        MPU_RASR_AP_RORO);  /* P:RO   U:RO
                                             * Instruction access */
 
-  mpu_configure_region(IMXRT_ITCM_BASE,  128 * 1024,
+  mpu_configure_region(IMXRT_ITCM_BASE,  CONFIG_IMXRT_ITCM * 1024,
                        MPU_RASR_TEX_NOR  | /* Normal             */
                        RASR_C_VALUE      | /* Cacheable          */
                        RASR_B_VALUE      | /* Bufferable
                                             * Not Shareable      */
-                       MPU_RASR_AP_RWRW);  /* P:RW   U:RW
+                       MPU_RASR_AP_RORO);  /* P:RO   U:RO
                                             * Instruction access */
 
-  mpu_configure_region(IMXRT_DTCM_BASE,  128 * 1024,
+  mpu_configure_region(IMXRT_DTCM_BASE,  CONFIG_IMXRT_DTCM * 1024,
                        MPU_RASR_TEX_NOR  | /* Normal             */
                        RASR_C_VALUE      | /* Cacheable          */
                        RASR_B_VALUE      | /* Bufferable

--- a/arch/arm/src/imxrt/imxrt_start.c
+++ b/arch/arm/src/imxrt/imxrt_start.c
@@ -35,6 +35,7 @@
 #include "arm_internal.h"
 #include "barriers.h"
 #include "nvic.h"
+#include "ram_vectors.h"
 
 #include "imxrt_clockconfig.h"
 #include "imxrt_mpuinit.h"
@@ -204,6 +205,10 @@ void __start(void)
     {
       *dest++ = *src++;
     }
+#endif
+
+#ifdef CONFIG_ARCH_RAMVECTORS
+  arm_ramvec_initialize();
 #endif
 
   /* Configure the UART so that we can get debug output as soon as possible */


### PR DESCRIPTION
## Summary
Backport of IMXRT 106X MPU fix and ramvector in ITCM

Fixes MPU for 106X for bootloader usecases and mark ITCM as RO.

Initialize ramvectors before MPU so we can locate vectors in ITCM.

## Impact
IMRT Family

## Testing
V6X-RT and MIMXRT1064
