### PR TITLE
[BACKPORT] arch/arm/stm32: Make Ethernet TX watchdog timeout configurable

### DIFF
--- a/arch/arm/src/stm32/Kconfig
+++ b/arch/arm/src/stm32/Kconfig
@@ -10848,6 +10848,13 @@ config STM32_ETH100MBPS
 		If STM32_AUTONEG is not defined, then this may be defined to select 100 MBps
 		speed.  Default: 10 Mbps
 
+config STM32_ETH_TXTIMEOUT
+	int "TX watchdog timeout (seconds)"
+	default 60
+	---help---
+		Seconds before the TX watchdog resets the MAC when a transmission
+		does not complete.
+
 config STM32_PHYSR
 	int "PHY Status Register Address (decimal)"
 	depends on STM32_AUTONEG

--- a/arch/arm/src/stm32/stm32_eth.c
+++ b/arch/arm/src/stm32/stm32_eth.c
@@ -259,6 +259,9 @@
 #ifndef CONFIG_STM32_ETH_NTXDESC
 #  define CONFIG_STM32_ETH_NTXDESC 4
 #endif
+#ifndef CONFIG_STM32_ETH_TXTIMEOUT
+#  define CONFIG_STM32_ETH_TXTIMEOUT 60
+#endif
 
 /* We need at least one more free buffer than transmit buffers */
 
@@ -292,9 +295,9 @@
 
 /* Timing *******************************************************************/
 
-/* TX timeout = 1 minute */
+/* TX timeout */
 
-#define STM32_TXTIMEOUT   (60*CLK_TCK)
+#define STM32_TXTIMEOUT   (CONFIG_STM32_ETH_TXTIMEOUT*CLK_TCK)
 
 /* PHY reset/configuration delays in milliseconds */
 

--- a/arch/arm/src/stm32f7/Kconfig
+++ b/arch/arm/src/stm32f7/Kconfig
@@ -6416,6 +6416,13 @@ config STM32F7_ETH100MBPS
 		If STM32F7_AUTONEG is not defined, then this may be defined to select 100 MBps
 		speed.  Default: 10 Mbps
 
+config STM32F7_ETH_TXTIMEOUT
+	int "TX watchdog timeout (seconds)"
+	default 60
+	---help---
+		Seconds before the TX watchdog resets the MAC when a transmission
+		does not complete.
+
 config STM32F7_PHYSR
 	int "PHY Status Register Address (decimal)"
 	depends on STM32F7_AUTONEG

--- a/arch/arm/src/stm32f7/stm32_ethernet.c
+++ b/arch/arm/src/stm32f7/stm32_ethernet.c
@@ -218,6 +218,9 @@
 #ifndef CONFIG_STM32F7_ETH_NTXDESC
 #  define CONFIG_STM32F7_ETH_NTXDESC 4
 #endif
+#ifndef CONFIG_STM32F7_ETH_TXTIMEOUT
+#  define CONFIG_STM32F7_ETH_TXTIMEOUT 60
+#endif
 
 #ifndef min
 #  define min(a,b) ((a) < (b) ? (a) : (b))
@@ -289,9 +292,9 @@
 
 /* Timing *******************************************************************/
 
-/* TX timeout = 1 minute */
+/* TX timeout */
 
-#define STM32_TXTIMEOUT   (60*CLK_TCK)
+#define STM32_TXTIMEOUT   (CONFIG_STM32F7_ETH_TXTIMEOUT*CLK_TCK)
 
 /* PHY reset/configuration delays in milliseconds */
 

--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -5186,6 +5186,13 @@ config STM32H7_ETH100MBPS
 		If STM32H7_AUTONEG is not defined, then this may be defined to select 100 MBps
 		speed.  Default: 10 Mbps
 
+config STM32H7_ETH_TXTIMEOUT
+	int "TX watchdog timeout (seconds)"
+	default 60
+	---help---
+		Seconds before the TX watchdog resets the MAC when a transmission
+		does not complete.
+
 config STM32H7_PHYSR
 	int "PHY Status Register Address (decimal)"
 	depends on STM32H7_AUTONEG

--- a/arch/arm/src/stm32h7/stm32_ethernet.c
+++ b/arch/arm/src/stm32h7/stm32_ethernet.c
@@ -271,6 +271,9 @@
 #ifndef CONFIG_STM32H7_ETH_NTXDESC
 #  define CONFIG_STM32H7_ETH_NTXDESC 4
 #endif
+#ifndef CONFIG_STM32H7_ETH_TXTIMEOUT
+#  define CONFIG_STM32H7_ETH_TXTIMEOUT 60
+#endif
 
 #ifndef min
 #  define min(a,b) ((a) < (b) ? (a) : (b))
@@ -335,9 +338,9 @@
 
 /* Timing *******************************************************************/
 
-/* TX timeout = 1 minute */
+/* TX timeout */
 
-#define STM32_TXTIMEOUT   (60*CLK_TCK)
+#define STM32_TXTIMEOUT   (CONFIG_STM32H7_ETH_TXTIMEOUT*CLK_TCK)
 
 /* PHY reset/configuration delays in milliseconds */
 


### PR DESCRIPTION
Backport of https://github.com/apache/nuttx/pull/19968.