### PR TITLE
[BACKPORT] arch/arm: Initialize the FlexCAN mailbox control word

### DIFF
--- a/arch/arm/src/imxrt/imxrt_flexcan.c
+++ b/arch/arm/src/imxrt/imxrt_flexcan.c
@@ -670,6 +670,7 @@ static int imxrt_transmit(struct imxrt_driver_s *priv)
     (peak_tx_mailbox_index_ > mbi ? peak_tx_mailbox_index_ : mbi);
 
   union cs_e cs;
+  cs.cs = 0;
   cs.code = CAN_TXMB_DATAORREMOTE;
   struct mb_s *mb = flexcan_get_mb(priv, mbi);
   mb->cs.code = CAN_TXMB_INACTIVE;
@@ -712,6 +713,7 @@ static int imxrt_transmit(struct imxrt_driver_s *priv)
         }
 
       cs.rtr = frame->can_id & FLAGRTR ? 1 : 0;
+      cs.brs = frame->flags & CANFD_BRS ? 1 : 0;
 
       cs.dlc = len_to_can_dlc[frame->len];
 

--- a/arch/arm/src/imxrt/imxrt_flexcan.c
+++ b/arch/arm/src/imxrt/imxrt_flexcan.c
@@ -81,6 +81,13 @@
 #define TXMBCOUNT                   (CONFIG_IMXRT_FLEXCAN_TXMB + 1)
 #define TOTALMBCOUNT                RXMBCOUNT + TXMBCOUNT
 
+/* TXMBCOUNT spans the mailbox reserved for the ERR005829 workaround as well,
+ * so the transmit ring is one shorter than the mailboxes it covers: the
+ * usable ones are RXMBCOUNT + 1 .. TOTALMBCOUNT - 1.
+ */
+
+#define TXMBRINGSIZE                (TXMBCOUNT - 1)
+
 #define IFLAG1_RX                   ((1 << RXMBCOUNT)-1)
 #define IFLAG1_TX                   (((1 << TXMBCOUNT)-2) << RXMBCOUNT)
 
@@ -266,7 +273,7 @@ struct imxrt_driver_s
   bool canfd_capable;
   int mb_address_offset;
 #ifdef TX_TIMEOUT_WQ
-  struct wdog_s txtimeout[TXMBCOUNT]; /* TX timeout timer */
+  struct wdog_s txtimeout[TXMBRINGSIZE]; /* TX timeout timer */
 #endif
   struct work_s rcvwork;            /* For deferring interrupt work to the wq */
   struct work_s irqwork;            /* For deferring interrupt work to the wq */
@@ -286,7 +293,7 @@ struct imxrt_driver_s
   const struct flexcan_config_s *config;
 
 #ifdef CONFIG_NET_CAN_RAW_TX_DEADLINE
-  struct txmbstats txmb[TXMBCOUNT];
+  struct txmbstats txmb[TXMBRINGSIZE];
 #endif
 };
 
