### PR TITLE
arch/arm/src/stm32h7: treat classic data_bitrate 0 as arbitration

### DIFF
--- a/arch/arm/src/stm32h7/stm32_fdcan_sock.c
+++ b/arch/arm/src/stm32h7/stm32_fdcan_sock.c
@@ -2091,6 +2091,25 @@ int fdcan_initialize(struct fdcan_driver_s *priv)
 
   putreg32(regval, priv->base + STM32_FDCAN_DBTP_OFFSET);
 
+#ifdef CONFIG_NET_CAN_CANFD
+  /* BRS needs TDC or the transmitter samples its own delayed bit and
+   * goes bus-off. Same formula as the PX4 stm32h7 UAVCAN driver.
+   */
+
+  if (priv->data_timing.bitrate > priv->arbi_timing.bitrate)
+    {
+      modifyreg32(priv->base + STM32_FDCAN_DBTP_OFFSET, 0, FDCAN_DBTP_TDC);
+      uint32_t tdco = (uint32_t)priv->data_timing.bs1 + 2U;
+      if (tdco > 0x7FU)
+        {
+          tdco = 0x7FU;
+        }
+
+      putreg32(tdco << FDCAN_TDCR_TDCO_SHIFT,
+               priv->base + STM32_FDCAN_TDCR_OFFSET);
+    }
+#endif
+
   /* Operation Configuration */
 
 #ifdef STM32H7_FDCAN_LOOPBACK

--- a/arch/arm/src/stm32h7/stm32_fdcan_sock.c
+++ b/arch/arm/src/stm32h7/stm32_fdcan_sock.c
@@ -40,6 +40,7 @@
 #include <nuttx/wqueue.h>
 #include <nuttx/signal.h>
 #include <nuttx/net/netdev.h>
+#include <nuttx/net/net.h>
 #include <nuttx/net/can.h>
 #include <netpacket/can.h>
 
@@ -1198,13 +1199,21 @@ static void fdcan_receive_work(void *arg)
           priv->dev.d_buf = (uint8_t *)frame;
         }
 
-      /* Send to socket interface */
+      /* Drop the critical section before the net stack. can_input()
+       * allocates IOBs and may take the net lock; doing that with IRQs
+       * masked hardfaults (IMPRECISERR in hpwork / can_datahandler).
+       * Hold the (recursive) net lock around can_input() the same way
+       * imxrt FlexCAN does, so can_callback()'s trylock succeeds.
+       */
 
+      leave_critical_section(flags);
+
+      net_lock();
       can_input(&priv->dev);
-
-      /* Update iface statistics */
-
+      net_unlock();
       NETDEV_RXPACKETS(&priv->dev);
+
+      flags = enter_critical_section();
 
       /* Point the packet buffer back to the next Tx buffer that will be
        * used during the next write.  If the write queue is full, then

--- a/arch/arm/src/stm32h7/stm32_fdcan_sock.c
+++ b/arch/arm/src/stm32h7/stm32_fdcan_sock.c
@@ -561,6 +561,12 @@ int32_t fdcan_bittiming(struct fdcan_bitseg *timing)
   const uint8_t max_quanta_per_bit = (timing->bitrate >= 1000000) ? 10 : 17;
   static const int max_sp_location = 900;
 
+  if (target_bitrate == 0)
+    {
+      nerr("Target bitrate invalid - zero.");
+      return 2;
+    }
+
   /* Computing (prescaler * BS):
    *   BITRATE = 1 / (PRESCALER * (1 / PCLK) * (1 + BS1 + BS2))
    *   BITRATE = PCLK / (PRESCALER * (1 + BS1 + BS2))
@@ -1732,7 +1738,11 @@ static int fdcan_ifup(struct net_driver_s *dev)
 
   irqstate_t flags = enter_critical_section();
 
-  fdcan_initialize(priv);
+  if (fdcan_initialize(priv) < 0)
+    {
+      leave_critical_section(flags);
+      return -EIO;
+    }
 
   fdcan_setinit(priv->base, 1);
   fdcan_setconfig(priv->base, 1);
@@ -1917,6 +1927,14 @@ static int fdcan_netdev_ioctl(struct net_driver_s *dev, int cmd,
           priv->arbi_timing.bitrate = req->arbi_bitrate * 1000;
 #ifdef CONFIG_NET_CAN_CANFD
           priv->data_timing.bitrate = req->data_bitrate * 1000;
+          /* Classic CAN ioctls pass data_bitrate 0. Programming 0 fails
+           * fdcan_bittiming() after it has already cleared IE, so RX
+           * interrupts never run. Match the arbitration rate instead.
+           */
+          if (priv->data_timing.bitrate == 0)
+            {
+              priv->data_timing.bitrate = priv->arbi_timing.bitrate;
+            }
 #endif
 
           /* Reset CAN controller and start with new timings */

