### PR TITLE
[BACKPORT] fs: simplify CONFIG_FS_LARGEFILE check to fix >4GB volume reporting

### DIFF
--- a/include/aio.h
+++ b/include/aio.h
@@ -97,7 +97,7 @@
 #define LIO_NOWAIT      0
 #define LIO_WAIT        1
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define aiocb64       aiocb
 #  define aio_read64    aio_read
 #  define aio_write64   aio_write

--- a/include/dirent.h
+++ b/include/dirent.h
@@ -86,7 +86,7 @@
 #define DT_LNK                    DTYPE_LINK
 #define DT_SOCK                   DTYPE_SOCK
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define dirent64                dirent
 #  define readdir64               readdir
 #  define readdir64_r             readdir_r

--- a/include/fcntl.h
+++ b/include/fcntl.h
@@ -134,7 +134,7 @@
 
 #define creat(path, mode) open(path, O_WRONLY|O_CREAT|O_TRUNC, mode)
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define F_GETLK64         F_GETLK
 #  define F_SETLK64         F_SETLK
 #  define F_SETLKW64        F_SETLKW

--- a/include/ftw.h
+++ b/include/ftw.h
@@ -63,7 +63,7 @@
                        * it.  */
 #endif
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define ftw64    ftw
 #  define nftw64   nftw
 #endif

--- a/include/inttypes.h
+++ b/include/inttypes.h
@@ -308,7 +308,7 @@
 
 /* off_t */
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #define PRIdOFF     PRId64
 #define PRIiOFF     PRIi64
 #define PRIoOFF     PRIo64

--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -791,6 +791,10 @@
 
 #endif
 
+#ifndef CONFIG_HAVE_LONG_LONG
+#  undef CONFIG_FS_LARGEFILE
+#endif
+
 /* Decorators */
 
 #ifdef CONFIG_ARCH_RAMFUNCS

--- a/include/stdio.h
+++ b/include/stdio.h
@@ -86,7 +86,7 @@
 
 #define TMP_MAX 56800235584ull
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define tmpfile64 tmpfile
 #  define fopen64   fopen
 #  define freopen64 freopen

--- a/include/stdlib.h
+++ b/include/stdlib.h
@@ -68,7 +68,7 @@
 #  define environ get_environ_ptr()
 #endif
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define mkstemp64            mkstemp
 #  define mkostemp64           mkostemp
 #  define mkstemps64           mkstemps

--- a/include/sys/mman.h
+++ b/include/sys/mman.h
@@ -122,7 +122,7 @@
 #define POSIX_TYPED_MEM_ALLOCATE_CONTIG  (1)
 #define POSIX_TYPED_MEM_MAP_ALLOCATABLE  (2)
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define mmap64 mmap
 #endif
 

--- a/include/sys/resource.h
+++ b/include/sys/resource.h
@@ -58,7 +58,7 @@
 #define RLIMIT_STACK    6           /* Limit on stack size */
 #define RLIMIT_AS       7           /* Limit on address space size */
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define RLIM_INFINITY    UINT64_MAX /* No limit */
 #  define RLIM_SAVED_MAX   UINT64_MAX /* Unrepresentable saved hard limit */
 #  define RLIM_SAVED_CUR   UINT64_MAX /* Unrepresentable saved soft limit */
@@ -95,7 +95,7 @@
  * It must be an unsigned integral type.
  */
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 typedef uint64_t rlim_t;
 #else
 typedef uint32_t rlim_t;

--- a/include/sys/sendfile.h
+++ b/include/sys/sendfile.h
@@ -39,7 +39,7 @@
 #  define CONFIG_SENDFILE_BUFSIZE 512
 #endif
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define sendfile64              sendfile
 #endif
 

--- a/include/sys/stat.h
+++ b/include/sys/stat.h
@@ -122,7 +122,7 @@
 #define st_ctime     st_ctim.tv_sec
 #define st_mtime     st_mtim.tv_sec
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define stat64     stat
 #  define fstat64    fstat
 #  define lstat64    lstat

--- a/include/sys/statfs.h
+++ b/include/sys/statfs.h
@@ -95,7 +95,7 @@
 #define CROMFS_MAGIC          0x4d4f5243
 #define RPMSGFS_MAGIC         0x54534f47
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define statfs64            statfs
 #  define fstatfs64           fstatfs
 #endif

