### PR TITLE
[BACKPORT] libs/libc/string: fix memmem() boundary case when needle is at end of haystack

### DIFF
--- a/libs/libc/string/lib_memmem.c
+++ b/libs/libc/string/lib_memmem.c
@@ -50,12 +50,17 @@ FAR void *memmem(FAR const void *haystack, size_t haystacklen,
   size_t i;
   size_t y;
 
+  if (needlelen == 0)
+    {
+      return (void *)haystack;
+    }
+
   if (needlelen > haystacklen)
     {
       return NULL;
     }
 
-  for (i = 0; i < haystacklen - needlelen; i++)
+  for (i = 0; i <= haystacklen - needlelen; i++)
     {
       y = 0;
       while (h[i + y] == n[y])


### PR DESCRIPTION
## Summary
Backport of https://github.com/apache/nuttx/pull/11889 onto `px4_firmware_nuttx-10.3.0+`.

## Problem
`memmem()` iterates `i < haystacklen - needlelen`, so a needle at the last legal offset never matches, including a needle-sized haystack.

## Solution
Include the last legal start offset. Empty needle returns haystack, matching Linux/BSD.