### PR TITLE
[BACKPORT] arch/arm/src/imxrt: Keep FlexCAN TX mailbox allocation in order.

### DIFF
--- a/arch/arm/src/imxrt/imxrt_flexcan.c
+++ b/arch/arm/src/imxrt/imxrt_flexcan.c
@@ -514,6 +514,50 @@ static void imxrt_reset(struct imxrt_driver_s *priv);
  ****************************************************************************/
 
 /****************************************************************************
+ * Function: imxrt_txmb_next
+ *
+ * Description:
+ *   Pick the mailbox to load the next frame into.
+ *
+ *   Every frame of a multi-frame transport transfer carries the same CAN
+ *   ID, and FlexCAN breaks an arbitration tie between mailboxes holding
+ *   equal IDs by taking the lowest mailbox number.  Handing out the
+ *   lowest *free* mailbox therefore lets a frame loaded into a
+ *   just-drained low mailbox win arbitration against older frames still
+ *   pending in higher ones, and the receiver sees the transfer out of
+ *   order.
+ *
+ *   Only ever hand out a mailbox above every pending one, and wrap back to
+ *   the bottom once the ring has drained.
+ *
+ * Input Parameters:
+ *   priv  - Reference to the driver state structure
+ *
+ * Returned Value:
+ *   The mailbox index to use, or TOTALMBCOUNT if none is available.
+ *
+ ****************************************************************************/
+
+static uint32_t imxrt_txmb_next(struct imxrt_driver_s *priv)
+{
+  uint32_t mbi  = RXMBCOUNT + 1;
+  uint32_t next = RXMBCOUNT + 1;
+
+  while (mbi < TOTALMBCOUNT)
+    {
+      struct mb_s *mb = flexcan_get_mb(priv, mbi);
+      if (mb->cs.code == CAN_TXMB_DATAORREMOTE)
+        {
+          next = mbi + 1;
+        }
+
+      mbi++;
+    }
+
+  return next;
+}
+
+/****************************************************************************
  * Function: imxrt_txringfull
  *
  * Description:
@@ -530,21 +574,7 @@ static void imxrt_reset(struct imxrt_driver_s *priv);
 
 static bool imxrt_txringfull(struct imxrt_driver_s *priv)
 {
-  uint32_t mbi = RXMBCOUNT + 1;
-  struct mb_s *mb;
-
-  while (mbi < TOTALMBCOUNT)
-    {
-      mb = flexcan_get_mb(priv, mbi);
-      if (mb->cs.code != CAN_TXMB_DATAORREMOTE)
-        {
-          return 0;
-        }
-
-      mbi++;
-    }
-
-  return 1;
+  return imxrt_txmb_next(priv) >= TOTALMBCOUNT;
 }
 
 /****************************************************************************
@@ -583,33 +613,20 @@ static int imxrt_transmit(struct imxrt_driver_s *priv)
   uint32_t txmb = 0;
 #endif
 
-  mbi = RXMBCOUNT + 1;
-  mb_bit = 1 << mbi;
+  mbi = imxrt_txmb_next(priv);
 
-  while (mbi < TOTALMBCOUNT)
-    {
-      /* Check whether message buffer is not currently transmitting */
-
-      struct mb_s *mb = flexcan_get_mb(priv, mbi);
-      if (mb->cs.code != CAN_TXMB_DATAORREMOTE)
-        {
-          putreg32(mb_bit, priv->base + IMXRT_CAN_IFLAG1_OFFSET);
-          break;
-        }
-
-      mb_bit <<= 1;
-      mbi++;
-#ifdef CONFIG_NET_CAN_RAW_TX_DEADLINE
-      txmb++;
-#endif
-    }
-
-  if (mbi == TOTALMBCOUNT)
+  if (mbi >= TOTALMBCOUNT)
     {
       nwarn("No TX MB available mbi %" PRIi32 "\n", mbi);
       NETDEV_TXERRORS(&priv->dev);
       return 0;       /* No transmission for you! */
     }
+
+  mb_bit = 1 << mbi;
+  putreg32(mb_bit, priv->base + IMXRT_CAN_IFLAG1_OFFSET);
+#ifdef CONFIG_NET_CAN_RAW_TX_DEADLINE
+  txmb = mbi - (RXMBCOUNT + 1);
+#endif
 
 #ifdef CONFIG_NET_CAN_RAW_TX_DEADLINE
   struct timespec ts;

