### PR TITLE
arch/esp32_spi.c & esp32_wifi_adapter.c amendments

### DIFF
--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -598,7 +598,7 @@ static uint32_t esp32_spi_setfrequency(struct spi_dev_s *dev,
               pre = 8192;
             }
 
-          errval = abs(APB_CLK_FREQ / (pre * n) - frequency);
+          errval = APB_CLK_FREQ / (pre * n) - frequency;
           if (bestn == -1 || errval <= besterr)
             {
               besterr = errval;

--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.c
@@ -5597,6 +5597,8 @@ int esp_wifi_sta_bitrate(struct iwreq *iwr, bool set)
   return OK;
 }
 
+#endif
+
 /****************************************************************************
  * Name: esp_wifi_sta_get_txpower
  *
@@ -5789,6 +5791,8 @@ int esp_wifi_sta_country(struct iwreq *iwr, bool set)
 
   return OK;
 }
+
+#ifdef ESP32_WLAN_HAS_STA
 
 /****************************************************************************
  * Name: esp_wifi_sta_rssi
@@ -6016,7 +6020,8 @@ int esp_wifi_softap_register_recv_cb(int (*recv_cb)(void *buffer,
 {
   int ret;
 
-  ret = esp_wifi_internal_reg_rxcb(ESP_IF_WIFI_AP, (wifi_rxcb_t)recv_cb);
+  // ret = esp_wifi_internal_reg_rxcb(ESP_IF_WIFI_AP, (wifi_rxcb_t)recv_cb);
+  ret = esp_wifi_internal_reg_rxcb(1, (wifi_rxcb_t)recv_cb);
 
   return wifi_errno_trans(ret);
 }

--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.h
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.h
@@ -420,6 +420,8 @@ int esp_wifi_sta_freq(struct iwreq *iwr, bool set);
 
 int esp_wifi_sta_bitrate(struct iwreq *iwr, bool set);
 
+#endif
+
 /****************************************************************************
  * Name: esp_wifi_sta_get_txpower
  *
@@ -489,6 +491,8 @@ int esp_wifi_sta_country(struct iwreq *iwr, bool set);
  *   Negated errno returned on failure.
  *
  ****************************************************************************/
+
+#ifdef ESP32_WLAN_HAS_STA
 
 int esp_wifi_sta_rssi(struct iwreq *iwr, bool set);
 #endif


### PR DESCRIPTION
This PR is working alongside https://github.com/PX4/PX4-Autopilot/pull/24887, to get PX4 running on the ESP32. 

- esp32_wifi_adapted.c: ESP32 SoftAP Mode depends on some STA mode functions. Moved those dependent functions out of the include guard of the ESP32_WLAN_HAS_STA

- esp32_spi.c : resolved compiler error: taking the absolute value of unsigned type 'uint32_t' {aka 'unsigned int'} has no effect

- The compiler cannot find the enum value of ESP_IF_WIFI_AP. This enum is dependent on the esp-wireless-drivers-3rdparty repo. The files of interest to resolve this issue are:
 `/src/include/esp_wifi_types.h`
```
typedef enum {
    WIFI_MODE_NULL = 0,  /**< null mode */
    WIFI_MODE_STA,       /**< WiFi station mode */
    WIFI_MODE_AP,        /**< WiFi soft-AP mode */
    WIFI_MODE_APSTA,     /**< WiFi station + soft-AP mode */
    WIFI_MODE_MAX
} wifi_mode_t;

typedef enum {
    WIFI_IF_STA = ESP_IF_WIFI_STA,
    WIFI_IF_AP  = ESP_IF_WIFI_AP,
} wifi_interface_t;

```

The other file of interest to resolve this would be `/src/include/esp_wifi_interface.h`:
```
typedef enum {
    ESP_IF_WIFI_STA = 0,     /**< ESP32 station interface */
    ESP_IF_WIFI_AP,          /**< ESP32 soft-AP interface */
    ESP_IF_ETH,              /**< ESP32 ethernet interface */
    ESP_IF_MAX
} esp_interface_t;

```

To resolve the compiler not being able to find `WIFI_IF_AP`. I just hardcoded it for now to 1. Any guidance on getting it to compiled via the correct header would be appreciated. (I have tried including both `esp_wifi_interface.h` and `esp_wifi_types.h` with no success. 