@@ -636,13 +643,18 @@ static int imxrt_transmit(struct imxrt_driver_s *priv)
     {
       struct timeval *tv =
              (struct timeval *)(priv->dev.d_buf + priv->dev.d_len);
-      priv->txmb[txmb].deadline = *tv;
       timeout  = (tv->tv_sec - ts.tv_sec)*CLK_TCK
                  + ((tv->tv_usec - ts.tv_nsec / 1000)*CLK_TCK) / 1000000;
       if (timeout < 0)
         {
           return 0;       /* No transmission for you! */
         }
+
+      /* Only now that the frame is going out, so a deadline is never left
+       * behind on a mailbox holding nothing.
+       */
+
+      priv->txmb[txmb].deadline = *tv;
     }
   else
     {
@@ -1040,6 +1052,16 @@ static void imxrt_txdone(struct imxrt_driver_s *priv)
            */
 
           wd_cancel(&priv->txtimeout[txmb]);
+
+          /* Retire the deadline with the frame. Left behind it sits in the
+           * past forever, and the next expiry of any other mailbox's
+           * watchdog makes imxrt_txtimeout_work() abort whatever frame has
+           * since been loaded here.
+           */
+
+          priv->txmb[txmb].deadline.tv_sec  = 0;
+          priv->txmb[txmb].deadline.tv_usec = 0;
+
           struct mb_s *mb = flexcan_get_mb(priv, mbi);
           mb->cs.code = CAN_TXMB_INACTIVE;
 #endif
@@ -1203,9 +1225,11 @@ static void imxrt_txtimeout_work(void *arg)
   uint32_t mb_bit;
 
   struct timespec ts;
-  struct timeval *now = (struct timeval *)&ts;
+  struct timeval now;
+
   clock_systime_timespec(&ts);
-  now->tv_usec = ts.tv_nsec / 1000; /* timespec to timeval conversion */
+  now.tv_sec  = ts.tv_sec;
+  now.tv_usec = ts.tv_nsec / 1000;
 
   /* The watchdog timed out, yet we still check mailboxes in case the
    * transmit function transmitted a new frame
@@ -1213,25 +1237,43 @@ static void imxrt_txtimeout_work(void *arg)
 
   flags  = getreg32(priv->base + IMXRT_CAN_IFLAG1_OFFSET);
 
-  for (mbi = 0; mbi < TXMBCOUNT; mbi++)
+  for (mbi = 0; mbi < TXMBRINGSIZE; mbi++)
     {
-      if (priv->txmb[mbi].deadline.tv_sec != 0
-          && (now->tv_sec > priv->txmb[mbi].deadline.tv_sec
-          || now->tv_usec > priv->txmb[mbi].deadline.tv_usec))
+      struct timeval *deadline = &priv->txmb[mbi].deadline;
+      struct mb_s *mb;
+
+      /* imxrt_txdone() zeroes the deadline of a mailbox it has retired, so a
+       * non-zero deadline here means the mailbox still holds a frame.
+       */
+
+      if (deadline->tv_sec == 0 && deadline->tv_usec == 0)
         {
-          NETDEV_TXTIMEOUTS(&priv->dev);
-
-          mb_bit = 1 << (RXMBCOUNT +  mbi);
-
-          if (flags & mb_bit)
-            {
-              putreg32(mb_bit, priv->base + IMXRT_CAN_IFLAG1_OFFSET);
-            }
-
-          struct mb_s *mb = flexcan_get_mb(priv, mbi + RXMBCOUNT);
-          mb->cs.code = CAN_TXMB_ABORT;
-          priv->txmb[mbi].pending = TX_ABORT;
+          continue;
         }
+
+      if (now.tv_sec < deadline->tv_sec
+          || (now.tv_sec == deadline->tv_sec
+              && now.tv_usec <= deadline->tv_usec))
+        {
+          continue;
+        }
+
+      NETDEV_TXTIMEOUTS(&priv->dev);
+
+      /* imxrt_transmit() stores the deadline of mailbox RXMBCOUNT + 1 + mbi
+       * in txmb[mbi]; the mailbox this loop aborts has to match.
+       */
+
+      mb_bit = 1 << (RXMBCOUNT + 1 + mbi);
+
+      if (flags & mb_bit)
+        {
+          putreg32(mb_bit, priv->base + IMXRT_CAN_IFLAG1_OFFSET);
+        }
+
+      mb = flexcan_get_mb(priv, RXMBCOUNT + 1 + mbi);
+      mb->cs.code = CAN_TXMB_ABORT;
+      priv->txmb[mbi].pending = TX_ABORT;
     }
 }
 
@@ -1867,6 +1909,9 @@ static void imxrt_reset(struct imxrt_driver_s *priv)
     }
 
   regval  = getreg32(priv->base + IMXRT_CAN_MCR_OFFSET);
+  regval &= ~CAN_MCR_MAXMB_MASK; /* Zero MAXMB to ensure "bitwise or"
+                                  * below sets the correct value.
+                                  */
   regval |= CAN_MCR_SLFWAK | CAN_MCR_WRNEN | CAN_MCR_SRXDIS |
             CAN_MCR_IRMQ | CAN_MCR_AEN |
             (((TOTALMBCOUNT - 1) << CAN_MCR_MAXMB_SHIFT) &

--- a/arch/arm/src/kinetis/kinetis_flexcan.c
+++ b/arch/arm/src/kinetis/kinetis_flexcan.c
@@ -682,6 +682,7 @@ static int kinetis_transmit(struct kinetis_driver_s *priv)
     (peak_tx_mailbox_index_ > mbi ? peak_tx_mailbox_index_ : mbi);
 
   union cs_e cs;
+  cs.cs = 0;
   cs.code = CAN_TXMB_DATAORREMOTE;
   struct mb_s *mb = &priv->tx[mbi];
   mb->cs.code = CAN_TXMB_INACTIVE;
@@ -724,6 +725,7 @@ static int kinetis_transmit(struct kinetis_driver_s *priv)
         }
 
       cs.rtr = frame->can_id & FLAGRTR ? 1 : 0;
+      cs.brs = frame->flags & CANFD_BRS ? 1 : 0;
 
       cs.dlc = len_to_can_dlc[frame->len];
 

