### PR TITLE
[BACKPORT] arch/arm/src/imxrt: Fix FlexCAN TX timeout aborting live mailboxes.

### DIFF
--- a/arch/arm/src/imxrt/imxrt_flexcan.c
+++ b/arch/arm/src/imxrt/imxrt_flexcan.c
@@ -1909,6 +1909,9 @@ static void imxrt_reset(struct imxrt_driver_s *priv)
     }
 
   regval  = getreg32(priv->base + IMXRT_CAN_MCR_OFFSET);
+  regval &= ~CAN_MCR_MAXMB_MASK; /* Zero MAXMB to ensure "bitwise or"
+                                  * below sets the correct value.
+                                  */
   regval |= CAN_MCR_SLFWAK | CAN_MCR_WRNEN | CAN_MCR_SRXDIS |
             CAN_MCR_IRMQ | CAN_MCR_AEN |
             (((TOTALMBCOUNT - 1) << CAN_MCR_MAXMB_SHIFT) &

--- a/arch/arm/src/imxrt/imxrt_flexcan.c
+++ b/arch/arm/src/imxrt/imxrt_flexcan.c
@@ -643,13 +643,18 @@ static int imxrt_transmit(struct imxrt_driver_s *priv)
     {
       struct timeval *tv =
              (struct timeval *)(priv->dev.d_buf + priv->dev.d_len);
-      priv->txmb[txmb].deadline = *tv;
       timeout  = (tv->tv_sec - ts.tv_sec)*CLK_TCK
                  + ((tv->tv_usec - ts.tv_nsec / 1000)*CLK_TCK) / 1000000;
       if (timeout < 0)
         {
           return 0;       /* No transmission for you! */
         }
+
+      /* Only now that the frame is going out, so a deadline is never left
+       * behind on a mailbox holding nothing.
+       */
+
+      priv->txmb[txmb].deadline = *tv;
     }
   else
     {

--- a/arch/arm/src/imxrt/imxrt_flexcan.c
+++ b/arch/arm/src/imxrt/imxrt_flexcan.c
@@ -81,6 +81,13 @@
 #define TXMBCOUNT                   (CONFIG_IMXRT_FLEXCAN_TXMB + 1)
 #define TOTALMBCOUNT                RXMBCOUNT + TXMBCOUNT
 
+/* TXMBCOUNT spans the mailbox reserved for the ERR005829 workaround as well,
+ * so the transmit ring is one shorter than the mailboxes it covers: the
+ * usable ones are RXMBCOUNT + 1 .. TOTALMBCOUNT - 1.
+ */
+
+#define TXMBRINGSIZE                (TXMBCOUNT - 1)
+
 #define IFLAG1_RX                   ((1 << RXMBCOUNT)-1)
 #define IFLAG1_TX                   (((1 << TXMBCOUNT)-2) << RXMBCOUNT)
 
@@ -266,7 +273,7 @@ struct imxrt_driver_s
   bool canfd_capable;
   int mb_address_offset;
 #ifdef TX_TIMEOUT_WQ
-  struct wdog_s txtimeout[TXMBCOUNT]; /* TX timeout timer */
+  struct wdog_s txtimeout[TXMBRINGSIZE]; /* TX timeout timer */
 #endif
   struct work_s rcvwork;            /* For deferring interrupt work to the wq */
   struct work_s irqwork;            /* For deferring interrupt work to the wq */
@@ -286,7 +293,7 @@ struct imxrt_driver_s
   const struct flexcan_config_s *config;
 
 #ifdef CONFIG_NET_CAN_RAW_TX_DEADLINE
-  struct txmbstats txmb[TXMBCOUNT];
+  struct txmbstats txmb[TXMBRINGSIZE];
 #endif
 };
 
@@ -1040,6 +1047,16 @@ static void imxrt_txdone(struct imxrt_driver_s *priv)
            */
 
           wd_cancel(&priv->txtimeout[txmb]);
+
+          /* Retire the deadline with the frame. Left behind it sits in the
+           * past forever, and the next expiry of any other mailbox's
+           * watchdog makes imxrt_txtimeout_work() abort whatever frame has
+           * since been loaded here.
+           */
+
+          priv->txmb[txmb].deadline.tv_sec  = 0;
+          priv->txmb[txmb].deadline.tv_usec = 0;
+
           struct mb_s *mb = flexcan_get_mb(priv, mbi);
           mb->cs.code = CAN_TXMB_INACTIVE;
 #endif
@@ -1203,9 +1220,11 @@ static void imxrt_txtimeout_work(void *arg)
   uint32_t mb_bit;
 
   struct timespec ts;
-  struct timeval *now = (struct timeval *)&ts;
+  struct timeval now;
+
   clock_systime_timespec(&ts);
-  now->tv_usec = ts.tv_nsec / 1000; /* timespec to timeval conversion */
+  now.tv_sec  = ts.tv_sec;
+  now.tv_usec = ts.tv_nsec / 1000;
 
   /* The watchdog timed out, yet we still check mailboxes in case the
    * transmit function transmitted a new frame
@@ -1213,25 +1232,43 @@ static void imxrt_txtimeout_work(void *arg)
 
   flags  = getreg32(priv->base + IMXRT_CAN_IFLAG1_OFFSET);
 
-  for (mbi = 0; mbi < TXMBCOUNT; mbi++)
+  for (mbi = 0; mbi < TXMBRINGSIZE; mbi++)
     {
-      if (priv->txmb[mbi].deadline.tv_sec != 0
-          && (now->tv_sec > priv->txmb[mbi].deadline.tv_sec
-          || now->tv_usec > priv->txmb[mbi].deadline.tv_usec))
+      struct timeval *deadline = &priv->txmb[mbi].deadline;
+      struct mb_s *mb;
+
+      /* imxrt_txdone() zeroes the deadline of a mailbox it has retired, so a
+       * non-zero deadline here means the mailbox still holds a frame.
+       */
+
+      if (deadline->tv_sec == 0 && deadline->tv_usec == 0)
         {
-          NETDEV_TXTIMEOUTS(&priv->dev);
-
-          mb_bit = 1 << (RXMBCOUNT +  mbi);
-
-          if (flags & mb_bit)
-            {
-              putreg32(mb_bit, priv->base + IMXRT_CAN_IFLAG1_OFFSET);
-            }
-
-          struct mb_s *mb = flexcan_get_mb(priv, mbi + RXMBCOUNT);
-          mb->cs.code = CAN_TXMB_ABORT;
-          priv->txmb[mbi].pending = TX_ABORT;
+          continue;
         }
+
+      if (now.tv_sec < deadline->tv_sec
+          || (now.tv_sec == deadline->tv_sec
+              && now.tv_usec <= deadline->tv_usec))
+        {
+          continue;
+        }
+
+      NETDEV_TXTIMEOUTS(&priv->dev);
+
+      /* imxrt_transmit() stores the deadline of mailbox RXMBCOUNT + 1 + mbi
+       * in txmb[mbi]; the mailbox this loop aborts has to match.
+       */
+
+      mb_bit = 1 << (RXMBCOUNT + 1 + mbi);
+
+      if (flags & mb_bit)
+        {
+          putreg32(mb_bit, priv->base + IMXRT_CAN_IFLAG1_OFFSET);
+        }
+
+      mb = flexcan_get_mb(priv, RXMBCOUNT + 1 + mbi);
+      mb->cs.code = CAN_TXMB_ABORT;
+      priv->txmb[mbi].pending = TX_ABORT;
     }
 }
 


