### PR TITLE
mtd/w25: add Micron N25Q128 JEDEC manufacturer and memory type support

### DIFF
--- a/drivers/mtd/w25.c
+++ b/drivers/mtd/w25.c
@@ -100,11 +100,13 @@
 
 #define W25_JEDEC_WINBOND          0xef  /* Winbond manufacturer ID */
 #define W25_JEDEC_AMIC             0x37  /* AMIC manufacturer ID */
+#define W25_JEDEC_MICRON           0x20  /* Micron/STMicro manufacturer ID (N25Q/M25P) */
 
 #define W25X_JEDEC_MEMORY_TYPE     0x30  /* W25X memory type */
 #define W25Q_JEDEC_MEMORY_TYPE_A   0x40  /* W25Q memory type */
 #define W25Q_JEDEC_MEMORY_TYPE_B   0x60  /* W25Q memory type */
 #define W25Q_JEDEC_MEMORY_TYPE_C   0x50  /* W25Q memory type */
+#define W25Q_JEDEC_MEMORY_TYPE_D   0xba  /* Micron N25Q memory type */
 
 #define W25_JEDEC_CAPACITY_8MBIT   0x14  /* 256x4096  = 8Mbit memory capacity */
 #define W25_JEDEC_CAPACITY_16MBIT  0x15  /* 512x4096  = 16Mbit memory capacity */
@@ -390,11 +392,13 @@ static inline int w25_readid(struct w25_dev_s *priv)
   /* Check for a valid manufacturer and memory type */
 
   if ((manufacturer == W25_JEDEC_WINBOND  ||
-       manufacturer == W25_JEDEC_AMIC)    &&
-      (memory == W25X_JEDEC_MEMORY_TYPE   ||
-       memory == W25Q_JEDEC_MEMORY_TYPE_A ||
-       memory == W25Q_JEDEC_MEMORY_TYPE_B ||
-       memory == W25Q_JEDEC_MEMORY_TYPE_C))
+       manufacturer == W25_JEDEC_AMIC     ||
+       manufacturer == W25_JEDEC_MICRON)  &&
+      (memory == W25X_JEDEC_MEMORY_TYPE        ||
+       memory == W25Q_JEDEC_MEMORY_TYPE_A      ||
+       memory == W25Q_JEDEC_MEMORY_TYPE_B      ||
+       memory == W25Q_JEDEC_MEMORY_TYPE_C      ||
+       memory == W25Q_JEDEC_MEMORY_TYPE_D))
     {
       /* Okay.. is it a FLASH capacity that we understand? If so, save
        * the FLASH capacity.


### PR DESCRIPTION
The Micron/STMicro N25Q128 SPI NOR flash (JEDEC 0x20/0xBA/0x18) is used
on several STM32H7 flight controllers as onboard dataflash. The existing
driver only accepted Winbond (0xEF) and AMIC (0x37) manufacturers,
causing silent chip-not-recognised failures.

Add W25_JEDEC_MICRON (0x20) to the manufacturer check and
W25Q_JEDEC_MEMORY_TYPE_D (0xBA) to the memory type check.

Tested on DAKEFPV H743 with Micron N25Q128 (JEDEC 0x20/0xBA/0x18).