### PR TITLE
Backport USB composite fix

### DIFF
--- a/drivers/usbdev/cdcacm.c
+++ b/drivers/usbdev/cdcacm.c
@@ -1982,7 +1982,7 @@ static int cdcacm_setup(FAR struct usbdevclass_driver_s *driver,
 #ifndef CONFIG_CDCACM_COMPOSITE
       ret = EP_SUBMIT(dev->ep0, ctrlreq);
 #else
-      ret = composite_ep0submit(driver, dev, ctrlreq);
+      ret = composite_ep0submit(driver, dev, ctrlreq, ctrl);
 #endif
       if (ret < 0)
         {

--- a/drivers/usbdev/composite.c
+++ b/drivers/usbdev/composite.c
@@ -658,7 +658,6 @@ static int composite_setup(FAR struct usbdevclass_driver_s *driver,
                                       outlen);
                   }
 
-                dispatched = true;
                 priv->config = value;
               }
           }
@@ -1087,14 +1086,29 @@ void composite_uninitialize(FAR void *handle)
 
 int composite_ep0submit(FAR struct usbdevclass_driver_s *driver,
                         FAR struct usbdev_s *dev,
-                        FAR struct usbdev_req_s *ctrlreq)
+                        FAR struct usbdev_req_s *ctrlreq,
+                        FAR const struct usb_ctrlreq_s *ctrl)
 {
-  /* This function is not really necessary in the current design.  However,
-   * keeping this will provide us a little flexibility in the future if
-   * it becomes necessary to manage the completion callbacks.
-   */
+  bool ep0submit = true;
 
-  return EP_SUBMIT(dev->ep0, ctrlreq);
+  /* Some EP0 responses must be send only once from the composite class */
+
+  if ((ctrl->type & USB_REQ_TYPE_MASK) == USB_REQ_TYPE_STANDARD)
+    {
+      if (ctrl->req == USB_REQ_SETCONFIGURATION)
+        {
+          ep0submit = false;
+        }
+    }
+
+  if (ep0submit)
+    {
+      return EP_SUBMIT(dev->ep0, ctrlreq);
+    }
+  else
+    {
+      return 0;
+    }
 }
 
 #endif /* CONFIG_USBDEV_COMPOSITE */

--- a/drivers/usbdev/dfu.c
+++ b/drivers/usbdev/dfu.c
@@ -424,7 +424,7 @@ static int  usbclass_setup(FAR struct usbdevclass_driver_s *driver,
     {
       ctrlreq->len   = (len < ret) ? len : ret;
       ctrlreq->flags = USBDEV_REQFLAGS_NULLPKT;
-      ret            = composite_ep0submit(driver, dev, ctrlreq);
+      ret            = composite_ep0submit(driver, dev, ctrlreq, ctrl);
       if (ret < 0)
         {
           usbtrace(TRACE_CLSERROR(USBSER_TRACEERR_EPRESPQ), (uint16_t)-ret);

--- a/drivers/usbdev/usbmsc.c
+++ b/drivers/usbdev/usbmsc.c
@@ -816,7 +816,7 @@ static int usbmsc_setup(FAR struct usbdevclass_driver_s *driver,
 #ifndef CONFIG_USBMSC_COMPOSITE
       ret = EP_SUBMIT(dev->ep0, ctrlreq);
 #else
-      ret = composite_ep0submit(driver, dev, ctrlreq);
+      ret = composite_ep0submit(driver, dev, ctrlreq, ctrl);
 #endif
       if (ret < 0)
         {

--- a/include/nuttx/usb/composite.h
+++ b/include/nuttx/usb/composite.h
@@ -130,10 +130,12 @@ void composite_uninitialize(FAR void *handle);
 struct usbdevclass_driver_s;
 struct usbdev_s;
 struct usbdev_req_s;
+struct usb_ctrlreq_s;
 
 int composite_ep0submit(FAR struct usbdevclass_driver_s *driver,
                         FAR struct usbdev_s *dev,
-                        FAR struct usbdev_req_s *ctrlreq);
+                        FAR struct usbdev_req_s *ctrlreq,
+                        FAR const struct usb_ctrlreq_s *ctrl);
 
 #undef EXTERN
 #if defined(__cplusplus)


### PR DESCRIPTION
Fix cherry picked from upstream https://github.com/apache/nuttx/pull/8883.

---

> - usbdev-composite: ep0 submit should be send only once for the composite class
Some of USB controllers handle USB_REQ_SETCONFIGURATION by hardware, so we had a situation that some of composite configurations worked (eg. spresense) but other not (eg. stm32 otg).
I think this problem was quite old (probably related thread on the old mailing list - https://nuttx.yahoogroups.narkive.com/Y6ZpMpFe/composite-usb-device-on-stm32f4-issues and annoing to find.

