### PR TITLE
Fix alignment for DMA on STM32H7 in function mmcsd_read_csd()

### DIFF
--- a/arch/arm/src/stm32h7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32h7/stm32_sdmmc.c
@@ -211,6 +211,9 @@
                                      STM32_SDMMC_CLKCR_EDGE       |     \
                                      STM32_SDMMC_CLKCR_PWRSAV     |     \
                                      STM32_SDMMC_CLKCR_WIDBUS_D1)
+#define STM32_SDMMC_CLKCR_MMCWIDEXFR (STM32_SDMMC_MMCXFR_CLKDIV   |     \
+                                     STM32_SDMMC_CLKCR_EDGE       |     \
+                                     STM32_SDMMC_CLKCR_WIDBUS_D4)
 #ifdef HAVE_SDMMC_SDIO_MODE
 /* Do not enable power saving configuration bit (in SD 4-bit mode) because
  * the SDIO clock is not enabled when the bus goes to the idle state.
@@ -2127,6 +2130,12 @@ static void stm32_clock(struct sdio_dev_s *dev, enum sdio_clock_e rate)
 
     case CLOCK_MMC_TRANSFER:
       clckr = STM32_SDMMC_CLKCR_MMCXFR;
+      break;
+
+    /* TODO: New mode for MMC 4-bit, not proven working yet */
+
+    case CLOCK_MMC_TRANSFER_4BIT:
+      clckr = STM32_SDMMC_CLKCR_MMCWIDEXFR;
       break;
 
     /* SD normal operation clocking (wide 4-bit mode) */

--- a/arch/arm/src/stm32h7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32h7/stm32_sdmmc.c
@@ -213,6 +213,7 @@
                                      STM32_SDMMC_CLKCR_WIDBUS_D1)
 #define STM32_SDMMC_CLKCR_MMCWIDEXFR (STM32_SDMMC_MMCXFR_CLKDIV   |     \
                                      STM32_SDMMC_CLKCR_EDGE       |     \
+                                     STM32_SDMMC_CLKCR_PWRSAV     |     \
                                      STM32_SDMMC_CLKCR_WIDBUS_D4)
 #ifdef HAVE_SDMMC_SDIO_MODE
 /* Do not enable power saving configuration bit (in SD 4-bit mode) because

--- a/arch/arm/src/stm32h7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32h7/stm32_sdmmc.c
@@ -1405,6 +1405,19 @@ static void stm32_recvdma(struct stm32_dev_s *priv)
     {
       /* In an aligned case, we have always received all blocks */
 
+      /* The IDMA wrote the data directly into priv->buffer. The invalidate
+       * done in stm32_dmarecvsetup happens BEFORE the transfer, and on
+       * Cortex-M7 those cache lines can be re-populated (speculative
+       * prefetch or another access) before the DMA finishes, leaving the CPU
+       * with stale data. Invalidate again now that the transfer is complete
+       * so subsequent reads see the freshly DMA'd data. Fixes intermittent
+       * read corruption with write-back dcache (no CONFIG_ARMV7M_DCACHE_
+       * WRITETHROUGH needed). See NuttX groups thread -KQr4Qq9uMg.
+       */
+
+      up_invalidate_dcache((uintptr_t)priv->buffer,
+                           (uintptr_t)priv->buffer + priv->receivecnt);
+
       priv->remaining = 0;
     }
 

--- a/arch/arm/src/stm32h7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32h7/stm32_sdmmc.c
@@ -238,7 +238,9 @@
 
 /* DTIMER setting */
 
-#define SDMMC_DTIMER_DATATIMEOUT_MS  250
+//#define SDMMC_DTIMER_DATATIMEOUT_MS  250
+// Slightly larger than MMCSD_BLOCK_WDATADELAY, see note there (mmcsd_sdio.c)
+#define SDMMC_DTIMER_DATATIMEOUT_MS  1000
 
 /* Block size for multi-block transfers */
 

