### PR TITLE
mmcsd: add 4-bit wide bus support for MMC/eMMC cards

### DIFF
--- a/arch/arm/src/stm32h7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32h7/stm32_sdmmc.c
@@ -207,6 +207,10 @@
                                      STM32_SDMMC_CLKCR_EDGE       |     \
                                      STM32_SDMMC_CLKCR_PWRSAV     |     \
                                      STM32_SDMMC_CLKCR_WIDBUS_D1)
+#define STM32_SDMMC_CLKCR_MMCXFR4   (STM32_SDMMC_MMCXFR_CLKDIV    |     \
+                                     STM32_SDMMC_CLKCR_EDGE       |     \
+                                     STM32_SDMMC_CLKCR_PWRSAV     |     \
+                                     STM32_SDMMC_CLKCR_WIDBUS_D4)
 #define STM32_SDMMC_CLCKR_SDXFR     (STM32_SDMMC_SDXFR_CLKDIV     |     \
                                      STM32_SDMMC_CLKCR_EDGE       |     \
                                      STM32_SDMMC_CLKCR_PWRSAV     |     \
@@ -2085,7 +2089,24 @@ static sdio_statset_t stm32_status(struct sdio_dev_s *dev)
 static void stm32_widebus(struct sdio_dev_s *dev, bool wide)
 {
   struct stm32_dev_s *priv = (struct stm32_dev_s *)dev;
+  uint32_t regval;
+
   priv->widebus = wide;
+
+  regval  = sdmmc_getreg32(priv, STM32_SDMMC_CLKCR_OFFSET);
+  regval &= ~STM32_SDMMC_CLKCR_WIDBUS_MASK;
+
+  if (wide)
+    {
+      regval |= STM32_SDMMC_CLKCR_WIDBUS_D4;
+      regval &= ~STM32_SDMMC_CLKCR_PWRSAV;
+    }
+  else
+    {
+      regval |= STM32_SDMMC_CLKCR_WIDBUS_D1;
+    }
+
+  sdmmc_putreg32(priv, regval, STM32_SDMMC_CLKCR_OFFSET);
 }
 
 /****************************************************************************
@@ -2127,6 +2148,12 @@ static void stm32_clock(struct sdio_dev_s *dev, enum sdio_clock_e rate)
 
     case CLOCK_MMC_TRANSFER:
       clckr = STM32_SDMMC_CLKCR_MMCXFR;
+      break;
+
+      /* Enable in MMC wide (4-bit) operation clocking */
+
+    case CLOCK_MMC_TRANSFER_4BIT:
+      clckr = STM32_SDMMC_CLKCR_MMCXFR4;
       break;
 
     /* SD normal operation clocking (wide 4-bit mode) */

--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -213,6 +213,7 @@ static void    mmcsd_mediachange(FAR void *arg);
 static int     mmcsd_widebus(FAR struct mmcsd_state_s *priv);
 #ifdef CONFIG_MMCSD_MMCSUPPORT
 static int     mmcsd_mmcinitialize(FAR struct mmcsd_state_s *priv);
+static int     mmcsd_mmc_widebus(FAR struct mmcsd_state_s *priv);
 static int     mmcsd_read_csd(FAR struct mmcsd_state_s *priv);
 #endif
 static int     mmcsd_sdinitialize(FAR struct mmcsd_state_s *priv);
