### PR TITLE
[BACKPORT] arch/arm/stm32h7: invalidate dcache after aligned SDMMC RX DMA

### DIFF
--- a/arch/arm/src/stm32h7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32h7/stm32_sdmmc.c
@@ -1397,7 +1397,22 @@ static void stm32_recvdma(struct stm32_dev_s *priv)
     }
   else
     {
-      /* In an aligned case, we have always received all blocks */
+      /* In an aligned case, we have always received all blocks.
+       *
+       * The destination buffer was invalidated before the DMA in
+       * stm32_dmarecvsetup(), but on the Cortex-M7 the cache can
+       * speculatively prefetch into this (cacheable) buffer between that
+       * point and DMA completion, leaving stale lines that shadow the
+       * data just written by the IDMA.  Invalidate again now that the
+       * transfer is complete, before the buffer is consumed, so the CPU
+       * reads the freshly received data instead of a previously cached
+       * sector.  The buffer and length are cache-line aligned here (that
+       * is why this aligned path was taken), so no adjacent memory is
+       * affected.
+       */
+
+      up_invalidate_dcache((uintptr_t)priv->buffer,
+                           (uintptr_t)priv->buffer + priv->receivecnt);
 
       priv->remaining = 0;
     }


### PR DESCRIPTION
Backport of apache/nuttx#19506 (open, not yet merged upstream at the
time of this backport).

Fixes a D-cache coherency bug in the STM32H7 SDMMC aligned RX DMA
path: the aligned completion branch in stm32_recvdma() never
invalidated the destination buffer after DMA completion, only
before it started in stm32_dmarecvsetup(). On the Cortex-M7 the
cache can speculatively prefetch into that buffer between the
pre-DMA invalidate and DMA completion, leaving stale lines that
shadow the freshly-written data.

Reproduced and hardware-verified on a PX4 FMUv6C board: MAVLink
ULog downloads were corrupted in 32-byte, cache-line-aligned
windows that were byte-for-byte identical to the previous 512-byte
SD sector — the exact signature of a stale cache line. See the
upstream PR for full forensic detail and verification (including a
byte-for-byte identical 5.8 MB download after the fix).
