### PR TITLE
[BACKPORT] arch/arm/imxrt: Serial add RXDMA support for singlewire mode

### DIFF
--- a/arch/arm/src/imxrt/imxrt_serial.c
+++ b/arch/arm/src/imxrt/imxrt_serial.c
@@ -880,6 +880,28 @@ static const struct uart_ops_s g_lpuart_singlewire_ops =
   .txready        = imxrt_txready,
   .txempty        = imxrt_txempty,
 };
+
+#ifdef SERIAL_HAVE_RXDMA
+static const struct uart_ops_s g_lpuart_singlewire_rxdma_ops =
+{
+  .setup          = imxrt_dma_setup,
+  .shutdown       = imxrt_dma_shutdown,
+  .attach         = imxrt_attach,
+  .detach         = imxrt_detach,
+  .ioctl          = imxrt_ioctl,
+  .receive        = imxrt_dma_receive,
+  .rxint          = imxrt_dma_rxint,
+  .rxavailable    = imxrt_dma_rxavailable,
+#ifdef CONFIG_SERIAL_IFLOWCONTROL
+  .rxflowcontrol  = imxrt_rxflowcontrol,
+#endif
+  .send           = imxrt_singlewire_send,
+  .txint          = imxrt_singlewire_txint,
+  .txready        = imxrt_txready,
+  .txempty        = imxrt_txempty,
+};
+#endif
+
 #endif
 
 #if !defined(SERIAL_HAVE_ONLY_TXDMA) && !defined(SERIAL_HAVE_ONLY_RXDMA)
@@ -1161,6 +1183,7 @@ static struct imxrt_uart_s g_lpuart1priv =
 #endif
 #ifdef CONFIG_IMXRT_LPUART_SINGLEWIRE
   .tx_gpio      = GPIO_LPUART1_TX,
+  .prev_ops     = 0,
 #endif
 
 #if (((defined(CONFIG_SERIAL_RS485CONTROL) || defined(CONFIG_SERIAL_IFLOWCONTROL))) \
@@ -1230,6 +1253,7 @@ static struct imxrt_uart_s g_lpuart2priv =
 #endif
 #ifdef CONFIG_IMXRT_LPUART_SINGLEWIRE
   .tx_gpio      = GPIO_LPUART2_TX,
+  .prev_ops     = 0,
 #endif
 #if (((defined(CONFIG_SERIAL_RS485CONTROL) || defined(CONFIG_SERIAL_IFLOWCONTROL))) \
     && defined(CONFIG_LPUART2_INVERTIFLOWCONTROL))
@@ -1296,6 +1320,7 @@ static struct imxrt_uart_s g_lpuart3priv =
 #endif
 #ifdef CONFIG_IMXRT_LPUART_SINGLEWIRE
   .tx_gpio      = GPIO_LPUART3_TX,
+  .prev_ops     = 0,
 #endif
 #if (((defined(CONFIG_SERIAL_RS485CONTROL) || defined(CONFIG_SERIAL_IFLOWCONTROL))) \
     && defined(CONFIG_LPUART3_INVERTIFLOWCONTROL))
@@ -1362,6 +1387,7 @@ static struct imxrt_uart_s g_lpuart4priv =
 #endif
 #ifdef CONFIG_IMXRT_LPUART_SINGLEWIRE
   .tx_gpio      = GPIO_LPUART4_TX,
+  .prev_ops     = 0,
 #endif
 #if (((defined(CONFIG_SERIAL_RS485CONTROL) || defined(CONFIG_SERIAL_IFLOWCONTROL))) \
     && defined(CONFIG_LPUART4_INVERTIFLOWCONTROL))
@@ -1428,6 +1454,7 @@ static struct imxrt_uart_s g_lpuart5priv =
 #endif
 #ifdef CONFIG_IMXRT_LPUART_SINGLEWIRE
   .tx_gpio      = GPIO_LPUART5_TX,
+  .prev_ops     = 0,
 #endif
 #if (((defined(CONFIG_SERIAL_RS485CONTROL) || defined(CONFIG_SERIAL_IFLOWCONTROL))) \
     && defined(CONFIG_LPUART5_INVERTIFLOWCONTROL))
@@ -1494,6 +1521,7 @@ static struct imxrt_uart_s g_lpuart6priv =
 #endif
 #ifdef CONFIG_IMXRT_LPUART_SINGLEWIRE
   .tx_gpio      = GPIO_LPUART6_TX,
+  .prev_ops     = 0,
 #endif
 #if (((defined(CONFIG_SERIAL_RS485CONTROL) || defined(CONFIG_SERIAL_IFLOWCONTROL))) \
     && defined(CONFIG_LPUART6_INVERTIFLOWCONTROL))