@@ -2511,6 +2512,60 @@ static int mmcsd_widebus(FAR struct mmcsd_state_s *priv)
 }
 
 /****************************************************************************
+ * Name: mmcsd_mmc_widebus
+ *
+ * Description:
+ *  An MMC card has been detected.  Select wide bus operation.
+ *  If the host mandates 4-bit (SDIO_CAPS_4BIT_ONLY), force it.
+ *  Otherwise try 4-bit; future eMMC revisions may add 8-bit support.
+ *
+ * Assumptions:
+ *   The card is in transfer state and the transfer clock has been selected.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_MMCSD_MMCSUPPORT
+static int mmcsd_mmc_widebus(FAR struct mmcsd_state_s *priv)
+{
+  int ret;
+
+  /* Unlike SD cards (SCR register), MMC EXT_CSD[183] reports the
+   * current bus width, not supported modes.  Simply try the SWITCH;
+   * the card will reject it if 4-bit is not supported.
+   */
+
+  if ((priv->caps & SDIO_CAPS_1BIT_ONLY) == 0)
+    {
+      /* Select wide, 4-bit bus operation.
+       * TODO: Try 8-bit first (0x02), fall back to 4-bit (0x01).
+       */
+
+      SDIO_WIDEBUS(priv->dev, true);
+      priv->widebus = true;
+      nxsig_usleep(MMCSD_CLK_DELAY);
+
+      mmcsd_sendcmdpoll(priv, MMCSD_CMD6,
+                        (0x03u << 24) | (183u << 16) |
+                        (0x01u << 8)  | 0x00u);
+      ret = mmcsd_recv_r1(priv, MMCSD_CMD6);
+      if (ret != OK)
+        {
+          ferr("ERROR: MMC wide bus switch failed: %d\n", ret);
+          SDIO_WIDEBUS(priv->dev, false);
+          priv->widebus = false;
+          return ret;
+        }
+
+      finfo("MMC wide bus operation selected\n");
+      return OK;
+    }
+
+  fwarn("WARNING: Card does not support wide-bus operation\n");
+  return -ENOSYS;
+}
+#endif
+
+/****************************************************************************
  * Name: mmcsd_mmcinitialize
  *
  * Description:
@@ -2591,6 +2646,8 @@ static int mmcsd_mmcinitialize(FAR struct mmcsd_state_s *priv)
       return ret;
     }
 
+  mmcsd_decode_csd(priv, csd);
+
   /* Set the Driver Stage Register (DSR) if (1) a CONFIG_MMCSD_DSR has been
    * provided and (2) the card supports a DSR register.  If no DSR value
    * the card default value (0x0404) will be used.
@@ -2611,10 +2668,8 @@ static int mmcsd_mmcinitialize(FAR struct mmcsd_state_s *priv)
       return ret;
     }
 
-  /* CSD Decoding for MMC should be done after entering in data-transfer mode
-   * because if the card has block addressing then extended CSD register
-   * must be read in order to get the right number of blocks and capacity,
-   * but it has to be done in data-transfer mode.
+  /* Read extended CSD in data-transfer mode to obtain the number of
+   * blocks, capacity, and the BUS_WIDTH support (EXT_CSD[183]).
    */
 
   if (IS_BLOCK(priv->type))
@@ -2622,7 +2677,8 @@ static int mmcsd_mmcinitialize(FAR struct mmcsd_state_s *priv)
       ret = mmcsd_read_csd(priv);
       if (ret != OK)
         {
-          ferr("ERROR: Failed to determinate number of blocks: %d\n", ret);
+          ferr("ERROR: Failed to determinate number of blocks: %d\n",
+               ret);
           return ret;
         }
     }
@@ -2633,6 +2689,15 @@ static int mmcsd_mmcinitialize(FAR struct mmcsd_state_s *priv)
 
   SDIO_CLOCK(priv->dev, CLOCK_MMC_TRANSFER);
   nxsig_usleep(MMCSD_CLK_DELAY);
+
+  /* Select wide (4-bit) bus operation (if the card supports it) */
+
+  ret = mmcsd_mmc_widebus(priv);
+  if (ret != OK)
+    {
+      ferr("ERROR: Failed to set MMC wide bus operation: %d\n", ret);
+    }
+
   return OK;
 }
 

