### PR TITLE
[BACKPORT] arch/arm/stm32: Support optional TX/RX UART GPIOs.

### DIFF
--- a/arch/arm/src/stm32/stm32_serial.c
+++ b/arch/arm/src/stm32/stm32_serial.c
@@ -1738,8 +1738,15 @@ static int up_setup(struct uart_dev_s *dev)
 
   /* Configure pins for USART use */
 
-  stm32_configgpio(priv->tx_gpio);
-  stm32_configgpio(priv->rx_gpio);
+  if (priv->tx_gpio != 0)
+    {
+      stm32_configgpio(priv->tx_gpio);
+    }
+
+  if (priv->rx_gpio != 0)
+    {
+      stm32_configgpio(priv->rx_gpio);
+    }
 
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
   if (priv->cts_gpio != 0)
@@ -1948,8 +1955,15 @@ static void up_shutdown(struct uart_dev_s *dev)
    * then this may need to be a configuration option.
    */
 
-  stm32_unconfiggpio(priv->tx_gpio);
-  stm32_unconfiggpio(priv->rx_gpio);
+  if (priv->tx_gpio != 0)
+    {
+      stm32_unconfiggpio(priv->tx_gpio);
+    }
+
+  if (priv->rx_gpio != 0)
+    {
+      stm32_unconfiggpio(priv->rx_gpio);
+    }
 
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
   if (priv->cts_gpio != 0)
@@ -2257,14 +2271,22 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
 #if defined(CONFIG_STM32_STM32F10XX)
         if ((arg & SER_SINGLEWIRE_ENABLED) != 0)
           {
-            stm32_configgpio((priv->tx_gpio & ~(GPIO_CNF_MASK)) |
-                             GPIO_CNF_AFOD);
+            if (priv->tx_gpio != 0)
+              {
+                stm32_configgpio((priv->tx_gpio & ~(GPIO_CNF_MASK)) |
+                                 GPIO_CNF_AFOD);
+              }
+
             cr |= USART_CR3_HDSEL;
           }
         else
           {
-            stm32_configgpio((priv->tx_gpio & ~(GPIO_CNF_MASK)) |
-                             GPIO_CNF_AFPP);
+            if (priv->tx_gpio != 0)
+              {
+                stm32_configgpio((priv->tx_gpio & ~(GPIO_CNF_MASK)) |
+                                 GPIO_CNF_AFPP);
+              }
+
             cr &= ~USART_CR3_HDSEL;
           }
 #else
@@ -2279,16 +2301,24 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
             gpio_val |= ((arg & SER_SINGLEWIRE_PULL_MASK) ==
                          SER_SINGLEWIRE_PULLDOWN) ? GPIO_PULLDOWN
                                                   : GPIO_FLOAT;
-            stm32_configgpio((priv->tx_gpio & ~(GPIO_PUPD_MASK |
-                                                GPIO_OPENDRAIN)) |
-                             gpio_val);
+            if (priv->tx_gpio != 0)
+              {
+                stm32_configgpio((priv->tx_gpio & ~(GPIO_PUPD_MASK |
+                                                    GPIO_OPENDRAIN)) |
+                                 gpio_val);
+              }
+
             cr |= USART_CR3_HDSEL;
           }
         else
           {
-            stm32_configgpio((priv->tx_gpio & ~(GPIO_PUPD_MASK |
-                                                GPIO_OPENDRAIN)) |
-                             GPIO_PUSHPULL);
+            if (priv->tx_gpio != 0)
+              {
+                stm32_configgpio((priv->tx_gpio & ~(GPIO_PUPD_MASK |
+                                                    GPIO_OPENDRAIN)) |
+                                 GPIO_PUSHPULL);
+              }
+
             cr &= ~USART_CR3_HDSEL;
           }
 #endif