--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -3056,6 +3056,11 @@ static int mmcsd_cardidentify(FAR struct mmcsd_state_s *priv)
     {
       ferr("ERROR: CMD1 RECVR3: %d\n", ret);
     }
+  else if (response == 0)
+    {
+      // CLEARLY still an SD-Card
+      finfo("CMD1 response data is 0, SD-Card detected\n");
+    }
   else
     {
       /* CMD1 succeeded... this must be an MMC card */

--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -2650,7 +2650,7 @@ static int mmcsd_mmcinitialize(FAR struct mmcsd_state_s *priv)
 
 static int mmcsd_read_csd(FAR struct mmcsd_state_s *priv)
 {
-  uint8_t buffer[512] aligned_data(16);
+  uint8_t buffer[512] aligned_data(32);
   int ret;
 
   DEBUGASSERT(priv != NULL);
@@ -2670,7 +2670,7 @@ static int mmcsd_read_csd(FAR struct mmcsd_state_s *priv)
 
   if ((priv->caps & SDIO_CAPS_DMASUPPORTED) != 0)
     {
-      ret = SDIO_DMAPREFLIGHT(priv->dev, buffer, priv->blocksize);
+      ret = SDIO_DMAPREFLIGHT(priv->dev, buffer, sizeof(buffer));
       if (ret != OK)
         {
           return ret;

--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -83,7 +83,10 @@
 
 #define MMCSD_SCR_DATADELAY     (100)      /* Wait up to 100MS to get SCR */
 #define MMCSD_BLOCK_RDATADELAY  (100)      /* Wait up to 100MS to get one data block */
-#define MMCSD_BLOCK_WDATADELAY  (260)      /* Wait up to 260MS to write one data block */
+//#define MMCSD_BLOCK_WDATADELAY  (260)      /* Wait up to 260MS to write one data block */
+// We're seeing issues with EMMC, it is known that first write can take a long time due to the EMMC
+// performing some one-time task, so make a longer timeout
+#define MMCSD_BLOCK_WDATADELAY  (990)      /* Wait up to 990MS to write one data block */
 
 #define IS_EMPTY(priv) (priv->type == MMCSD_CARDTYPE_UNKNOWN)
 
@@ -3101,6 +3104,13 @@ static int mmcsd_cardidentify(FAR struct mmcsd_state_s *priv)
     {
       // CLEARLY still an SD-Card
       finfo("CMD1 response data is 0, SD-Card detected\n");
+
+      /* CMD1 is illegal for SD cards and may leave the card in a non-idle
+       * or error-latched state. Reset it back to a clean idle state before
+       * SD identification (CMD8/ACMD41) so detection is deterministic.
+      */
+      mmcsd_sendcmdpoll(priv, MMCSD_CMD0, 0);
+      nxsig_usleep(MMCSD_IDLE_DELAY);
     }
   else
     {

--- a/include/nuttx/sdio.h
+++ b/include/nuttx/sdio.h
@@ -924,7 +924,8 @@ enum sdio_clock_e
 {
   CLOCK_SDIO_DISABLED = 0, /* Clock is disabled */
   CLOCK_IDMODE,            /* Initial ID mode clocking (<400KHz) */
-  CLOCK_MMC_TRANSFER,      /* MMC normal operation clocking */
+  CLOCK_MMC_TRANSFER,      /* MMC normal operation clocking (narrow 1-bit mode) */
+  CLOCK_MMC_TRANSFER_4BIT, /* MMC normal operation clocking (wide 4-bit mode) */
   CLOCK_SD_TRANSFER_1BIT,  /* SD normal operation clocking (narrow 1-bit mode) */
   CLOCK_SD_TRANSFER_4BIT   /* SD normal operation clocking (wide 4-bit mode) */
 };


### PR DESCRIPTION
This function (mmcsd_read_csd()) gets called during init of an MMC card. STM32H7 DMA expects 32 byte alignment, so the call to SDIO_DMAPREFLIGHT() fails.

## Summary
Issue https://github.com/PX4/NuttX/issues/346

## Impact

## Testing