--- a/include/sys/statvfs.h
+++ b/include/sys/statvfs.h
@@ -38,7 +38,7 @@
 #define ST_RDONLY             0x0001 /* Mount read-only.  */
 #define ST_NOSUID             0x0002 /* Ignore suid and sgid bits.  */
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define statvfs64           statvfs
 #  define fstatvfs64          fstatvfs
 #endif

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -77,7 +77,7 @@
 #define SCHED_PRIORITY_MIN       1
 #define SCHED_PRIORITY_IDLE      0
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define fsblkcnt64_t           fsblkcnt_t
 #  define fsfilcnt64_t           fsfilcnt_t
 #  define blkcnt64_t             blkcnt_t
@@ -187,7 +187,7 @@ typedef int wint_t;
 
 typedef int wctype_t;
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 /* Large file versions */
 
 typedef uint64_t     fsblkcnt_t;

--- a/include/sys/uio.h
+++ b/include/sys/uio.h
@@ -48,7 +48,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define preadv64  preadv
 #  define pwritev64 pwritev
 #endif

--- a/include/unistd.h
+++ b/include/unistd.h
@@ -271,7 +271,7 @@
 #define optind                           (*(getoptindp()))
 #define optopt                           (*(getoptoptp()))
 
-#if defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)
+#if defined(CONFIG_FS_LARGEFILE)
 #  define lseek64                        lseek
 #  define pread64                        pread
 #  define pwrite64                       pwrite


### PR DESCRIPTION
## Summary

Backport of upstream NuttX commit 92b2f1bd3d3 ("fs: Undefine
CONFIG_FS_LARGEFILE if compiler doesn't support long long").

On this branch, the 64-bit file types (fsblkcnt_t, off_t, blkcnt_t, ...)
are gated on `defined(CONFIG_FS_LARGEFILE) && defined(CONFIG_HAVE_LONG_LONG)`
in 18 places across 16 public headers. CONFIG_HAVE_LONG_LONG, however, is
not a Kconfig symbol — it is only (un)defined inside `nuttx/compiler.h`
per compiler — so the gate result depends on header include order in each
translation unit, and CONFIG_FS_LARGEFILE is effectively unusable.

With 32-bit fsblkcnt_t, statfs consumers (procfs `/fs/usage`, `df`)
compute the volume size as `f_bsize * f_blocks` in 32 bits, which wraps
at 4GB:

- 8 GB eMMC (7,818,182,656 B) is reported as ~3.5 GB
- 32 GB SD card (31,914,983,424 B) is reported as 1,850,212,352 B
  (~1.7 GB) — exactly `size mod 2^32`

The block driver geometry itself is correct (the driver reads the full
capacity); only the statfs layer wraps.

This change simplifies the check to `defined(CONFIG_FS_LARGEFILE)` only,
matching upstream, and undefines CONFIG_FS_LARGEFILE in `nuttx/compiler.h`
when the compiler lacks long long support. The diffstat is identical to
the upstream commit (17 files, 22 insertions, 18 deletions). It was
applied as an equivalent patch because a verbatim cherry-pick conflicts
with this branch's older header context; the resulting content is the
same. Original authorship is preserved.

## Impact

- No behavior change unless CONFIG_FS_LARGEFILE is enabled (it is not
  enabled by default in this branch).
- With CONFIG_FS_LARGEFILE=y, statfs/df report the true capacity of
  volumes >= 4GB instead of the wrapped value, and file offsets become
  64-bit as intended.
- The behavior becomes deterministic instead of include-order dependent.

## Testing

Hardware: custom STM32H743 board (8GB eMMC on SDMMC1) and PX4 FMU-V6X
(32GB SD card), PX4 v1.15 on px4_firmware_nuttx-10.3.0+.

Without CONFIG_FS_LARGEFILE (FMU-V6X, 32GB SD):

    nsh> ls -l /dev/mmcsd0
     brw-rw-rw-1850212352 /dev/mmcsd0
    nsh> df -h
      vfat       1749M      240K      1749M /fs/microsd

With CONFIG_FS_LARGEFILE=y and this backport:

    nsh> ls -l /dev/mmcsd0
     brw-rw-rw-31914983424 /dev/mmcsd0
    nsh> df -h
      vfat       29G        240K       29G /fs/microsd

The 8GB eMMC board likewise reports the full 7,818,182,656 B / 7452M.

Note: enabling CONFIG_FS_LARGEFILE in the board defconfigs is a separate
change on the PX4 Firmware side; this PR only fixes the gating so that
the option actually works.