--- a/include/nuttx/sdio.h
+++ b/include/nuttx/sdio.h
@@ -924,9 +924,10 @@ enum sdio_clock_e
 {
   CLOCK_SDIO_DISABLED = 0, /* Clock is disabled */
   CLOCK_IDMODE,            /* Initial ID mode clocking (<400KHz) */
-  CLOCK_MMC_TRANSFER,      /* MMC normal operation clocking */
+  CLOCK_MMC_TRANSFER,      /* MMC normal operation clocking (narrow 1-bit mode) */
   CLOCK_SD_TRANSFER_1BIT,  /* SD normal operation clocking (narrow 1-bit mode) */
-  CLOCK_SD_TRANSFER_4BIT   /* SD normal operation clocking (wide 4-bit mode) */
+  CLOCK_SD_TRANSFER_4BIT,  /* SD normal operation clocking (wide 4-bit mode) */
+  CLOCK_MMC_TRANSFER_4BIT  /* MMC normal operation clocking (wide 4-bit mode) */
 };
 
 /* Event set.  A uint8_t is big enough to hold a set of 8-events.  If more


### PR DESCRIPTION
## Summary
This commit adds MMC/eMMC 4-bit wide bus support.  The bus width
configuration is placed in the arch-specific stm32_widebus() callback,
which directly writes the STM32_SDMMC_CLKCR register.  This differs
from the traditional SD card approach where bus width is configured
through mmcsd_widebus() in the MMC/SD framework layer, but I believe
this is the more appropriate location — configuring hardware registers
belongs in the arch-specific layer.

One known side effect: on STM32H7, SD cards will now have the WIDBUS
bits written twice during initialization — once by stm32_widebus()
(via SDIO_WIDEBUS in mmcsd_widebus) and again by stm32_clock() via
the CLOCK_SD_TRANSFER_4BIT preset, which also includes WIDBUS bits.
This is harmless but redundant.

A follow-up cleanup could remove WIDBUS bits from the clock presets
(CLOCK_SD_TRANSFER_4BIT, CLOCK_MMC_TRANSFER_4BIT) and let
stm32_widebus() be the single point of bus width configuration.
However, that would require testing across all supported platforms
and is left for a future PR.

## Impact
Issue https://github.com/PX4/NuttX/issues/346

## Testing
Below are my hardware test data based on the PX4-V6X design, using eMMC memory.
```bash
nsh> ver all
HW arch:
PX4 git-hash: a5e191b7f5f2744b74a5aae0782eed390b8c6dd5
PX4 version: 1.15.2 0 (17760768)
PX4 git-branch: v1.15.2-dev
OS: NuttX
OS version: Release 11.0.0 (184549631)
OS git-hash: 53795e88496a505c6fe679de637a2e3f6ba500f7
Build datetime: Jul 16 2026 13:38:06
Build uri: localhost
Build variant: default
Toolchain: GNU GCC, 10.3.1 20210824 (release)
PX4GUID: 000600000000363836363033510500200047
MCU: STM32H7[4|5]xxx, rev. V 
nsh> sd_bench -v
INFO  [sd_bench] Using block size = 4096 bytes, sync=0
INFO  [sd_bench]
INFO  [sd_bench] Testing Sequential Write Speed...
INFO  [sd_bench]   Run  0:  4003.32 KB/s, max write time: 9 ms (= 444.44 KB/s), fsync: 2 ms
INFO  [sd_bench]   Run  1:  4135.69 KB/s, max write time: 7 ms (= 571.43 KB/s), fsync: 4 ms
INFO  [sd_bench]   Run  2:  4146.69 KB/s, max write time: 8 ms (= 500.00 KB/s), fsync: 3 ms
INFO  [sd_bench]   Run  3:  4135.73 KB/s, max write time: 8 ms (= 500.00 KB/s), fsync: 3 ms
INFO  [sd_bench]   Run  4:  4157.10 KB/s, max write time: 7 ms (= 571.43 KB/s), fsync: 3 ms
INFO  [sd_bench]   Avg   :  4115.71 KB/s
INFO  [sd_bench]   Overall max write time: 9 ms
INFO  [sd_bench]
INFO  [sd_bench] Testing Sequential Read Speed of 10309 blocks
INFO  [sd_bench]   Run  0:  6301.92 KB/s, max read/verify time: 2 ms (=2000.00 KB/s)
INFO  [sd_bench]   Run  1:  6268.30 KB/s, max read/verify time: 2 ms (=2000.00 KB/s)
INFO  [sd_bench]   Run  2:  6250.49 KB/s, max read/verify time: 2 ms (=2000.00 KB/s)
INFO  [sd_bench]   Run  3:  6270.58 KB/s, max read/verify time: 1 ms (=4000.00 KB/s)
INFO  [sd_bench]   Avg   :  6273.31 KB/s 10309 blocks read and verified
```