### PR TITLE
[BACKPORT] arch/arm/stm32h7: Invalidate DCACHE after flash erase

### DIFF
--- a/arch/arm/src/stm32h7/stm32_flash.c
+++ b/arch/arm/src/stm32h7/stm32_flash.c
@@ -390,7 +390,7 @@ static int stm32h7_israngeerased(size_t startaddress, size_t size)
       count += 4;
     }
 
-  baddr = (uint8_t *)startaddress;
+  baddr = (uint8_t *)addr;
   while (count < size)
     {
       if (getreg8(baddr) != FLASH_ERASEDVALUE)
@@ -823,7 +823,15 @@ ssize_t up_progmem_eraseblock(size_t block)
   stm32h7_flash_modifyreg32(priv, STM32_FLASH_CR1_OFFSET, FLASH_CR_SER, 0);
   stm32h7_flash_modifyreg32(priv, STM32_FLASH_CR1_OFFSET, FLASH_CR_SNB_MASK,
                             0);
+
   ret = 0;
+
+  /* The flash controller does not maintain the CPU D-Cache, so invalidate
+   * the erased range to keep the blank check below (and any subsequent
+   * reads) from observing stale cached data.
+   */
+
+  up_invalidate_dcache(block_address, block_address + FLASH_SECTOR_SIZE);
 
 exit_with_lock_sem:
   stm32h7_lock_flash(priv);


### PR DESCRIPTION
## Summary
Backport of the DCACHE-coherency fix from upstream NuttX commit [4c71075ea552](https://github.com/apache/nuttx/commit/4c71075ea552d11ba9a2b5b52191854fadda9660) ("arch/arm/stm32h7: multiple fixes for stm32h7 flash interface") to this branch's stm32h7 flash driver. Upstream's fix lands in `stm32h743xx_flash.c`, which only exists after the H7B3 driver refactor, so it does not cherry-pick onto this pre-refactor branch; this PR applies the same change to the inline `stm32_flash.c`.

## Problem
`up_progmem_eraseblock()` erases via the flash controller, which does not maintain the CPU DCACHE. The post-erase blank check (`stm32h7_israngeerased()`) reads the sector back through cacheable loads, so it can observe stale pre-erase data and misreport a successful erase as `-EIO`. Observed on ARK_FPV (STM32H743, `FLASH_BASED_PARAMS`) after flashing PX4 over ArduPilot: ArduPilot's storage data in the parameter sector gets cached during `parameter_flashfs_init()`'s scan, the subsequent erase physically succeeds (the sector reads all 0xFF over SWD) but is reported as failed, so every boot ends with `FAILED to init params in FLASH -5` and no working parameter storage. `stm32h7_israngeerased()` additionally restarts its trailing byte check at `startaddress` instead of continuing where the word loop stopped, so for unaligned sizes the tail is never actually checked (latent here since callers pass whole sectors; fixed by the same upstream commit).

## Solution
Invalidate the DCACHE over the erased sector after a successful erase, before the verify, matching upstream. `up_invalidate_dcache()` compiles to a no-op when the DCACHE is disabled, so the call is unguarded, also matching upstream. Continue the byte-tail blank check from the word-loop position. Matching upstream, no invalidate is added to the write path: the flash region is write-through cacheable, so programming stores remain coherent once the erase path invalidates.
