### PR TITLE
[BACKPORT] arch/arm: apply Ethernet for STM32H755XI

### DIFF
--- a/arch/arm/src/stm32h7/hardware/stm32_ethernet.h
+++ b/arch/arm/src/stm32h7/hardware/stm32_ethernet.h
@@ -32,6 +32,7 @@
  */
 
 #if defined(CONFIG_STM32H7_STM32H7X3XX) || \
+    defined(CONFIG_STM32H7_STM32H7X5XX) || \
     defined(CONFIG_STM32H7_STM32H7X7XX)
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
Enabled Ethernet definition for the STM32H7X5XX family.
I  picked up only the part from the master branch(8ceff0dc : "arm/stm32h7: Add STM32H745 family") that enables the Ethernet definition for the STM32H7X5XX family.

## Impact
None.

## Testing
We have confirmed that the firmware correctly on PX4 Autopilot.