--- a/net/can/can_callback.c
+++ b/net/can/can_callback.c
@@ -121,9 +121,12 @@ uint16_t can_callback(FAR struct net_driver_s *dev,
   if (conn)
     {
 #ifdef CONFIG_NET_TIMESTAMP
-      /* TIMESTAMP sockopt is activated, create timestamp and copy to iob */
+      /* TIMESTAMP sockopt is activated, create timestamp and copy to iob.
+       * d_appdata can be NULL on STM32H7 FDCAN HPWORK; writing through it
+       * hardfaults (IMPRECISERR in can_callback).
+       */
 
-      if (conn->sconn.s_timestamp)
+      if (conn->sconn.s_timestamp && dev->d_appdata != NULL)
         {
           struct timespec *ts = (struct timespec *)
                                                 &dev->d_appdata[dev->d_len];
@@ -135,23 +138,26 @@ uint16_t can_callback(FAR struct net_driver_s *dev,
         }
 #endif
 
-      /* Try to lock the network when successful send data to the listener */
+      /* Hold the net lock across both the listener callback and the
+       * read-ahead queue. can_datahandler() requires the lock; the old
+       * path unlocked first and then queued, which hardfaulted
+       * (IMPRECISERR) on STM32H7 FDCAN HPWORK in can_datahandler /
+       * can_readahead_signal.
+       *
+       * If the lock is busy, leave CAN_NEWDATA set so can_input()
+       * returns -EAGAIN and the driver retries.
+       */
 
       if (net_trylock() == OK)
         {
           flags = devif_conn_event(dev, conn, flags, conn->sconn.list);
+
+          if ((flags & CAN_NEWDATA) != 0)
+            {
+              flags = can_data_event(dev, conn, flags);
+            }
+
           net_unlock();
-        }
-
-      /* Either we did not get the lock or there is no application listening
-       * If we did not get a lock we store the frame in the read-ahead buffer
-       */
-
-      if ((flags & CAN_NEWDATA) != 0)
-        {
-          /* Data was not handled.. dispose of it appropriately */
-
-          flags = can_data_event(dev, conn, flags);
         }
     }
 

--- a/net/can/can_conn.c
+++ b/net/can/can_conn.c
@@ -147,6 +147,11 @@ FAR struct can_conn_s *can_alloc(void)
   conn = (FAR struct can_conn_s *)dq_remfirst(&g_free_can_connections);
   if (conn != NULL)
     {
+      /* Recycled connections keep stale readahead queue pointers. */
+
+      conn->readahead.qh_head = NULL;
+      conn->readahead.qh_tail = NULL;
+
       /* FIXME SocketCAN default behavior enables loopback */
 
 #ifdef CONFIG_NET_CANPROTO_OPTIONS


### PR DESCRIPTION
## Problem

Classic CAN `SIOCSCANBITRATE` callers (PX4 UAVCAN/SLCAN) pass `data_bitrate = 0`. `fdcan_bittiming()` rejects that after `fdcan_initialize()` has already cleared FDCAN `IE`, so RX interrupts never run. On an ARK FPV + DroneCAN ESC this filled RX FIFO 0 (`RF0L` set) while UAVCAN showed `RX frames: 0` and dynamic node allocation never completed.

## Fix

- Map a zero data-phase rate onto the arbitration rate so `BRSE` stays off and `IE.RF0NE` is programmed.
- Reject a zero target bitrate before dividing.
- Do not `ifup` after `fdcan_initialize()` fails.

Verified on ARK FPV: after this plus the matching PX4 SocketCAN caller change, CAN1 RX runs, DNA allocates node 123, and `esc.Status` is received.