### PR TITLE
[BACKPORT] arch/arm: add STM32H755XI chip

### DIFF
--- a/arch/arm/include/stm32h7/chip.h
+++ b/arch/arm/include/stm32h7/chip.h
@@ -71,7 +71,8 @@
     defined (CONFIG_ARCH_CHIP_STM32H753VI) || \
     defined (CONFIG_ARCH_CHIP_STM32H753XI) || \
     defined (CONFIG_ARCH_CHIP_STM32H753ZI) || \
-    defined (CONFIG_ARCH_CHIP_STM32H755II)
+    defined (CONFIG_ARCH_CHIP_STM32H755II) || \
+    defined (CONFIG_ARCH_CHIP_STM32H755XI)
 #elif defined(CONFIG_ARCH_CHIP_STM32H747XI)
 #else
 #  error STM32 H7 chip not identified

--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -223,10 +223,20 @@ config ARCH_CHIP_STM32H755II
 	select STM32H7_IO_CONFIG_I
 	select STM32H7_HAVE_FDCAN1
 	select STM32H7_HAVE_FDCAN2
-	select STM32H7_HAVE_SMPS
 	---help---
 		STM32 H7 Cortex M7, 2048 Kb FLASH, 1024K Kb SRAM,
 		with cryptographic accelerator, LQFP176/UFBGA176
+
+config ARCH_CHIP_STM32H755XI
+	bool "STM32H755XI"
+	select STM32H7_STM32H7X5XX
+	select STM32H7_FLASH_CONFIG_I
+	select STM32H7_IO_CONFIG_X
+	select STM32H7_HAVE_FDCAN1
+	select STM32H7_HAVE_FDCAN2
+	---help---
+		STM32 H7 Cortex M7, 2048 Kb FLASH, 1024K Kb SRAM,
+		with cryptographic accelerator, TFBGA240
 
 endchoice # STM32 H7 Chip Selection
 


### PR DESCRIPTION
Backport of https://github.com/apache/nuttx/pull/18739.

Support STM32H755XI chip.
The STM32H755XI is a chip with a different package than the STM32H755II.

## Summary
Add STM32H755XI, based on the STM32H755II. For JAE flight controllers with PX4 NuttX.

## Impact
None.

## Testing
We have confirmed that the firmware correctly on PX4 Autopilot.