@@ -2398,7 +2428,6 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
     case TIOCSBRK:  /* BSD compatibility: Turn break on, unconditionally */
       {
         irqstate_t flags;
-        uint32_t tx_break;
 
         flags = enter_critical_section();
 
@@ -2410,9 +2439,13 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
 
         /* Configure TX as a GPIO output pin and Send a break signal */
 
-        tx_break = GPIO_OUTPUT | (~(GPIO_MODE_MASK | GPIO_OUTPUT_SET) &
-                                  priv->tx_gpio);
-        stm32_configgpio(tx_break);
+        if (priv->tx_gpio != 0)
+          {
+            uint32_t tx_break = GPIO_OUTPUT |
+                    (~(GPIO_MODE_MASK | GPIO_OUTPUT_SET) &
+                     priv->tx_gpio);
+            stm32_configgpio(tx_break);
+          }
 
         leave_critical_section(flags);
       }
@@ -2426,7 +2459,10 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
 
         /* Configure TX back to U(S)ART */
 
-        stm32_configgpio(priv->tx_gpio);
+        if (priv->tx_gpio != 0)
+          {
+            stm32_configgpio(priv->tx_gpio);
+          }
 
         priv->ie &= ~USART_CR1_IE_BREAK_INPROGRESS;
 

--- a/arch/arm/src/stm32f7/stm32_serial.c
+++ b/arch/arm/src/stm32f7/stm32_serial.c
@@ -1904,8 +1904,15 @@ static int up_setup(struct uart_dev_s *dev)
 
   /* Configure pins for USART use */
 
-  stm32_configgpio(priv->tx_gpio);
-  stm32_configgpio(priv->rx_gpio);
+  if (priv->tx_gpio != 0)
+    {
+      stm32_configgpio(priv->tx_gpio);
+    }
+
+  if (priv->rx_gpio != 0)
+    {
+      stm32_configgpio(priv->rx_gpio);
+    }
 
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
   if (priv->cts_gpio != 0)
@@ -2117,8 +2124,15 @@ static void up_shutdown(struct uart_dev_s *dev)
    * then this may need to be a configuration option.
    */
 
-  stm32_unconfiggpio(priv->tx_gpio);
-  stm32_unconfiggpio(priv->rx_gpio);
+  if (priv->tx_gpio != 0)
+    {
+      stm32_unconfiggpio(priv->tx_gpio);
+    }
+
+  if (priv->rx_gpio != 0)
+    {
+      stm32_unconfiggpio(priv->rx_gpio);
+    }
 
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
   if (priv->cts_gpio != 0)
@@ -2442,15 +2456,24 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
             gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) ==
                                SER_SINGLEWIRE_PULLDOWN ?
                                GPIO_PULLDOWN : GPIO_FLOAT;
-            stm32_configgpio((priv->tx_gpio &
-                            ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) | gpio_val);
+            if (priv->tx_gpio != 0)
+              {
+                stm32_configgpio((priv->tx_gpio &
+                                  ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) |
+                                  gpio_val);
+              }
+
             cr |= USART_CR3_HDSEL;
           }
         else
           {
-            stm32_configgpio((priv->tx_gpio & ~(GPIO_PUPD_MASK |
-                                                GPIO_OPENDRAIN)) |
-                                                GPIO_PUSHPULL);
+            if (priv->tx_gpio != 0)
+              {
+                stm32_configgpio((priv->tx_gpio & ~(GPIO_PUPD_MASK |
+                                                    GPIO_OPENDRAIN)) |
+                                                    GPIO_PUSHPULL);
+              }
+
             cr &= ~USART_CR3_HDSEL;
           }
 
@@ -2657,7 +2680,6 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
     case TIOCSBRK:  /* BSD compatibility: Turn break on, unconditionally */
       {
         irqstate_t flags;
-        uint32_t tx_break;
 
         flags = enter_critical_section();
 
@@ -2669,9 +2691,12 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
 
         /* Configure TX as a GPIO output pin and Send a break signal */
 
-        tx_break = GPIO_OUTPUT |
-                   (~(GPIO_MODE_MASK | GPIO_OUTPUT_SET) & priv->tx_gpio);
-        stm32_configgpio(tx_break);
+        if (priv->tx_gpio != 0)
+          {
+            uint32_t tx_break = GPIO_OUTPUT |
+                    (~(GPIO_MODE_MASK | GPIO_OUTPUT_SET) & priv->tx_gpio);
+            stm32_configgpio(tx_break);
+          }
 
         leave_critical_section(flags);
       }
