### PR TITLE
[BACKPORT] sched: Fix stdio initialization of standard streams when buffering is disabled

### DIFF
--- a/sched/tls/task_initinfo.c
+++ b/sched/tls/task_initinfo.c
@@ -77,6 +77,7 @@ static void task_init_stream(FAR struct streamlist *list)
       stream[i].fs_flags   |= __FS_FLAG_LBF; /* Line buffering */
 
 #  endif /* CONFIG_STDIO_LINEBUFFER */
+#endif /* !CONFIG_STDIO_DISABLE_BUFFERING && CONFIG_STDIO_BUFFER_SIZE > 0 */
 
       /* Save the file description and open flags.  Setting the
        * file descriptor locks this stream.
@@ -84,14 +85,6 @@ static void task_init_stream(FAR struct streamlist *list)
 
       stream[i].fs_cookie   = (FAR void *)(intptr_t)i;
       stream[i].fs_oflags   = i ? O_WROK : O_RDONLY;
-
-      /* Assign custom callbacks to NULL. */
-
-      stream[i].fs_iofunc.read  = NULL;
-      stream[i].fs_iofunc.write = NULL;
-      stream[i].fs_iofunc.seek  = NULL;
-      stream[i].fs_iofunc.close = NULL;
-#endif /* !CONFIG_STDIO_DISABLE_BUFFERING && CONFIG_STDIO_BUFFER_SIZE > 0 */
     }
 }
 #endif


### PR DESCRIPTION
Backport of apache/nuttx#19884 (upstream 2b1cf4238756, merged 2026-08-17) for the NuttX 12.12.0 upgrade (PX4/PX4-Autopilot#26215).

On the PX4 side this hits any defconfig with `CONFIG_STDIO_DISABLE_BUFFERING=y`: the fmu-v5x and radiolink/PIX6 nsh configs (being reverted to buffered stdio separately), nxp/ucans32k146, and the ~50 bootloader defconfigs.

One conflict resolved against upstream: this branch still uses the `O_WROK` alias where upstream now spells it `O_WRONLY` (aliases removed post-12.12 by 6161c73639). Kept the fork's spelling, identical semantics.

cc @PetervdPerk-NXP @jlaitine
