### PR TITLE
fs: align littlefs version with PX4 default

### DIFF
--- a/fs/littlefs/Kconfig
+++ b/fs/littlefs/Kconfig
@@ -166,7 +166,7 @@ config FS_LITTLEFS_GETPATH
 
 config FS_LITTLEFS_VERSION
 	string "LITTLEFS version to use"
-	default "v2.5.1"
+	default "v2.11.3"
 	---help---
 		The LITTLEFS version to use.
 


### PR DESCRIPTION
To align with https://github.com/PX4/NuttX/pull/371, otherwise as soon as we update to this NuttX version we will trigger the downgrade path again.