@@ -2685,7 +2710,10 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
 
         /* Configure TX back to U(S)ART */
 
-        stm32_configgpio(priv->tx_gpio);
+        if (priv->tx_gpio != 0)
+          {
+            stm32_configgpio(priv->tx_gpio);
+          }
 
         priv->ie &= ~USART_CR1_IE_BREAK_INPROGRESS;
 

--- a/arch/arm/src/stm32h7/stm32_serial.c
+++ b/arch/arm/src/stm32h7/stm32_serial.c
@@ -2082,8 +2082,15 @@ static int up_setup(struct uart_dev_s *dev)
 
   /* Configure pins for USART use */
 
-  stm32_configgpio(priv->tx_gpio);
-  stm32_configgpio(priv->rx_gpio);
+  if (priv->tx_gpio != 0)
+    {
+      stm32_configgpio(priv->tx_gpio);
+    }
+
+  if (priv->rx_gpio != 0)
+    {
+      stm32_configgpio(priv->rx_gpio);
+    }
 
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
   if (priv->cts_gpio != 0)
@@ -2314,8 +2321,15 @@ static void up_shutdown(struct uart_dev_s *dev)
    *  If not, then this may need to be a configuration option.
    */
 
-  stm32_unconfiggpio(priv->tx_gpio);
-  stm32_unconfiggpio(priv->rx_gpio);
+  if (priv->tx_gpio != 0)
+    {
+      stm32_unconfiggpio(priv->tx_gpio);
+    }
+
+  if (priv->rx_gpio != 0)
+    {
+      stm32_unconfiggpio(priv->rx_gpio);
+    }
 
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
   if (priv->cts_gpio != 0)
@@ -2644,15 +2658,24 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
             gpio_val |= (arg & SER_SINGLEWIRE_PULL_MASK) ==
                          SER_SINGLEWIRE_PULLDOWN ?
                          GPIO_PULLDOWN : GPIO_FLOAT;
-            stm32_configgpio((priv->tx_gpio &
-                            ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) | gpio_val);
+            if (priv->tx_gpio != 0)
+              {
+                stm32_configgpio((priv->tx_gpio &
+                                  ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) |
+                                  gpio_val);
+              }
+
             cr |= USART_CR3_HDSEL;
           }
         else
           {
-            stm32_configgpio((priv->tx_gpio &
-                            ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) |
-                              GPIO_PUSHPULL);
+            if (priv->tx_gpio != 0)
+              {
+                stm32_configgpio((priv->tx_gpio &
+                                  ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) |
+                                  GPIO_PUSHPULL);
+              }
+
             cr &= ~USART_CR3_HDSEL;
           }
 
@@ -2859,7 +2882,6 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
     case TIOCSBRK:  /* BSD compatibility: Turn break on, unconditionally */
       {
         irqstate_t flags;
-        uint32_t tx_break;
 
         flags = enter_critical_section();
 
@@ -2871,9 +2893,12 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
 
         /* Configure TX as a GPIO output pin and Send a break signal */
 
-        tx_break = GPIO_OUTPUT |
-                (~(GPIO_MODE_MASK | GPIO_OUTPUT_SET) & priv->tx_gpio);
-        stm32_configgpio(tx_break);
+        if (priv->tx_gpio != 0)
+          {
+            uint32_t tx_break = GPIO_OUTPUT |
+                    (~(GPIO_MODE_MASK | GPIO_OUTPUT_SET) & priv->tx_gpio);
+            stm32_configgpio(tx_break);
+          }
 
         leave_critical_section(flags);
       }
@@ -2887,7 +2912,10 @@ static int up_ioctl(struct file *filep, int cmd, unsigned long arg)
 
         /* Configure TX back to U(S)ART */
 
