### PR TITLE
Allow enabling libc netdb support via menuconfig

### DIFF
--- a/libs/libc/netdb/Kconfig
+++ b/libs/libc/netdb/Kconfig
@@ -3,11 +3,11 @@
 # see the file kconfig-language.txt in the NuttX tools repository.
 #
 
-config LIBC_NETDB
-	bool
-	default n
-
 menu "NETDB Support"
+
+config LIBC_NETDB
+	bool "Enable libc netdb"
+	default n
 
 config LIBC_GAISTRERROR
 	bool "Enable gai_strerror"


### PR DESCRIPTION
## Summary

This PR allows enabling libc netdb support via `make <target> menuconfig`. The PR adds a checkbox under NETDB Support menu by adding a prompt to an existing config item. This is allows fixing https://github.com/PX4/PX4-Autopilot/issues/25540 and https://github.com/PX4/PX4-Autopilot/issues/24273.

<img width="936" height="392" alt="Screenshot from 2025-09-25 13-35-11" src="https://github.com/user-attachments/assets/5eef3da6-1ee9-415b-9444-105ffc2f1ba4" />

## Impact

Allow compiling with `uxrce_dds_client` support enabled which requires `freeaddrinfo()` and friends but with minimal changes to NuttX fork itself.

## Testing

Fresh checkout fails.

```
$ make micoair_h743-v2_default -j8
...
/home/tuupola/Code/c/PX4-Autopilot/src/modules/uxrce_dds_client/Micro-XRCE-DDS-Client/src/c/profile/transport/ip/udp/udp_transport_posix.c:57:13: error: implicit declaration of function 'freeaddrinfo' [-Wimplicit-function-declaration]
   57 |             freeaddrinfo(result);
      |             ^~~~~~~~~~~~
ninja: build stopped: subcommand failed.
...
```

After enabling libc netdb support compilation succeeds.

```
$ make micoair_h743-v2 menuconfig

$ git diff boards/micoair/h743-v2/nuttx-config/nsh/defconfig
diff --git a/boards/micoair/h743-v2/nuttx-config/nsh/defconfig b/boards/micoair/h743-v2/nuttx-config/nsh/defconfig
index dab70e35fa..3945e6a2b0 100644
--- a/boards/micoair/h743-v2/nuttx-config/nsh/defconfig
+++ b/boards/micoair/h743-v2/nuttx-config/nsh/defconfig
@@ -118,6 +118,7 @@ CONFIG_IOB_NCHAINS=24
 CONFIG_LIBC_FLOATINGPOINT=y
 CONFIG_LIBC_LONG_LONG=y
 CONFIG_LIBC_MAX_EXITFUNS=1
+CONFIG_LIBC_NETDB=y
 CONFIG_LIBC_STRERROR=y
 CONFIG_MEMSET_64BIT=y
 CONFIG_MEMSET_OPTSPEED=y

$ make micoair_h743-v2_default -j8
...
Memory region         Used Size  Region Size  %age Used
        ITCM_RAM:           0 B        64 KB      0.00%
           FLASH:     1903296 B      1920 KB     96.81%
       DTCM1_RAM:           0 B        64 KB      0.00%
       DTCM2_RAM:           0 B        64 KB      0.00%
        AXI_SRAM:       52088 B       512 KB      9.93%
           SRAM1:           0 B       128 KB      0.00%
           SRAM2:           0 B       128 KB      0.00%
           SRAM3:           0 B        32 KB      0.00%
           SRAM4:           0 B        64 KB      0.00%
          BKPRAM:           0 B         4 KB      0.00%
```