--- a/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
@@ -680,6 +680,7 @@ static int s32k1xx_transmit(struct s32k1xx_driver_s *priv)
     (peak_tx_mailbox_index_ > mbi ? peak_tx_mailbox_index_ : mbi);
 
   union cs_e cs;
+  cs.cs = 0;
   cs.code = CAN_TXMB_DATAORREMOTE;
   struct mb_s *mb = &priv->tx[mbi];
   mb->cs.code = CAN_TXMB_INACTIVE;
@@ -724,6 +725,7 @@ static int s32k1xx_transmit(struct s32k1xx_driver_s *priv)
         }
 
       cs.rtr = frame->can_id & FLAGRTR ? 1 : 0;
+      cs.brs = frame->flags & CANFD_BRS ? 1 : 0;
 
       cs.dlc = len_to_can_dlc[frame->len];
 

--- a/arch/arm/src/s32k3xx/s32k3xx_flexcan.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_flexcan.c
@@ -846,6 +846,7 @@ static int s32k3xx_transmit(struct s32k3xx_driver_s *priv)
     (peak_tx_mailbox_index_ > mbi ? peak_tx_mailbox_index_ : mbi);
 
   union cs_e cs;
+  cs.cs = 0;
   cs.code = CAN_TXMB_DATAORREMOTE;
   struct mb_s *mb = &priv->tx[mbi];
   mb->cs.code = CAN_TXMB_INACTIVE;
@@ -890,6 +891,7 @@ static int s32k3xx_transmit(struct s32k3xx_driver_s *priv)
         }
 
       cs.rtr = frame->can_id & FLAGRTR ? 1 : 0;
+      cs.brs = frame->flags & CANFD_BRS ? 1 : 0;
 
       cs.dlc = len_to_can_dlc[frame->len];
 


### PR DESCRIPTION
Backport of [apache/nuttx#19605](https://github.com/apache/nuttx/pull/19605), already merged to master. Nothing to wait for.

## Summary

Backports all four commits of apache/nuttx#19605 — imxrt `5f8a3ea68dc`, s32k1xx `94f4b9e92f6`, s32k3xx `b3a280e3b00`, kinetis `c4010cb205a` — which zero `union cs_e cs` in the FlexCAN transmit path.

`imxrt_transmit()` and its siblings assign only `code`, `ide`, `rtr` and `dlc` of the mailbox control word. Every member of the union is `volatile`, so the compiler updates it in place in its stack slot rather than materialising a value, and EDL, BRS, ESI, SRR and the reserved bits keep whatever the stack held; `mb->cs = cs` then writes all 32 bits into the mailbox. Where the controller has CAN FD enabled — on i.MX RT117x that is the arch Kconfig's doing, not the board's — a stray EDL transmits a classic frame as CAN FD, which no classic node acknowledges, so FlexCAN retries it at bus rate until the transmit deadline aborts the mailbox.

Upstream landed them as an undescribed side note in a bit-rate-switch change, which is why nothing pointed at them from the symptoms below.

## Impact

- Is new feature added? NO
- Is existing feature changed? YES — CAN FD frames take BRS from the socket instead of from the stack.
- Impact on user? YES — SocketCAN traffic on i.MX RT stops driving the interface error-passive. No API change.
- Impact on build? NO
- Impact on hardware? YES — every i.MX RT board using SocketCAN. Kinetis and s32k1xx have no FD hardware, so there the stray bits are only SRR and the reserved fields.
- Impact on documentation? NO
- Impact on security? NO
- Impact on compatibility? NO

## Testing

ARK FMU-v6XRT, two 1 Mbit/s DroneCAN buses with a GNSS node each, 8-channel ESC RawCommand out at 400 Hz and RawIMU back: 705 offered frames/s per bus, 31% bus utilisation. ECR, ESR1 and the TX mailbox control words sampled over SWD every 0.3 ms without halting the core, 120 s per run.

Before, per bus:

```
CAN1  17 error episodes  peak TXERRCNT 253  1730 samples error-passive  38 TX timeouts  0.07% loss
CAN2  31 error episodes  peak TXERRCNT 248  2768 samples error-passive  60 TX timeouts  0.16% loss
```

Every one of those 48 episodes had exactly one mailbox stuck with EDL set while healthy frames went out of the others:

```
MB11 x90  0xbce80000 code=c dlc=8 EDL|ESI|SRR|IDE
MB12 x88  0x0c280000 code=c dlc=8 IDE
```

After, per bus:

```
CAN1  0 episodes  TXERRCNT 0  0 samples error-passive  0 TX timeouts  0.00% loss
CAN2  0 episodes  TXERRCNT 0  0 samples error-passive  0 TX timeouts  0.00% loss
```

---
