### PR TITLE
[BACKPORT] fix(net/igmp): restore General Query handling broken by pointer compare

### DIFF
--- a/net/igmp/igmp_input.c
+++ b/net/igmp/igmp_input.c
@@ -177,6 +177,13 @@ void igmp_input(struct net_driver_s *dev)
          *   receivers.
          */
 
+        /* The group address lies in the IGMP header where it is stored as
+         * an unaligned uint16_t[2] in network order.  Convert it to an
+         * in_addr_t before it is used in any comparison.
+         */
+
+        grpaddr = net_ip4addr_conv32(igmp->grpaddr);
+
         /* Check if the query was sent to all systems */
 
         if (net_ipv4addr_cmp(destipaddr, g_ipv4_allsystems))
@@ -198,7 +205,7 @@ void igmp_input(struct net_driver_s *dev)
              *    Query."
              */
 
-            if (igmp->grpaddr == 0)
+            if (net_ipv4addr_cmp(grpaddr, INADDR_ANY))
               {
                 FAR struct igmp_group_s *member;
 
@@ -233,7 +240,7 @@ void igmp_input(struct net_driver_s *dev)
                       }
                   }
               }
-            else /* if (igmp->grpaddr != 0) */
+            else /* if (!net_ipv4addr_cmp(grpaddr, INADDR_ANY)) */
               {
                 ninfo("Group-specific multicast query\n");
 
@@ -243,8 +250,7 @@ void igmp_input(struct net_driver_s *dev)
 
                 IGMP_STATINCR(g_netstats.igmp.ucast_query);
 
-                grpaddr = net_ip4addr_conv32(igmp->grpaddr);
-                group   = igmp_grpallocfind(dev, &grpaddr);
+                group = igmp_grpallocfind(dev, &grpaddr);
 
                 if (group != NULL)
                   {
@@ -262,7 +268,7 @@ void igmp_input(struct net_driver_s *dev)
 
         /* Not sent to all systems -- Unicast query */
 
-        else if (group->grpaddr != 0)
+        else if (!net_ipv4addr_cmp(grpaddr, INADDR_ANY))
           {
             ninfo("Unicast query\n");
             IGMP_STATINCR(g_netstats.igmp.ucast_query);


### PR DESCRIPTION
## Summary

Backport of [apache/nuttx#19436](https://github.com/apache/nuttx/pull/19436) (upstream commit [`f20cf4aac3`](https://github.com/apache/nuttx/commit/f20cf4aac336cdd5623fe29bac1ea91134ac5d78)). Fixes the `ark_fmu-v6xrt` build failure and restores IGMP General Query handling, which has never worked on this branch.

## Problem

`igmp->grpaddr` is declared `uint16_t grpaddr[2]`, so it decays to a pointer and `igmp->grpaddr == 0` tests the address of a struct member. That is always false, and `-Werror` rejects it:

```
igmp_input.c:201:31: warning: the comparison will always evaluate as 'false' for the address of 'grpaddr' will never be NULL [-Waddress]
```

The build error is the visible half. The functional half is that the General Query branch is unreachable, so GCC discards it: `.text` for `igmp_input.o` is 496 bytes on this branch today and 648 once the branch is reachable again. A General Query — destination 224.0.0.1, group address 0 — is the periodic query every IGMP querier sends. It currently falls through to the group-specific branch, where `igmp_grpallocfind()` allocates a group for 0.0.0.0 and schedules a report for it, while the groups the device actually joined never get their report timers restarted. The querier then ages out those memberships and multicast delivery to the device stops.

Upstream's 09bb292fa2 ("net/igmp: fix build warning on GCC 12.2.0") should **not** be backported instead. It looks like a fix but only wraps the identical comparison in `net_ipv4addr_cmp()`, which silences the diagnostic solely because NuttX includes its own headers via `-isystem` and GCC suppresses warnings originating in system-header macros. Taking that commit would quiet the build and leave the defect in place.

## Solution

Convert the header field once with `net_ip4addr_conv32()` and compare the resulting `in_addr_t`. The conversion already existed in the group-specific branch, so this only hoists it and reuses it at the other two comparison sites.

The cherry-pick conflicts because this branch predates 09bb292fa2 and still carries the original expressions; resolved by taking upstream's side at all three sites. The resulting `IGMP_MEMBERSHIP_QUERY` block is byte-identical to apache/nuttx master, so future rebases converge rather than re-conflict.