-        stm32_configgpio(priv->tx_gpio);
+        if (priv->tx_gpio != 0)
+          {
+            stm32_configgpio(priv->tx_gpio);
+          }
 
         priv->ie &= ~USART_CR1_IE_BREAK_INPROGRESS;
 

--- a/arch/arm/src/stm32l4/stm32l4_serial.c
+++ b/arch/arm/src/stm32l4/stm32l4_serial.c
@@ -1462,8 +1462,15 @@ static int stm32l4serial_setup(struct uart_dev_s *dev)
 
   /* Configure pins for USART use */
 
-  stm32l4_configgpio(priv->tx_gpio);
-  stm32l4_configgpio(priv->rx_gpio);
+  if (priv->tx_gpio != 0)
+    {
+      stm32l4_configgpio(priv->tx_gpio);
+    }
+
+  if (priv->rx_gpio != 0)
+    {
+      stm32l4_configgpio(priv->rx_gpio);
+    }
 
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
   if (priv->cts_gpio != 0)
@@ -1688,8 +1695,15 @@ static void stm32l4serial_shutdown(struct uart_dev_s *dev)
    * then this may need to be a configuration option.
    */
 
-  stm32l4_unconfiggpio(priv->tx_gpio);
-  stm32l4_unconfiggpio(priv->rx_gpio);
+  if (priv->tx_gpio != 0)
+    {
+      stm32l4_unconfiggpio(priv->tx_gpio);
+    }
+
+  if (priv->rx_gpio != 0)
+    {
+      stm32l4_unconfiggpio(priv->rx_gpio);
+    }
 
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
   if (priv->cts_gpio != 0)
