### PR TITLE
[BACKPORT] arch/arm/src/imxrt: complete the FlexCAN TX timeout backport

### DIFF
--- a/arch/arm/src/imxrt/imxrt_flexcan.c
+++ b/arch/arm/src/imxrt/imxrt_flexcan.c
@@ -2015,6 +2015,9 @@ static void imxrt_reset(struct imxrt_driver_s *priv)
     }
 
   regval  = getreg32(priv->base + IMXRT_CAN_MCR_OFFSET);
+  regval &= ~CAN_MCR_MAXMB_MASK; /* Zero MAXMB to ensure "bitwise or"
+                                  * below sets the correct value.
+                                  */
   regval |= CAN_MCR_SLFWAK | CAN_MCR_WRNEN | CAN_MCR_SRXDIS |
             CAN_MCR_IRMQ | CAN_MCR_AEN |
             (((TOTALMBCOUNT - 1) << CAN_MCR_MAXMB_SHIFT) &

--- a/arch/arm/src/imxrt/imxrt_flexcan.c
+++ b/arch/arm/src/imxrt/imxrt_flexcan.c
@@ -697,13 +697,18 @@ static int imxrt_transmit(struct imxrt_driver_s *priv)
     {
       struct timeval *tv =
              (struct timeval *)(priv->dev.d_buf + priv->dev.d_len);
-      priv->txmb[txmb].deadline = *tv;
       timeout  = (tv->tv_sec - ts.tv_sec)*CLK_TCK
                  + ((tv->tv_usec - ts.tv_nsec / 1000)*CLK_TCK) / 1000000;
       if (timeout < 0)
         {
           return 0;       /* No transmission for you! */
         }
+
+      /* Only now that the frame is going out, so a deadline is never left
+       * behind on a mailbox holding nothing.
+       */
+
+      priv->txmb[txmb].deadline = *tv;
     }
   else
     {


### PR DESCRIPTION
## Summary

Two upstream i.MX RT FlexCAN fixes that `px4_firmware_nuttx-10.3.0+` has and this branch does not.

## Problem

`1f64888154b` was taken from the pull-request branch of apache/nuttx#19970 before review split out two more hunks, so this branch carries the TX-timeout fix without them:

- `imxrt_transmit()` stores the caller's TX deadline before testing whether it has already passed, so the early return for an expired deadline leaves a deadline on a mailbox holding no frame. The next watchdog expiry aborts whatever frame the allocator has since put there.
- `imxrt_reset()` ORs MAXMB into MCR. MAXMB resets to 0x0f, so any configuration with fewer than 16 mailboxes runs with MAXMB = 15 and FlexCAN arbitrates over mailboxes the driver never initialised. With `CONFIG_IMXRT_FLEXCAN_RXMB 10` / `_TXMB 3` — both v6XRT boards in PX4 — MAXMB should be 13, and with the 64-byte CAN FD layout MB14 and MB15 are past the end of the mailbox RAM region.

## Solution

Cherry-pick `b8fdbd85430` and `15d17b3f6ac` from apache/nuttx master.

Tested on an ARK FMU-v6XRT with two DroneCAN nodes on separate buses, PX4/PX4-Autopilot#26215: T0–T5 of the CAN regression suite pass (31–41 % bus utilisation, 0 % loss, TEC/REC 0, error-active throughout), 7 transfer errors in 301 s at idle, and `UAVCAN_BITRATE` round-trips 1 Mbit/s → 500 kbit/s → 1 Mbit/s with both nodes recovering.
