### PR TITLE
feat(libc): add netdb core API support

### DIFF
--- a/include/netdb.h
+++ b/include/netdb.h
@@ -283,14 +283,7 @@ int rexec_af(FAR char **ahost, int inport, FAR const char *user,
              FAR const char *passwd, FAR const char *cmd, FAR int *fd2p,
              sa_family_t af);
 
-#ifdef CONFIG_LIBC_NETDB
-#if 0 /* None of these are yet supported */
-
-void                 endhostent(void);
-void                 endnetent(void);
-void                 endprotoent(void);
-void                 endservent(void);
-#endif
+#ifdef CONFIG_LIBC_NETDB_CORE
 void                 freeaddrinfo(FAR struct addrinfo *ai);
 FAR const char      *gai_strerror(int);
 int                  getaddrinfo(FAR const char *nodename,
@@ -301,6 +294,16 @@ int                  getnameinfo(FAR const struct sockaddr *sa,
                                  socklen_t salen, FAR char *node,
                                  socklen_t nodelen, FAR char *service,
                                  socklen_t servicelen, int flags);
+#endif
+
+#ifdef CONFIG_LIBC_NETDB
+#if 0 /* None of these are yet supported */
+
+void                 endhostent(void);
+void                 endnetent(void);
+void                 endprotoent(void);
+void                 endservent(void);
+#endif
 
 FAR struct hostent  *gethostbyaddr(FAR const void *addr, socklen_t len,
                                    int type);

--- a/libs/libc/netdb/Kconfig
+++ b/libs/libc/netdb/Kconfig
@@ -6,8 +6,16 @@
 config LIBC_NETDB
 	bool
 	default n
+    select LIBC_NETDB_CORE
 
 menu "NETDB Support"
+
+config LIBC_NETDB_CORE
+    bool "Enable minimal netdb core API"
+    default n
+    ---help---
+        Enable minimal netdb functions backends.
+        Provides freeaddrinfo(), gai_strerror(), getaddrinfo(), getnameinfo().
 
 config LIBC_GAISTRERROR
 	bool "Enable gai_strerror"


### PR DESCRIPTION
- Added LIBC_NETDB_CORE config option to enable minimal netdb core API
- Updated netdb.h header file to conditionally compile related functions based on configuration

## Summary
Introduced a minimal netdb core API controlled by the new LIBC_NETDB_CORE config option.  
This allows enabling essential netdb functions without requiring the full netdb implementation.

## Impact
- Existing builds are not affected unless LIBC_NETDB_CORE is explicitly enabled.  
- Ensures conditional compilation to avoid unnecessary code inclusion.

## Testing
- Verified successful build with LIBC_NETDB_CORE enabled and disabled.  
- Checked that related functions in netdb.h are correctly included/excluded based on the configuration.  