--- a/arch/arm/src/imxrt/imxrt_flexcan.c
+++ b/arch/arm/src/imxrt/imxrt_flexcan.c
@@ -1549,19 +1549,19 @@ static int imxrt_ioctl(struct net_driver_s *dev, int cmd,
             }
 
           if (priv->canfd_capable)
-          {
-            data_timing.bitrate = req->data_bitrate * 1000;
-            data_timing.samplep = req->data_samplep;
+            {
+              data_timing.bitrate = req->data_bitrate * 1000;
+              data_timing.samplep = req->data_samplep;
 
-            if (ret == OK && imxrt_bitratetotimeseg(&data_timing, 10, 1))
-              {
-                ret = OK;
-              }
-            else
-              {
-                ret = -EINVAL;
-              }
-          }
+              if (ret == OK && imxrt_bitratetotimeseg(&data_timing, 10, 1))
+                {
+                  ret = OK;
+                }
+              else
+                {
+                  ret = -EINVAL;
+                }
+            }
 
           if (ret == OK)
             {
@@ -1569,9 +1569,9 @@ static int imxrt_ioctl(struct net_driver_s *dev, int cmd,
 
               priv->arbi_timing = arbi_timing;
               if (priv->canfd_capable)
-              {
-                priv->data_timing = data_timing;
-              }
+                {
+                  priv->data_timing = data_timing;
+                }
 
               imxrt_ifup(dev);
             }
@@ -1753,8 +1753,8 @@ static int imxrt_initialize(struct imxrt_driver_s *priv)
    *  transmiting the package, hence we write 0x3
    */
 
-      struct mb_s *buffer = flexcan_get_mb(priv, RXMBCOUNT);
-      buffer->cs.code = 0x3;
+  struct mb_s *buffer = flexcan_get_mb(priv, RXMBCOUNT);
+  buffer->cs.code = 0x3;
 
   for (i = RXMBCOUNT + 1; i < TOTALMBCOUNT; i++)
     {
@@ -1899,97 +1899,97 @@ int imxrt_caninitialize(int intf)
   switch (intf)
     {
 #ifdef CONFIG_IMXRT_FLEXCAN1
-    case 1:
-      imxrt_clockall_can1();
-      imxrt_clockall_can1_serial();
-      priv               = &g_flexcan1;
-      memset(priv, 0, sizeof(struct imxrt_driver_s));
-      priv->base         = IMXRT_CAN1_BASE;
-      priv->config       = &imxrt_flexcan1_config;
+      case 1:
+        imxrt_clockall_can1();
+        imxrt_clockall_can1_serial();
+        priv               = &g_flexcan1;
+        memset(priv, 0, sizeof(struct imxrt_driver_s));
+        priv->base         = IMXRT_CAN1_BASE;
+        priv->config       = &imxrt_flexcan1_config;
 #  if defined(CONFIG_NET_CAN_CANFD) && defined(CONFIG_IMXRT_FLEXCAN1_FD)
-      priv->canfd_capable = true;
-      priv->mb_address_offset = 14;
+        priv->canfd_capable = true;
+        priv->mb_address_offset = 14;
 #  else
-      priv->canfd_capable = false;
-      priv->mb_address_offset = 0;
+        priv->canfd_capable = false;
+        priv->mb_address_offset = 0;
 #  endif
 
-      /* Default bitrate configuration */
+        /* Default bitrate configuration */
 
 #  if defined(CONFIG_NET_CAN_CANFD) && defined(CONFIG_IMXRT_FLEXCAN1_FD)
-      priv->arbi_timing.bitrate = CONFIG_FLEXCAN1_ARBI_BITRATE;
-      priv->arbi_timing.samplep = CONFIG_FLEXCAN1_ARBI_SAMPLEP;
-      priv->data_timing.bitrate = CONFIG_FLEXCAN1_DATA_BITRATE;
-      priv->data_timing.samplep = CONFIG_FLEXCAN1_DATA_SAMPLEP;
+        priv->arbi_timing.bitrate = CONFIG_FLEXCAN1_ARBI_BITRATE;
+        priv->arbi_timing.samplep = CONFIG_FLEXCAN1_ARBI_SAMPLEP;
+        priv->data_timing.bitrate = CONFIG_FLEXCAN1_DATA_BITRATE;
+        priv->data_timing.samplep = CONFIG_FLEXCAN1_DATA_SAMPLEP;
 #  else
-      priv->arbi_timing.bitrate = CONFIG_FLEXCAN1_BITRATE;
-      priv->arbi_timing.samplep = CONFIG_FLEXCAN1_SAMPLEP;
+        priv->arbi_timing.bitrate = CONFIG_FLEXCAN1_BITRATE;
+        priv->arbi_timing.samplep = CONFIG_FLEXCAN1_SAMPLEP;
 #  endif
-      break;
+        break;
 #endif
 
 #ifdef CONFIG_IMXRT_FLEXCAN2
-    case 2:
-      imxrt_clockall_can2();
-      imxrt_clockall_can2_serial();
-      priv         = &g_flexcan2;
-      memset(priv, 0, sizeof(struct imxrt_driver_s));
-      priv->base   = IMXRT_CAN2_BASE;
-      priv->config = &imxrt_flexcan2_config;
+      case 2:
+        imxrt_clockall_can2();
+        imxrt_clockall_can2_serial();
+        priv         = &g_flexcan2;
+        memset(priv, 0, sizeof(struct imxrt_driver_s));
+        priv->base   = IMXRT_CAN2_BASE;
+        priv->config = &imxrt_flexcan2_config;
 #  if defined(CONFIG_NET_CAN_CANFD) && defined(CONFIG_IMXRT_FLEXCAN2_FD)
-      priv->canfd_capable = true;
-      priv->mb_address_offset = 14;
+        priv->canfd_capable = true;
+        priv->mb_address_offset = 14;
 #  else
-      priv->canfd_capable = false;
-      priv->mb_address_offset = 0;
+        priv->canfd_capable = false;
+        priv->mb_address_offset = 0;
 #  endif
 
-      /* Default bitrate configuration */
+        /* Default bitrate configuration */
 
 #  if defined(CONFIG_NET_CAN_CANFD) && defined(CONFIG_IMXRT_FLEXCAN2_FD)
-      priv->arbi_timing.bitrate = CONFIG_FLEXCAN2_ARBI_BITRATE;
-      priv->arbi_timing.samplep = CONFIG_FLEXCAN2_ARBI_SAMPLEP;
-      priv->data_timing.bitrate = CONFIG_FLEXCAN2_DATA_BITRATE;
-      priv->data_timing.samplep = CONFIG_FLEXCAN2_DATA_SAMPLEP;
+        priv->arbi_timing.bitrate = CONFIG_FLEXCAN2_ARBI_BITRATE;
+        priv->arbi_timing.samplep = CONFIG_FLEXCAN2_ARBI_SAMPLEP;
+        priv->data_timing.bitrate = CONFIG_FLEXCAN2_DATA_BITRATE;
+        priv->data_timing.samplep = CONFIG_FLEXCAN2_DATA_SAMPLEP;
 #  else
-      priv->arbi_timing.bitrate = CONFIG_FLEXCAN2_BITRATE;
-      priv->arbi_timing.samplep = CONFIG_FLEXCAN2_SAMPLEP;
+        priv->arbi_timing.bitrate = CONFIG_FLEXCAN2_BITRATE;
+        priv->arbi_timing.samplep = CONFIG_FLEXCAN2_SAMPLEP;
 #  endif
-      break;
+        break;
 #endif
 
 #ifdef CONFIG_IMXRT_FLEXCAN3
-    case 3:
-      imxrt_clockall_can3();
-      imxrt_clockall_can3_serial();
-      priv         = &g_flexcan3;
-      memset(priv, 0, sizeof(struct imxrt_driver_s));
-      priv->base   = IMXRT_CAN3_BASE;
-      priv->config = &imxrt_flexcan3_config;
+      case 3:
+        imxrt_clockall_can3();
+        imxrt_clockall_can3_serial();
+        priv         = &g_flexcan3;
+        memset(priv, 0, sizeof(struct imxrt_driver_s));
+        priv->base   = IMXRT_CAN3_BASE;
+        priv->config = &imxrt_flexcan3_config;
 #  ifdef CONFIG_NET_CAN_CANFD
-      priv->canfd_capable = true;
-      priv->mb_address_offset = 14;
+        priv->canfd_capable = true;
+        priv->mb_address_offset = 14;
 #  else
-      priv->canfd_capable = false;
-      priv->mb_address_offset = 0;
+        priv->canfd_capable = false;
+        priv->mb_address_offset = 0;
 #  endif
 
-      /* Default bitrate configuration */
+        /* Default bitrate configuration */
 
 #  ifdef CONFIG_NET_CAN_CANFD
-      priv->arbi_timing.bitrate = CONFIG_FLEXCAN3_ARBI_BITRATE;
-      priv->arbi_timing.samplep = CONFIG_FLEXCAN3_ARBI_SAMPLEP;
-      priv->data_timing.bitrate = CONFIG_FLEXCAN3_DATA_BITRATE;
-      priv->data_timing.samplep = CONFIG_FLEXCAN3_DATA_SAMPLEP;
+        priv->arbi_timing.bitrate = CONFIG_FLEXCAN3_ARBI_BITRATE;
+        priv->arbi_timing.samplep = CONFIG_FLEXCAN3_ARBI_SAMPLEP;
+        priv->data_timing.bitrate = CONFIG_FLEXCAN3_DATA_BITRATE;
+        priv->data_timing.samplep = CONFIG_FLEXCAN3_DATA_SAMPLEP;
 #  else
-      priv->arbi_timing.bitrate = CONFIG_FLEXCAN3_BITRATE;
-      priv->arbi_timing.samplep = CONFIG_FLEXCAN3_SAMPLEP;
+        priv->arbi_timing.bitrate = CONFIG_FLEXCAN3_BITRATE;
+        priv->arbi_timing.samplep = CONFIG_FLEXCAN3_SAMPLEP;
 #  endif
-      break;
+        break;
 #endif
 
-    default:
-      return -ENODEV;
+      default:
+        return -ENODEV;
     }
 
   if (!imxrt_bitratetotimeseg(&priv->arbi_timing, 1, 0))


### PR DESCRIPTION
## Summary

Backport of apache/nuttx#19957, plus the nxstyle cleanup that PR carries for the same file.

`imxrt_transmit()` picks the lowest free TX mailbox. FlexCAN breaks an arbitration tie between mailboxes holding *equal* CAN IDs by taking the lowest mailbox number, so refilling a just-drained low mailbox while older frames are still pending in higher ones puts the newer frame on the wire first. Every frame of a DroneCAN multi-frame transfer carries the same CAN ID, so the receiver sees a broken toggle bit and discards the transfer.

## Problem

One of three stacked causes of the corrupted DroneCAN traffic in PX4/PX4-Autopilot#26868. Measured on an ARK FMU-v6XRT with an ARK X20 GNSS node on the same bus as a control — the node's 10-frame transfers were intact in every capture, which places the fault on the i.MX RT transmit path rather than the bus:

| source | stream | transfers | corrupt, before |
|---|---|---|---|
| FMU | `remoteid.Location`, 6 frames | 60 | **81.7%** |
| FMU | `remoteid.BasicID`, 4 frames | 60 | 6.7% |
| FMU | single-frame streams | 897 | 0% |
| GNSS node | `gnss.Fix2`, 10 frames | 600 | 0% |

## Solution

Hand out a mailbox above every pending one, and wrap back to the bottom only once the ring has drained.

This patch alone fixes the 4-frame stream and takes the 6-frame one to 40%. The remainder is two bugs above this driver, fixed separately in PX4/PX4-Autopilot#28363 (a frame discarded rather than retried when the ring is full, and a TX queue bypass in libuavcan). With all three: **0 corrupt transfers in 35 513 frames over 2 min**, CAN1 `HW errors` 0 and `IO errors` 0, sensor rates unchanged.

The second commit fixes pre-existing nxstyle violations in the same file. It is whitespace only — `git diff -w` against its parent is empty, and the built binary is byte-identical to the pre-restyle build that was validated on hardware.