@@ -2005,17 +2019,23 @@ static int stm32l4serial_ioctl(struct file *filep, int cmd,
               (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLDOWN ?
                                                   GPIO_PULLDOWN : GPIO_FLOAT;
 
-            stm32l4_configgpio((priv->tx_gpio & ~(GPIO_PUPD_MASK |
-                                                  GPIO_OPENDRAIN)) |
-                                                  gpio_val);
+            if (priv->tx_gpio != 0)
+              {
+                stm32l4_configgpio((priv->tx_gpio & ~(GPIO_PUPD_MASK |
+                                                      GPIO_OPENDRAIN)) |
+                                                      gpio_val);
+              }
 
             cr |= USART_CR3_HDSEL;
           }
         else
           {
-            stm32l4_configgpio((priv->tx_gpio & ~(GPIO_PUPD_MASK |
-                                                  GPIO_OPENDRAIN)) |
-                                                  GPIO_PUSHPULL);
+            if (priv->tx_gpio != 0)
+              {
+                stm32l4_configgpio((priv->tx_gpio & ~(GPIO_PUPD_MASK |
+                                                      GPIO_OPENDRAIN)) |
+                                                      GPIO_PUSHPULL);
+              }
 
             cr &= ~USART_CR3_HDSEL;
           }
@@ -2223,7 +2243,6 @@ static int stm32l4serial_ioctl(struct file *filep, int cmd,
     case TIOCSBRK:  /* BSD compatibility: Turn break on, unconditionally */
       {
         irqstate_t flags;
-        uint32_t tx_break;
 
         flags = enter_critical_section();
 
@@ -2235,9 +2254,12 @@ static int stm32l4serial_ioctl(struct file *filep, int cmd,
 
         /* Configure TX as a GPIO output pin and Send a break signal */
 
-        tx_break = GPIO_OUTPUT |
-                   (~(GPIO_MODE_MASK | GPIO_OUTPUT_SET) & priv->tx_gpio);
-        stm32l4_configgpio(tx_break);
+        if (priv->tx_gpio != 0)
+          {
+            uint32_t tx_break = GPIO_OUTPUT |
+                    (~(GPIO_MODE_MASK | GPIO_OUTPUT_SET) & priv->tx_gpio);
+            stm32l4_configgpio(tx_break);
+          }
 
         leave_critical_section(flags);
       }
@@ -2251,7 +2273,10 @@ static int stm32l4serial_ioctl(struct file *filep, int cmd,
 
         /* Configure TX back to U(S)ART */
 
-        stm32l4_configgpio(priv->tx_gpio);
+        if (priv->tx_gpio != 0)
+          {
+            stm32l4_configgpio(priv->tx_gpio);
+          }
 
         priv->ie &= ~USART_CR1_IE_BREAK_INPROGRESS;
 

--- a/arch/arm/src/stm32l5/stm32l5_serial.c
+++ b/arch/arm/src/stm32l5/stm32l5_serial.c
@@ -1396,8 +1396,15 @@ static int stm32l5serial_setup(struct uart_dev_s *dev)
 
   /* Configure pins for USART use */
 
-  stm32l5_configgpio(priv->tx_gpio);
-  stm32l5_configgpio(priv->rx_gpio);
+  if (priv->tx_gpio != 0)
+    {
+      stm32l5_configgpio(priv->tx_gpio);
+    }
+
+  if (priv->rx_gpio != 0)
+    {
+      stm32l5_configgpio(priv->rx_gpio);
+    }
 
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
   if (priv->cts_gpio != 0)
@@ -1622,8 +1629,15 @@ static void stm32l5serial_shutdown(struct uart_dev_s *dev)
    * then this may need to be a configuration option.
    */
 
-  stm32l5_unconfiggpio(priv->tx_gpio);
-  stm32l5_unconfiggpio(priv->rx_gpio);
+  if (priv->tx_gpio != 0)
+    {
+      stm32l5_unconfiggpio(priv->tx_gpio);
+    }
+
+  if (priv->rx_gpio != 0)
+    {
+      stm32l5_unconfiggpio(priv->rx_gpio);
+    }
 
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
   if (priv->cts_gpio != 0)
@@ -1946,17 +1960,24 @@ static int stm32l5serial_ioctl(struct file *filep, int cmd,
                 gpio_val |= GPIO_FLOAT;
               }
 
-            stm32l5_configgpio((priv->tx_gpio &
-                                ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) |
-                               gpio_val);
+            if (priv->tx_gpio != 0)
+              {
+                stm32l5_configgpio((priv->tx_gpio &
+                                    ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) |
+                                    gpio_val);
+              }
 
             cr |= USART_CR3_HDSEL;
           }
         else
           {
-            stm32l5_configgpio((priv->tx_gpio &
-                                ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) |
-                               GPIO_PUSHPULL);
+            if (priv->tx_gpio != 0)
+              {
+                stm32l5_configgpio((priv->tx_gpio &
+                                    ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) |
+                                    GPIO_PUSHPULL);
+              }
+
             cr &= ~USART_CR3_HDSEL;
           }
 
@@ -2163,7 +2184,6 @@ static int stm32l5serial_ioctl(struct file *filep, int cmd,
     case TIOCSBRK:  /* BSD compatibility: Turn break on, unconditionally */
       {
         irqstate_t flags;
-        uint32_t tx_break;
 
         flags = enter_critical_section();
 
@@ -2175,9 +2195,12 @@ static int stm32l5serial_ioctl(struct file *filep, int cmd,
 
         /* Configure TX as a GPIO output pin and Send a break signal */
 
-        tx_break = GPIO_OUTPUT |
-                   (~(GPIO_MODE_MASK | GPIO_OUTPUT_SET) & priv->tx_gpio);
-        stm32l5_configgpio(tx_break);
+        if (priv->tx_gpio != 0)
+          {
+            uint32_t tx_break = GPIO_OUTPUT |
+                    (~(GPIO_MODE_MASK | GPIO_OUTPUT_SET) & priv->tx_gpio);
+            stm32l5_configgpio(tx_break);
+          }
 
         leave_critical_section(flags);
       }
@@ -2191,7 +2214,10 @@ static int stm32l5serial_ioctl(struct file *filep, int cmd,
 
         /* Configure TX back to U(S)ART */
 
-        stm32l5_configgpio(priv->tx_gpio);
+        if (priv->tx_gpio != 0)
+          {
+            stm32l5_configgpio(priv->tx_gpio);
+          }
 
         priv->ie &= ~USART_CR1_IE_BREAK_INPROGRESS;
 

--- a/arch/arm/src/stm32u5/stm32_serial.c
+++ b/arch/arm/src/stm32u5/stm32_serial.c
@@ -1396,8 +1396,15 @@ static int stm32serial_setup(struct uart_dev_s *dev)
 
   /* Configure pins for USART use */
 
-  stm32_configgpio(priv->tx_gpio);
-  stm32_configgpio(priv->rx_gpio);
+  if (priv->tx_gpio != 0)
+    {
+      stm32_configgpio(priv->tx_gpio);
+    }
+
+  if (priv->rx_gpio != 0)
+    {
+      stm32_configgpio(priv->rx_gpio);
+    }
 
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
   if (priv->cts_gpio != 0)
@@ -1622,8 +1629,15 @@ static void stm32serial_shutdown(struct uart_dev_s *dev)
    * then this may need to be a configuration option.
    */
 
-  stm32_unconfiggpio(priv->tx_gpio);
-  stm32_unconfiggpio(priv->rx_gpio);
+  if (priv->tx_gpio != 0)
+    {
+      stm32_unconfiggpio(priv->tx_gpio);
+    }
+
+  if (priv->rx_gpio != 0)
+    {
+      stm32_unconfiggpio(priv->rx_gpio);
+    }
 
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
   if (priv->cts_gpio != 0)
@@ -1946,17 +1960,24 @@ static int stm32serial_ioctl(struct file *filep, int cmd,
                 gpio_val |= GPIO_FLOAT;
               }
 
-            stm32_configgpio((priv->tx_gpio &
-                                ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) |
-                               gpio_val);
+            if (priv->tx_gpio != 0)
+              {
+                stm32_configgpio((priv->tx_gpio &
+                                  ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) |
+                                  gpio_val);
+              }
 
             cr |= USART_CR3_HDSEL;
           }
         else
           {
-            stm32_configgpio((priv->tx_gpio &
-                                ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) |
-                               GPIO_PUSHPULL);
+            if (priv->tx_gpio != 0)
+              {
+                stm32_configgpio((priv->tx_gpio &
+                                  ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) |
+                                  GPIO_PUSHPULL);
+              }
+
             cr &= ~USART_CR3_HDSEL;
           }
 
@@ -2163,7 +2184,6 @@ static int stm32serial_ioctl(struct file *filep, int cmd,
     case TIOCSBRK:  /* BSD compatibility: Turn break on, unconditionally */
       {
         irqstate_t flags;
-        uint32_t tx_break;
 
         flags = enter_critical_section();
 
@@ -2175,9 +2195,12 @@ static int stm32serial_ioctl(struct file *filep, int cmd,
 
         /* Configure TX as a GPIO output pin and Send a break signal */
 
-        tx_break = GPIO_OUTPUT |
-                   (~(GPIO_MODE_MASK | GPIO_OUTPUT_SET) & priv->tx_gpio);
-        stm32_configgpio(tx_break);
+        if (priv->tx_gpio != 0)
+          {
+            uint32_t tx_break = GPIO_OUTPUT |
+                    (~(GPIO_MODE_MASK | GPIO_OUTPUT_SET) & priv->tx_gpio);
+            stm32_configgpio(tx_break);
+          }
 
         leave_critical_section(flags);
       }
@@ -2191,7 +2214,10 @@ static int stm32serial_ioctl(struct file *filep, int cmd,
 
         /* Configure TX back to U(S)ART */
 
-        stm32_configgpio(priv->tx_gpio);
+        if (priv->tx_gpio != 0)
+          {
+            stm32_configgpio(priv->tx_gpio);
+          }
 
         priv->ie &= ~USART_CR1_IE_BREAK_INPROGRESS;
 

--- a/arch/arm/src/stm32wb/stm32wb_serial.c
+++ b/arch/arm/src/stm32wb/stm32wb_serial.c
@@ -1090,8 +1090,15 @@ static int stm32wb_serial_setup(struct uart_dev_s *dev)
 
   /* Configure pins for USART use */
 
-  stm32wb_configgpio(priv->tx_gpio);
-  stm32wb_configgpio(priv->rx_gpio);
+  if (priv->tx_gpio != 0)
+    {
+      stm32wb_configgpio(priv->tx_gpio);
+    }
+
+  if (priv->rx_gpio != 0)
+    {
+      stm32wb_configgpio(priv->rx_gpio);
+    }
 
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
   if (priv->cts_gpio != 0)
@@ -1314,8 +1321,15 @@ static void stm32wb_serial_shutdown(struct uart_dev_s *dev)
    * then this may need to be a configuration option.
    */
 
-  stm32wb_unconfiggpio(priv->tx_gpio);
-  stm32wb_unconfiggpio(priv->rx_gpio);
+  if (priv->tx_gpio != 0)
+    {
+      stm32wb_unconfiggpio(priv->tx_gpio);
+    }
+
+  if (priv->rx_gpio != 0)
+    {
+      stm32wb_unconfiggpio(priv->rx_gpio);
+    }
 
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
   if (priv->cts_gpio != 0)
@@ -1626,17 +1640,23 @@ static int stm32wb_serial_ioctl(struct file *filep, int cmd,
               (arg & SER_SINGLEWIRE_PULL_MASK) == SER_SINGLEWIRE_PULLDOWN ?
                                                   GPIO_PULLDOWN : GPIO_FLOAT;
 
-            stm32wb_configgpio((priv->tx_gpio & ~(GPIO_PUPD_MASK |
-                                                  GPIO_OPENDRAIN)) |
-                                                  gpio_val);
+            if (priv->tx_gpio != 0)
+              {
+                stm32wb_configgpio((priv->tx_gpio & ~(GPIO_PUPD_MASK |
+                                                      GPIO_OPENDRAIN)) |
+                                                      gpio_val);
+              }
 
             cr |= USART_CR3_HDSEL;
           }
         else
           {
-            stm32wb_configgpio((priv->tx_gpio & ~(GPIO_PUPD_MASK |
-                                                  GPIO_OPENDRAIN)) |
-                                                  GPIO_PUSHPULL);
+            if (priv->tx_gpio != 0)
+              {
+                stm32wb_configgpio((priv->tx_gpio & ~(GPIO_PUPD_MASK |
+                                                      GPIO_OPENDRAIN)) |
+                                                      GPIO_PUSHPULL);
+              }
 
             cr &= ~USART_CR3_HDSEL;
           }
@@ -1844,7 +1864,6 @@ static int stm32wb_serial_ioctl(struct file *filep, int cmd,
     case TIOCSBRK:  /* BSD compatibility: Turn break on, unconditionally */
       {
         irqstate_t flags;
-        uint32_t tx_break;
 
         flags = enter_critical_section();
 
@@ -1856,9 +1875,12 @@ static int stm32wb_serial_ioctl(struct file *filep, int cmd,
 
         /* Configure TX as a GPIO output pin and Send a break signal */
 
-        tx_break = GPIO_OUTPUT |
-                   (~(GPIO_MODE_MASK | GPIO_OUTPUT_SET) & priv->tx_gpio);
-        stm32wb_configgpio(tx_break);
+        if (priv->tx_gpio != 0)
+          {
+            uint32_t tx_break = GPIO_OUTPUT |
+                    (~(GPIO_MODE_MASK | GPIO_OUTPUT_SET) & priv->tx_gpio);
+            stm32wb_configgpio(tx_break);
+          }
 
         leave_critical_section(flags);
       }
@@ -1872,7 +1894,10 @@ static int stm32wb_serial_ioctl(struct file *filep, int cmd,
 
         /* Configure TX back to U(S)ART */
 
-        stm32wb_configgpio(priv->tx_gpio);
+        if (priv->tx_gpio != 0)
+          {
+            stm32wb_configgpio(priv->tx_gpio);
+          }
 
         priv->ie &= ~USART_CR1_IE_BREAK_INPROGRESS;
 

--- a/arch/arm/src/stm32wl5/stm32wl5_serial.c
+++ b/arch/arm/src/stm32wl5/stm32wl5_serial.c
@@ -1153,8 +1153,15 @@ static int stm32wl5serial_setup(FAR struct uart_dev_s *dev)
 
   /* Configure pins for USART use */
 
-  stm32wl5_configgpio(priv->tx_gpio);
-  stm32wl5_configgpio(priv->rx_gpio);
+  if (priv->tx_gpio != 0)
+    {
+      stm32wl5_configgpio(priv->tx_gpio);
+    }
+
+  if (priv->rx_gpio != 0)
+    {
+      stm32wl5_configgpio(priv->rx_gpio);
+    }
 
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
   if (priv->cts_gpio != 0)
@@ -1379,8 +1386,15 @@ static void stm32wl5serial_shutdown(FAR struct uart_dev_s *dev)
    * then this may need to be a configuration option.
    */
 
-  stm32wl5_unconfiggpio(priv->tx_gpio);
-  stm32wl5_unconfiggpio(priv->rx_gpio);
+  if (priv->tx_gpio != 0)
+    {
+      stm32wl5_unconfiggpio(priv->tx_gpio);
+    }
+
+  if (priv->rx_gpio != 0)
+    {
+      stm32wl5_unconfiggpio(priv->rx_gpio);
+    }
 
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
   if (priv->cts_gpio != 0)
@@ -1705,17 +1719,24 @@ static int stm32wl5serial_ioctl(FAR struct file *filep, int cmd,
                 gpio_val |= GPIO_FLOAT;
               }
 
-            stm32wl5_configgpio((priv->tx_gpio &
-                                ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) |
-                               gpio_val);
+            if (priv->tx_gpio != 0)
+              {
+                stm32wl5_configgpio((priv->tx_gpio &
+                                     ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) |
+                                     gpio_val);
+              }
 
             cr |= USART_CR3_HDSEL;
           }
         else
           {
-            stm32wl5_configgpio((priv->tx_gpio &
-                                ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) |
-                               GPIO_PUSHPULL);
+            if (priv->tx_gpio != 0)
+              {
+                stm32wl5_configgpio((priv->tx_gpio &
+                                     ~(GPIO_PUPD_MASK | GPIO_OPENDRAIN)) |
+                                     GPIO_PUSHPULL);
+              }
+
             cr &= ~USART_CR3_HDSEL;
           }
 
@@ -1922,7 +1943,6 @@ static int stm32wl5serial_ioctl(FAR struct file *filep, int cmd,
     case TIOCSBRK:  /* BSD compatibility: Turn break on, unconditionally */
       {
         irqstate_t flags;
-        uint32_t tx_break;
 
         flags = enter_critical_section();
 
@@ -1934,9 +1954,12 @@ static int stm32wl5serial_ioctl(FAR struct file *filep, int cmd,
 
         /* Configure TX as a GPIO output pin and Send a break signal */
 
-        tx_break = GPIO_OUTPUT |
-                   (~(GPIO_MODE_MASK | GPIO_OUTPUT_SET) & priv->tx_gpio);
-        stm32wl5_configgpio(tx_break);
+        if (priv->tx_gpio != 0)
+          {
+            uint32_t tx_break = GPIO_OUTPUT |
+                    (~(GPIO_MODE_MASK | GPIO_OUTPUT_SET) & priv->tx_gpio);
+            stm32wl5_configgpio(tx_break);
+          }
 
         leave_critical_section(flags);
       }
@@ -1950,7 +1973,10 @@ static int stm32wl5serial_ioctl(FAR struct file *filep, int cmd,
 
         /* Configure TX back to U(S)ART */
 
-        stm32wl5_configgpio(priv->tx_gpio);
+        if (priv->tx_gpio != 0)
+          {
+            stm32wl5_configgpio(priv->tx_gpio);
+          }
 
         priv->ie &= ~USART_CR1_IE_BREAK_INPROGRESS;
 


### PR DESCRIPTION
Backport of https://github.com/apache/nuttx/pull/18975