@@ -1560,6 +1588,7 @@ static struct imxrt_uart_s g_lpuart7priv =
 #endif
 #ifdef CONFIG_IMXRT_LPUART_SINGLEWIRE
   .tx_gpio      = GPIO_LPUART7_TX,
+  .prev_ops     = 0,
 #endif
 #if (((defined(CONFIG_SERIAL_RS485CONTROL) || defined(CONFIG_SERIAL_IFLOWCONTROL))) \
     && defined(CONFIG_LPUART7_INVERTIFLOWCONTROL))
@@ -1626,6 +1655,7 @@ static struct imxrt_uart_s g_lpuart8priv =
 #endif
 #ifdef CONFIG_IMXRT_LPUART_SINGLEWIRE
   .tx_gpio      = GPIO_LPUART8_TX,
+  .prev_ops     = 0,
 #endif
 #if (((defined(CONFIG_SERIAL_RS485CONTROL) || defined(CONFIG_SERIAL_IFLOWCONTROL))) \
     && defined(CONFIG_LPUART8_INVERTIFLOWCONTROL))
@@ -1692,6 +1722,7 @@ static struct imxrt_uart_s g_lpuart9priv =
 #endif
 #ifdef CONFIG_IMXRT_LPUART_SINGLEWIRE
   .tx_gpio      = GPIO_LPUART9_TX,
+  .prev_ops     = 0,
 #endif
 #if (((defined(CONFIG_SERIAL_RS485CONTROL) || defined(CONFIG_SERIAL_IFLOWCONTROL))) \
     && defined(CONFIG_LPUART9_INVERTIFLOWCONTROL))
@@ -1758,6 +1789,7 @@ static struct imxrt_uart_s g_lpuart10priv =
 #endif
 #ifdef CONFIG_IMXRT_LPUART_SINGLEWIRE
   .tx_gpio      = GPIO_LPUART10_TX,
+  .prev_ops     = 0,
 #endif
 #if (((defined(CONFIG_SERIAL_RS485CONTROL) || defined(CONFIG_SERIAL_IFLOWCONTROL))) \
     && defined(CONFIG_LPUART10_INVERTIFLOWCONTROL))
@@ -1824,6 +1856,7 @@ static struct imxrt_uart_s g_lpuart11priv =
 #endif
 #ifdef CONFIG_IMXRT_LPUART_SINGLEWIRE
   .tx_gpio      = GPIO_LPUART11_TX,
+  .prev_ops     = 0,
 #endif
 #if (((defined(CONFIG_SERIAL_RS485CONTROL) || defined(CONFIG_SERIAL_IFLOWCONTROL))) \
     && defined(CONFIG_LPUART11_INVERTIFLOWCONTROL))
@@ -1890,6 +1923,7 @@ static struct imxrt_uart_s g_lpuart12priv =
 #endif
 #ifdef CONFIG_IMXRT_LPUART_SINGLEWIRE
   .tx_gpio      = GPIO_LPUART12_TX,
+  .prev_ops     = 0,
 #endif
 #if (((defined(CONFIG_SERIAL_RS485CONTROL) || defined(CONFIG_SERIAL_IFLOWCONTROL))) \
     && defined(CONFIG_LPUART12_INVERTIFLOWCONTROL))
@@ -2663,7 +2697,16 @@ static int imxrt_ioctl(struct file *filep, int cmd, unsigned long arg)
                           ~(IOMUX_PULL_MASK | IOMUX_OPENDRAIN)) | gpio_val);
             regval |= LPUART_CTRL_LOOPS | LPUART_CTRL_RSRC;
             priv->prev_ops = priv->dev.ops;
-            priv->dev.ops = &g_lpuart_singlewire_ops;
+#ifdef SERIAL_HAVE_RXDMA
+            if(priv->dev.ops->receive == imxrt_dma_receive)
+              {
+                priv->dev.ops = &g_lpuart_singlewire_rxdma_ops;
+              }
+            else
+#endif
+              {
+                priv->dev.ops = &g_lpuart_singlewire_ops;
+              }
           }
         else
           {
@@ -2671,9 +2714,10 @@ static int imxrt_ioctl(struct file *filep, int cmd, unsigned long arg)
                                                  IOMUX_OPENDRAIN)) |
                                                  IOMUX_PULL_NONE);
             regval &= ~(LPUART_CTRL_LOOPS | LPUART_CTRL_RSRC);
-            if(priv->dev.ops == &g_lpuart_singlewire_ops)
+            if(priv->prev_ops)
               {
                 priv->dev.ops = priv->prev_ops;
+                priv->prev_ops = 0;
               }
           }
 


### PR DESCRIPTION
## Summary
Allows the use of RXDMA when in singlewire mode

## Impact
IMXRT

## Testing
MR-Tropic.
