### PR TITLE
[BACKPORT] nxsem_destroyholder: Use critical section when destroying holder(s)

### DIFF
--- a/sched/semaphore/sem_holder.c
+++ b/sched/semaphore/sem_holder.c
@@ -796,6 +796,8 @@ void nxsem_initialize_holders(void)
 
 void nxsem_destroyholder(FAR sem_t *sem)
 {
+  irqstate_t flags = enter_critical_section();
+
   /* It might be an error if a semaphore is destroyed while there are any
    * holders of the semaphore (except perhaps the thread that release the
    * semaphore itself).  We actually have to assume that the caller knows
@@ -830,6 +832,8 @@ void nxsem_destroyholder(FAR sem_t *sem)
 #endif
 
   nxsem_foreachholder(sem, nxsem_recoverholders, NULL);
+
+  leave_critical_section(flags);
 }
 
 /****************************************************************************


### PR DESCRIPTION
Backport of https://github.com/apache/nuttx/pull/15243