### PR DESCRIPTION
Rebased onto `px4_firmware_nuttx-10.3.0+` now that #394 is in it as `3d7f0016cd7`, and grown from one fix to three — the extra two turned up while chasing an unrelated CAN FD framing bug in the same driver.

Upstream at apache/nuttx#19970; draft until that merges. Stacked on #396 so both trees match apache/nuttx master; retarget to `px4_firmware_nuttx-10.3.0+` once #396 lands.


## Summary

Three defects in the i.MX RT FlexCAN transmit path, all found while chasing an error-passive storm on an ARK FMU-v6XRT.

**`imxrt_txtimeout_work()` aborts the wrong mailboxes.** It aborts mailbox `RXMBCOUNT + mbi` while the deadline it consulted belongs to `RXMBCOUNT + 1 + mbi`, so every abort lands one mailbox low; `mbi == 0` writes `CAN_TXMB_ABORT` into the buffer reserved for the ERR005829 workaround and the highest TX mailbox is never aborted at all. Its expiry test is `now.tv_sec > d.tv_sec || now.tv_usec > d.tv_usec`, which declares any deadline crossing a second boundary expired, and the `now` it compares against is a `struct timespec` cast to a `struct timeval`. The walk runs to `TXMBCOUNT`, which counts the reserved mailbox too, so the last iteration addresses one mailbox past the ring and `mb_address[]` one past its end — in bounds today only because `txmb[]` is never written that far. And `imxrt_txdone()` cancels the watchdog but leaves `txmb[].deadline` set, so a retired mailbox looks expired forever and the next expiry on any other mailbox aborts whatever frame has since been loaded there.

Since `imxrt_txmb_next()` only hands out a mailbox above every pending one, a mailbox left in `DATAORREMOTE` also pins the allocator at `TOTALMBCOUNT` and transmit never recovers.

**`imxrt_transmit()` stores the deadline before it knows the frame is going out.** The early return for an already-expired deadline then leaves that deadline on a mailbox holding no frame, and the next watchdog expiry counts a transmit timeout that did not happen and aborts a mailbox the allocator may since have handed to a live frame.

**`MCR[MAXMB]` is OR-ed in rather than assigned.** MAXMB resets to 0x0f, so the OR can only raise it: every configuration with fewer than 16 mailboxes runs with MAXMB = 15 and FlexCAN arbitrates over mailboxes the driver never initialised — with the classic payload layout MB14 and MB15 hold power-on contents, and with a 64-byte CAN FD layout they are past the end of the mailbox RAM region. `s32k1xx_flexcan.c` already carries this fix; the same two lines go here.

The same `timeval` cast, the same OR-ed expiry test and the same unwritten deadline are in `kinetis_flexcan.c`, `s32k1xx_flexcan.c` and `s32k3xx_flexcan.c`, and the MAXMB one in kinetis and s32k3xx. Those drivers index `priv->tx[mbi]` directly, so the mailbox off-by-one is imxrt's alone. Left untouched here because there is no hardware to test them on — happy to extend the PR if a maintainer prefers.

## Impact

- Is new feature added? NO
- Is existing feature changed? YES — a transmit deadline now expires when it is actually due, and aborts the mailbox that owns it.
- Impact on user? YES — SocketCAN on i.MX RT no longer loses the interface to one expired frame. No API change.
- Impact on build? NO
- Impact on hardware? YES — i.MX RT boards using SocketCAN.
- Impact on documentation? NO
- Impact on security? NO
- Impact on compatibility? NO

## Testing

ARK FMU-v6XRT (i.MX RT1176), `ark_fmu-v6xrt_default`, arm-none-eabi-gcc 13.2.1. Two 1 Mbit/s DroneCAN buses with a GNSS node on each, driven by the PX4 uavcan driver. ECR, ESR1 and MCR read over SWD without halting the core.

TX timeout fix, one bus at 736 offered frames/s (9% utilisation):

```
before:  0 frames/s transmitted, ECR[TXERRCNT] pinned at 128,
         ESR1[FLTCONF] error passive, still dead after a reboot
after:   734 frames/s, 0.1% loss, TXERRCNT 0, error active
```

MAXMB fix, `MCR` read back on both instances:

```
before:  0x0063180f   (MAXMB 15, 14 mailboxes configured)
after:   0x0063180d   (MAXMB 13)
```

No regression at 8-channel ESC RawCommand to both buses at 400 Hz plus RawIMU back — 705 offered frames/s per bus, 31% utilisation, 120 s: 0 error episodes, TXERRCNT 0, 0 transmit timeouts, 0.00% loss on both interfaces.

The deadline-store fix is structural; its window is too narrow to provoke deliberately, and it is covered by the same run showing no timeouts.
