### PR TITLE
SocketCAN per-socket receive buffer and receive wakeup

### DIFF
--- a/arch/arm/src/imxrt/imxrt_flexcan.c
+++ b/arch/arm/src/imxrt/imxrt_flexcan.c
@@ -67,7 +67,7 @@
  * is required.
  */
 
-#define CANWORK    LPWORK
+#define CANWORK    HPWORK
 #define CANRCVWORK HPWORK
 
 /* CONFIG_IMXRT_FLEXCAN_NETHIFS determines the number of physical
@@ -100,7 +100,11 @@
 
 #define POOL_SIZE                   1
 
+#ifdef CONFIG_NET_CAN_RAW_TX_DEADLINE
 #define MSG_DATA                    sizeof(struct timeval)
+#else
+#define MSG_DATA                    0
+#endif
 
 /* CAN bit timing values  */
 #define CLK_FREQ                    80000000
@@ -323,7 +327,7 @@ static struct imxrt_driver_s g_flexcan3;
 static uint8_t g_tx_pool[(sizeof(struct canfd_frame)+MSG_DATA)*POOL_SIZE];
 static uint8_t g_rx_pool[(sizeof(struct canfd_frame)+MSG_DATA)*POOL_SIZE];
 #else
-static uint8_t g_tx_pool[sizeof(struct can_frame)*POOL_SIZE];
+static uint8_t g_tx_pool[(sizeof(struct can_frame)+MSG_DATA)*POOL_SIZE];
 static uint8_t g_rx_pool[sizeof(struct can_frame)*POOL_SIZE];
 #endif
 
@@ -716,12 +720,17 @@ static int imxrt_transmit(struct imxrt_driver_s *priv)
 
       if (CONFIG_NET_CAN_RAW_DEFAULT_TX_DEADLINE > 0)
         {
-          timeout = ((CONFIG_NET_CAN_RAW_DEFAULT_TX_DEADLINE / 1000000)
-              *CLK_TCK);
+          timeout = USEC2TICK(CONFIG_NET_CAN_RAW_DEFAULT_TX_DEADLINE);
           priv->txmb[txmb].deadline.tv_sec = ts.tv_sec +
               CONFIG_NET_CAN_RAW_DEFAULT_TX_DEADLINE / 1000000;
           priv->txmb[txmb].deadline.tv_usec = (ts.tv_nsec / 1000) +
               CONFIG_NET_CAN_RAW_DEFAULT_TX_DEADLINE % 1000000;
+
+          if (priv->txmb[txmb].deadline.tv_usec >= 1000000)
+            {
+              priv->txmb[txmb].deadline.tv_sec++;
+              priv->txmb[txmb].deadline.tv_usec -= 1000000;
+            }
         }
       else
         {
@@ -813,9 +822,11 @@ static int imxrt_transmit(struct imxrt_driver_s *priv)
   NETDEV_TXPACKETS(&priv->dev);
 
 #ifdef TX_TIMEOUT_WQ
-  /* Setup the TX timeout watchdog (perhaps restarting the timer) */
+  /* Setup the TX timeout watchdog (perhaps restarting the timer).  Only a
+   * timeout of -1 means no deadline; 0 is a deadline inside this tick.
+   */
 
-  if (timeout > 0)
+  if (timeout >= 0)
     {
       wd_start(&priv->txtimeout[txmb], timeout + 1,
                imxrt_txtimeout_expiry, (wdparm_t)priv);
@@ -1161,6 +1172,11 @@ static void imxrt_tx_work(void *arg)
   struct imxrt_driver_s *priv = (struct imxrt_driver_s *)arg;
 
   imxrt_sample_errors(priv);
+
+  /* A sender reaches the mailboxes under net_lock, so this pass holds it. */
+
+  net_lock();
+
   imxrt_txdone(priv);
 
 #ifdef TX_TIMEOUT_WQ
@@ -1174,8 +1190,13 @@ static void imxrt_tx_work(void *arg)
 
   modifyreg32(priv->base + IMXRT_CAN_IMASK1_OFFSET, 0, IFLAG1_TX);
 
-  net_lock();
-  if (priv->bifup)
+  /* Poll only when a mailbox is free.  A sender may have refilled the
+   * mailbox this pass retired, and a poll without a free mailbox lets the
+   * socket layer report a frame as sent that imxrt_transmit() then has
+   * nowhere to put.
+   */
+
+  if (priv->bifup && !imxrt_txringfull(priv))
     {
       devif_poll(&priv->dev, imxrt_txpoll);
     }
@@ -1345,6 +1366,16 @@ static void imxrt_txtimeout_abort(struct imxrt_driver_s *priv)
 
       mb = flexcan_get_mb(priv, RXMBCOUNT + 1 + mbi);
       mb->cs.code = CAN_TXMB_ABORT;
+
+      /* Retire the deadline with the frame, as imxrt_txdone() does for a
+       * completion.  An aborting mailbox is no longer CAN_TXMB_DATAORREMOTE,
+       * so imxrt_txmb_next() hands it out again; a deadline left set here
+       * expires on every later pass, counting a timeout each time and
+       * aborting whatever has since been loaded into the mailbox.
+       */
+
+      deadline->tv_sec  = 0;
+      deadline->tv_usec = 0;
     }
 }
 

--- a/arch/arm/src/kinetis/kinetis_flexcan.c
+++ b/arch/arm/src/kinetis/kinetis_flexcan.c
@@ -90,7 +90,11 @@
 
 #define POOL_SIZE                   1
 
+#ifdef CONFIG_NET_CAN_RAW_TX_DEADLINE
 #define MSG_DATA                    sizeof(struct timeval)
+#else
+#define MSG_DATA                    0
+#endif
 
 /* CAN bit timing values  */
 #define CLK_FREQ                    BOARD_EXTAL_FREQ
@@ -341,7 +345,7 @@ static struct kinetis_driver_s g_flexcan2;
 static uint8_t g_tx_pool[(sizeof(struct canfd_frame)+MSG_DATA)*POOL_SIZE];
 static uint8_t g_rx_pool[(sizeof(struct canfd_frame)+MSG_DATA)*POOL_SIZE];
 #else
-static uint8_t g_tx_pool[sizeof(struct can_frame)*POOL_SIZE];
+static uint8_t g_tx_pool[(sizeof(struct can_frame)+MSG_DATA)*POOL_SIZE];
 static uint8_t g_rx_pool[sizeof(struct can_frame)*POOL_SIZE];
 #endif
 

--- a/arch/arm/src/s32k3xx/s32k3xx_flexcan.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_flexcan.c
@@ -92,7 +92,11 @@
 
 #define POOL_SIZE                   1
 
+#ifdef CONFIG_NET_CAN_RAW_TX_DEADLINE
 #define MSG_DATA                    sizeof(struct timeval)
+#else
+#define MSG_DATA                    0
+#endif
 
 /* CAN bit timing values  */
 #define PRESDIV_MAX                 256
@@ -507,7 +511,7 @@ static struct s32k3xx_driver_s g_flexcan5;
 static uint8_t g_tx_pool[(sizeof(struct canfd_frame)+MSG_DATA)*POOL_SIZE];
 static uint8_t g_rx_pool[(sizeof(struct canfd_frame)+MSG_DATA)*POOL_SIZE];
 #else
-static uint8_t g_tx_pool[sizeof(struct can_frame)*POOL_SIZE];
+static uint8_t g_tx_pool[(sizeof(struct can_frame)+MSG_DATA)*POOL_SIZE];
 static uint8_t g_rx_pool[sizeof(struct can_frame)*POOL_SIZE];
 #endif
 

--- a/include/nuttx/can.h
+++ b/include/nuttx/can.h
@@ -35,6 +35,10 @@
 
 #include <nuttx/can/can_common.h>
 
+#ifdef CONFIG_NET_CAN_RAW_RXNOTIFY
+#  include <nuttx/wqueue.h>
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -122,6 +126,10 @@
                                  /* All filters must match to trigger */
 #define CAN_RAW_TX_DEADLINE    (__SO_PROTOCOL + 6)
                                  /* Abort frame when deadline passed */
+#ifdef CONFIG_NET_CAN_RAW_RXNOTIFY
+#define CAN_RAW_RXNOTIFY       (__SO_PROTOCOL + 7)
+                                 /* Worker to run on received frames */
+#endif
 
 /* CAN filter support (Hardware level filtering) ****************************/
 
@@ -364,6 +372,23 @@ struct can_filter
   canid_t can_id;
   canid_t can_mask;
 };
+
+#ifdef CONFIG_NET_CAN_RAW_RXNOTIFY
+
+/* struct can_rxnotify_s - CAN_RAW_RXNOTIFY registration.
+ * worker: Called on the high priority work queue once per batch of frames
+ *         received by the socket, NULL to disarm the notification.
+ * arg:    Handed to the worker.
+ *
+ * The socket keeps the registration until it disarms it or is closed.
+ */
+
+struct can_rxnotify_s
+{
+  worker_t     worker;
+  FAR void    *arg;
+};
+#endif
 
 /****************************************************************************
  * Public Function Prototypes

--- a/net/can/Kconfig
+++ b/net/can/Kconfig
@@ -71,6 +71,40 @@ config CAN_MAX_CONNS
 		This is useful in case the system is under very heavy load (or
 		under attack), ensuring that the heap will not be exhausted.
 
+config NET_CAN_SOCK_RXBUF
+	bool "Per-socket receive buffer instead of I/O buffers"
+	default n
+	---help---
+		Store received frames in a buffer that belongs to the socket
+		instead of in I/O buffers from the shared pool.
+
+		A received frame is copied from the device buffer into the buffer of
+		every listening socket, so CAN reception neither starves nor is
+		starved by the other protocols using the pool.  The buffer is
+		guarded by an irqsave spinlock because some drivers deliver a frame
+		from their receive interrupt handler.
+
+		When this is disabled, CAN sockets read ahead into I/O buffers from
+		the shared pool.
+
+config NET_CAN_SOCK_RXBUF_SIZE
+	int "Receive buffer size per socket (bytes)"
+	depends on NET_CAN_SOCK_RXBUF
+	default 144
+	range 144 32768
+	---help---
+		Bytes of receive buffer reserved in every preallocated CAN
+		connection.
+
+		One frame is stored as one record: a packed header holding the
+		length of the frame, and its arrival time if CONFIG_NET_TIMESTAMP
+		is set, followed by the frame as the driver delivers it.  The
+		minimum size holds one frame of the largest type the build
+		supports.
+
+		A frame that does not fit in the free space is dropped and counted
+		as a receive drop.
+
 config NET_CAN_EXTID
 	bool "Enable CAN extended IDs"
 	default n

--- a/net/can/Kconfig
+++ b/net/can/Kconfig
@@ -167,6 +167,27 @@ config NET_CAN_RAW_FILTER_MAX
 	---help---
 		Maximum number of CAN_RAW filters that can be set per CAN connection.
 
+config NET_CAN_RAW_RXNOTIFY
+	bool "CAN_RAW_RXNOTIFY sockopt"
+	default n
+	depends on NET_CAN_SOCK_OPTS && BUILD_FLAT
+	select SCHED_WORKQUEUE
+	select SCHED_HPWORK
+	---help---
+		Enable the CAN_RAW_RXNOTIFY socket option.  A socket registers a
+		worker with it, and the worker is queued on the high priority work
+		queue once per batch of received frames: the first frame of a batch
+		queues it and the frames behind it find it already queued.  The
+		registration lasts until the socket sets a NULL worker or closes.
+
+		The stack calls the worker pointer as it was given and validates
+		nothing, so this option is for flat builds, where the reader of the
+		frames lives in the same image as the network stack.  Arming it is
+		as trusted an operation as writing to kernel memory.
+
+		When this is disabled, readers are woken only by poll() and by the
+		CAN notifier.
+
 config NET_CAN_NPOLLWAITERS
 	int "Number of poll threads"
 	default 4

--- a/net/can/Kconfig
+++ b/net/can/Kconfig
@@ -133,6 +133,13 @@ config NET_CAN_RAW_FILTER_MAX
 	---help---
 		Maximum number of CAN_RAW filters that can be set per CAN connection.
 
+config NET_CAN_NPOLLWAITERS
+	int "Number of poll threads"
+	default 4
+	---help---
+		Maximum number of threads than can be waiting for POLL events.
+		Default: 4
+
 config NET_CAN_NOTIFIER
 	bool "Support CAN notifications"
 	default n

--- a/net/can/can.h
+++ b/net/can/can.h
@@ -81,6 +81,15 @@ struct can_conn_s
 
   FAR struct net_driver_s *dev;      /* Reference to CAN device */
 
+  /* The send callback of the socket.  can_sendmsg() allocates it on the
+   * first send and keeps it for as long as the socket stays bound to
+   * snd_dev and that device stays up, so sending a frame costs no
+   * callback allocation.
+   */
+
+  FAR struct devif_callback_s *snd_cb; /* NULL until the first send */
+  FAR struct net_driver_s *snd_dev;    /* Device snd_cb belongs to */
+
   /* Read-ahead buffering.
    *
    *   readahead - A singly linked list of type struct iob_qentry_s

--- a/net/can/can.h
+++ b/net/can/can.h
@@ -30,11 +30,17 @@
 #include <nuttx/config.h>
 
 #include <sys/types.h>
+#include <sys/time.h>
+#include <assert.h>
 #include <poll.h>
 
+#include <nuttx/compiler.h>
+#include <nuttx/circbuf.h>
 #include <nuttx/semaphore.h>
+#include <nuttx/spinlock.h>
 #include <nuttx/can.h>
 #include <nuttx/net/net.h>
+#include <nuttx/net/can.h>
 #include <nuttx/net/netdev.h>
 
 #include "devif/devif.h"
@@ -57,6 +63,39 @@
 #define can_callback_free(dev,conn,cb) \
   devif_conn_callback_free(dev, cb, &conn->sconn.list, &conn->sconn.list_tail)
 
+#ifdef CONFIG_NET_CAN_SOCK_RXBUF
+
+/* The space one record of the largest frame takes in the receive
+ * buffer.  The buffer is never configured smaller than that, so a socket
+ * can always receive.
+ */
+
+#  define CAN_RXQ_RECORD_MAX (sizeof(struct can_rxhdr_s) + NET_CAN_PKTSIZE)
+
+/* CAN_RXQ_CLAMP() fits an SO_RCVBUF size into the receive buffer */
+
+#  define CAN_RXQ_CLAMP(size) \
+     ((size) > CONFIG_NET_CAN_SOCK_RXBUF_SIZE ? \
+      CONFIG_NET_CAN_SOCK_RXBUF_SIZE : \
+      ((size) < (int)CAN_RXQ_RECORD_MAX ? (int)CAN_RXQ_RECORD_MAX : (size)))
+
+/* CAN_RXQ_LIMIT() is the number of bytes the socket may retain */
+
+#  if CONFIG_NET_RECV_BUFSIZE > 0
+#    define CAN_RXQ_LIMIT(conn) ((size_t)(conn)->recv_buffsize)
+#  else
+#    define CAN_RXQ_LIMIT(conn) ((size_t)CONFIG_NET_CAN_SOCK_RXBUF_SIZE)
+#  endif
+#endif
+
+/* can_rxq_empty() reports whether a frame is waiting to be read */
+
+#ifdef CONFIG_NET_CAN_SOCK_RXBUF
+#  define can_rxq_empty(conn) circbuf_is_empty(&(conn)->rxq)
+#else
+#  define can_rxq_empty(conn) IOB_QEMPTY(&(conn)->readahead)
+#endif
+
 /****************************************************************************
  * Public Type Definitions
  ****************************************************************************/
@@ -70,6 +109,27 @@ struct can_poll_s
   FAR struct pollfd *fds;          /* Needed to handle poll events */
   FAR struct devif_callback_s *cb; /* Needed to teardown the poll */
 };
+
+#ifdef CONFIG_NET_CAN_SOCK_RXBUF
+
+/* The header of one record in the receive buffer of a socket.  It
+ * is written and read as a byte stream, so it needs no alignment there and
+ * is packed to leave more of the buffer to the frames themselves.
+ */
+
+begin_packed_struct struct can_rxhdr_s
+{
+#ifdef CONFIG_NET_TIMESTAMP
+  struct timeval ts;                 /* Arrival time, for SO_TIMESTAMP */
+#endif
+  uint16_t len;                      /* Length of the frame that follows */
+} end_packed_struct;
+
+/* The buffer holds at least one record of the largest frame */
+
+static_assert(CONFIG_NET_CAN_SOCK_RXBUF_SIZE >= (int)CAN_RXQ_RECORD_MAX,
+              "The receive buffer cannot hold one CAN frame");
+#endif
 
 /* This "connection" structure describes the underlying state of the socket */
 
@@ -90,6 +150,17 @@ struct can_conn_s
   FAR struct devif_callback_s *snd_cb; /* NULL until the first send */
   FAR struct net_driver_s *snd_dev;    /* Device snd_cb belongs to */
 
+#ifdef CONFIG_NET_CAN_SOCK_RXBUF
+  /* Receive buffer of the socket.  A received frame is copied into it from
+   * the device buffer, so this socket never holds an I/O buffer from the
+   * shared pool.  rxq holds variable length records in rxbuf, one per
+   * frame: a struct can_rxhdr_s followed by the frame itself.
+   */
+
+  uint8_t          rxbuf[CONFIG_NET_CAN_SOCK_RXBUF_SIZE];
+  struct circbuf_s rxq;              /* Records of the retained frames */
+  spinlock_t       rxq_lock;         /* Protects the receive buffer */
+#else
   /* Read-ahead buffering.
    *
    *   readahead - A singly linked list of type struct iob_qentry_s
@@ -97,9 +168,14 @@ struct can_conn_s
    */
 
   struct iob_queue_s readahead;      /* remove Read-ahead buffering */
+#endif
 
 #if CONFIG_NET_RECV_BUFSIZE > 0
+#  ifdef CONFIG_NET_CAN_SOCK_RXBUF
+  int32_t recv_buffsize;             /* SO_RCVBUF limit, in bytes */
+#  else
   int32_t recv_buffnum;              /* Recv buffer number */
+#  endif
 #endif
 
   /* CAN-specific content follows */
@@ -247,8 +323,29 @@ uint16_t can_callback(FAR struct net_driver_s *dev,
  *
  ****************************************************************************/
 
+#ifndef CONFIG_NET_CAN_SOCK_RXBUF
 uint16_t can_datahandler(FAR struct net_driver_s *dev,
                          FAR struct can_conn_s *conn);
+#endif
+
+/****************************************************************************
+ * Name: can_recv_filter
+ *
+ * Description:
+ *   Check a CAN ID against the filters of a socket.
+ *
+ * Input Parameters:
+ *   conn - A pointer to the CAN connection structure
+ *   id   - The CAN ID of the frame, including its flags
+ *
+ * Returned Value:
+ *   One if the socket accepts the frame, zero if it does not.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_CANPROTO_OPTIONS
+int can_recv_filter(FAR struct can_conn_s *conn, canid_t id);
+#endif
 
 /****************************************************************************
  * Name: can_recvmsg

--- a/net/can/can.h
+++ b/net/can/can.h
@@ -101,7 +101,7 @@ struct can_conn_s
    * socket events.
    */
 
-  struct can_poll_s pollinfo[4]; /* FIXME make dynamic */
+  struct can_poll_s pollinfo[CONFIG_NET_CAN_NPOLLWAITERS];
 
 #ifdef CONFIG_NET_CANPROTO_OPTIONS
   struct can_filter filters[CONFIG_NET_CAN_RAW_FILTER_MAX];

--- a/net/can/can.h
+++ b/net/can/can.h
@@ -46,7 +46,7 @@
 #include "devif/devif.h"
 #include "socket/socket.h"
 
-#ifdef CONFIG_NET_CAN_NOTIFIER
+#if defined(CONFIG_NET_CAN_NOTIFIER) || defined(CONFIG_NET_CAN_RAW_RXNOTIFY)
 #  include <nuttx/wqueue.h>
 #endif
 
@@ -86,6 +86,27 @@
 #  else
 #    define CAN_RXQ_LIMIT(conn) ((size_t)CONFIG_NET_CAN_SOCK_RXBUF_SIZE)
 #  endif
+#endif
+
+/* can_rxnotify() runs the worker a socket registered with
+ * CAN_RAW_RXNOTIFY.  The receive paths call it after retaining a frame, so
+ * it must be safe to call from an interrupt; work_queue() is.
+ */
+
+#ifdef CONFIG_NET_CAN_RAW_RXNOTIFY
+#  define can_rxnotify(conn) \
+     do \
+       { \
+         if ((conn)->rxnotify_worker != NULL && \
+             work_available(&(conn)->rxnotify_work)) \
+           { \
+             work_queue(HPWORK, &(conn)->rxnotify_work, \
+                        (conn)->rxnotify_worker, (conn)->rxnotify_arg, 0); \
+           } \
+       } \
+     while (0)
+#else
+#  define can_rxnotify(conn)
 #endif
 
 /* can_rxq_empty() reports whether a frame is waiting to be read */
@@ -194,6 +215,17 @@ struct can_conn_s
 #  ifdef CONFIG_NET_CAN_ERRORS
   can_err_mask_t err_mask;
 #  endif
+#endif
+
+#ifdef CONFIG_NET_CAN_RAW_RXNOTIFY
+  /* CAN_RAW_RXNOTIFY registration.  The work structure is what makes the
+   * notification one per batch: while the worker is still queued, a further
+   * received frame does not queue it again.
+   */
+
+  struct work_s rxnotify_work;       /* Queued on the first frame of a batch */
+  worker_t      rxnotify_worker;     /* NULL when the socket did not arm it */
+  FAR void     *rxnotify_arg;        /* Handed to the worker */
 #endif
 };
 

--- a/net/can/can_callback.c
+++ b/net/can/can_callback.c
@@ -279,16 +279,23 @@ uint16_t can_callback(FAR struct net_driver_s *dev,
 #endif
               NETDEV_RXDROPPED(dev);
             }
-#ifdef CONFIG_NET_CAN_NOTIFIER
           else
             {
+#ifdef CONFIG_NET_CAN_NOTIFIER
               /* Provide notification(s) that additional CAN read-ahead
                * data is available.
                */
 
               can_readahead_signal(conn);
-            }
 #endif
+              /* Run the worker the socket registered with
+               * CAN_RAW_RXNOTIFY.  A driver that delivers a batch of
+               * frames in one pass queues it on the first frame of the
+               * batch, so the socket is woken once per batch.
+               */
+
+              can_rxnotify(conn);
+            }
 
           /* The listeners run even when the frame was dropped, so a reader
            * blocked on an already full buffer is woken and takes the
@@ -429,6 +436,14 @@ uint16_t can_datahandler(FAR struct net_driver_s *dev,
 
       can_readahead_signal(conn);
 #endif
+      /* Run the worker the socket registered with CAN_RAW_RXNOTIFY.  A
+       * driver that delivers a batch of frames in one pass queues it on
+       * the first frame of the batch, so the socket is woken once per
+       * batch.
+       */
+
+      can_rxnotify(conn);
+
       ret = iob->io_pktlen;
 
       /* Device buffer has been enqueued, clear the handle */

--- a/net/can/can_callback.c
+++ b/net/can/can_callback.c
@@ -27,9 +27,13 @@
 #include <nuttx/config.h>
 #if defined(CONFIG_NET) && defined(CONFIG_NET_CAN)
 
+#include <stdbool.h>
 #include <stdint.h>
+#include <string.h>
+#include <errno.h>
 #include <debug.h>
 
+#include <nuttx/clock.h>
 #include <nuttx/net/netconfig.h>
 #include <nuttx/net/netdev.h>
 #include <nuttx/mm/iob.h>
@@ -45,6 +49,8 @@
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
+#ifndef CONFIG_NET_CAN_SOCK_RXBUF
 
 /****************************************************************************
  * Name: can_data_event
@@ -98,6 +104,125 @@ can_data_event(FAR struct net_driver_s *dev, FAR struct can_conn_s *conn,
   dev->d_len = 0;
   return ret;
 }
+#endif /* !CONFIG_NET_CAN_SOCK_RXBUF */
+
+#ifdef CONFIG_NET_CAN_SOCK_RXBUF
+
+/****************************************************************************
+ * Name: can_accepts
+ *
+ * Description:
+ *   Check whether a socket wants a received frame.  This runs before the
+ *   frame is copied into the receive buffer of the socket, so a
+ *   frame the socket does not want costs neither a slot nor a copy.
+ *
+ * Input Parameters:
+ *   dev  - The device which was active when the frame was received
+ *   conn - A pointer to the CAN connection structure
+ *
+ * Returned Value:
+ *   True if the socket wants the frame.
+ *
+ * Assumptions:
+ *   This function can be called from an interrupt.
+ *
+ ****************************************************************************/
+
+static bool can_accepts(FAR struct net_driver_s *dev,
+                        FAR struct can_conn_s *conn)
+{
+#ifdef CONFIG_NET_CANPROTO_OPTIONS
+  canid_t can_id;
+
+  memcpy(&can_id, dev->d_appdata, sizeof(canid_t));
+  if (can_recv_filter(conn, can_id) == 0)
+    {
+      return false;
+    }
+#endif
+
+  /* Do not pass frames with DLC > 8 to a legacy socket */
+
+#if defined(CONFIG_NET_CANPROTO_OPTIONS) && defined(CONFIG_NET_CAN_CANFD)
+  if (!_SO_GETOPT(conn->sconn.s_options, CAN_RAW_FD_FRAMES))
+#endif
+    {
+      if (dev->d_len > sizeof(struct can_frame))
+        {
+          return false;
+        }
+    }
+
+  return true;
+}
+
+/****************************************************************************
+ * Name: can_rxq_push
+ *
+ * Description:
+ *   Append one received frame to the receive buffer of a socket as
+ *   a struct can_rxhdr_s followed by the frame itself.  The record carries
+ *   the arrival time if the socket asked for SO_TIMESTAMP.
+ *
+ * Input Parameters:
+ *   conn  - The CAN connection that is to retain the frame
+ *   frame - The frame, in the device buffer
+ *   len   - The length of the frame
+ *
+ * Returned Value:
+ *   The number of frame bytes retained, or -ENOBUFS if the record does not
+ *   fit in the free space or would exceed the SO_RCVBUF limit of the
+ *   socket.
+ *
+ * Assumptions:
+ *   This function can be called from an interrupt.
+ *
+ ****************************************************************************/
+
+static int can_rxq_push(FAR struct can_conn_s *conn,
+                        FAR const void *frame, uint16_t len)
+{
+  struct can_rxhdr_s hdr;
+#ifdef CONFIG_NET_TIMESTAMP
+  struct timespec ts;
+#endif
+  irqstate_t flags;
+  size_t record;
+
+  record  = sizeof(hdr) + len;
+  hdr.len = len;
+
+#ifdef CONFIG_NET_TIMESTAMP
+  /* Every record carries the arrival time, so a frame retained before the
+   * socket set SO_TIMESTAMP still has one.  recvmsg() hands it out only
+   * when the option is set.  The clock is read outside the lock below.
+   */
+
+  clock_systime_timespec(&ts);
+  hdr.ts.tv_sec  = ts.tv_sec;
+  hdr.ts.tv_usec = ts.tv_nsec / 1000;
+#endif
+
+  /* Some CAN drivers deliver a received frame from their receive interrupt
+   * handler, so the buffer is guarded by an irqsave spinlock.
+   */
+
+  flags = spin_lock_irqsave(&conn->rxq_lock);
+
+  if (circbuf_space(&conn->rxq) < record ||
+      circbuf_used(&conn->rxq) + record > CAN_RXQ_LIMIT(conn))
+    {
+      spin_unlock_irqrestore(&conn->rxq_lock, flags);
+      return -ENOBUFS;
+    }
+
+  circbuf_write(&conn->rxq, &hdr, sizeof(hdr));
+  circbuf_write(&conn->rxq, frame, len);
+
+  spin_unlock_irqrestore(&conn->rxq_lock, flags);
+  return len;
+}
+#endif
 
 /****************************************************************************
  * Public Functions
@@ -120,6 +245,81 @@ can_data_event(FAR struct net_driver_s *dev, FAR struct can_conn_s *conn,
 uint16_t can_callback(FAR struct net_driver_s *dev,
                       FAR struct can_conn_s *conn, uint16_t flags)
 {
+#ifdef CONFIG_NET_CAN_SOCK_RXBUF
+  bool newdata = (flags & CAN_NEWDATA) != 0;
+
+  /* Some sanity checking */
+
+  if (conn)
+    {
+      if (newdata)
+        {
+          if (!can_accepts(dev, conn))
+            {
+              /* The filters of the socket, or its CAN_RAW_FD_FRAMES
+               * setting, reject the frame.  Nothing is copied and nothing
+               * is dropped: another socket may still want it.
+               */
+
+              dev->d_len = 0;
+              return flags & ~CAN_NEWDATA;
+            }
+
+          /* Retain the frame in the receive buffer of this
+           * socket before any listener runs, so a reader always finds it
+           * there and the shared I/O buffer pool is never touched.
+           */
+
+          if (can_rxq_push(conn, dev->d_appdata, dev->d_len) < 0)
+            {
+              ninfo("Dropped %d bytes\n", dev->d_len);
+
+#ifdef CONFIG_NET_STATISTICS
+              g_netstats.can.drop++;
+#endif
+              NETDEV_RXDROPPED(dev);
+            }
+#ifdef CONFIG_NET_CAN_NOTIFIER
+          else
+            {
+              /* Provide notification(s) that additional CAN read-ahead
+               * data is available.
+               */
+
+              can_readahead_signal(conn);
+            }
+#endif
+
+          /* The listeners run even when the frame was dropped, so a reader
+           * blocked on an already full buffer is woken and takes the
+           * oldest record out of it.
+           */
+        }
+
+      /* Deliver the event now if the network can be locked without
+       * blocking.  Otherwise the frame stays retained without a wakeup;
+       * the next frame, recvmsg() or poll() finds it.
+       */
+
+      if (net_trylock() == OK)
+        {
+          flags = devif_conn_event(dev, flags, conn->sconn.list);
+          net_unlock();
+        }
+
+      if (newdata)
+        {
+          /* The frame is retained whether or not a listener took it, so
+           * the device buffer is free again.
+           */
+
+          flags &= ~CAN_NEWDATA;
+          dev->d_len = 0;
+        }
+    }
+
+  return flags;
+#else
   /* Some sanity checking */
 
   if (conn)
@@ -170,7 +370,10 @@ uint16_t can_callback(FAR struct net_driver_s *dev,
     }
 
   return flags;
+#endif
 }
+
+#ifndef CONFIG_NET_CAN_SOCK_RXBUF
 
 /****************************************************************************
  * Name: can_datahandler
@@ -245,5 +448,6 @@ errout:
   netdev_iob_release(dev);
   return ret;
 }
+#endif /* !CONFIG_NET_CAN_SOCK_RXBUF */
 
 #endif /* CONFIG_NET && CONFIG_NET_CAN */

--- a/net/can/can_conn.c
+++ b/net/can/can_conn.c
@@ -148,6 +148,19 @@ void can_free(FAR struct can_conn_s *conn)
 
   DEBUGASSERT(conn->crefs == 0);
 
+  /* Free the send callback of the socket.  The device it belongs to may
+   * have been unregistered meanwhile; can_callback_free() checks that and
+   * takes the callback out of the list of the connection either way.
+   */
+
+  if (conn->snd_cb != NULL)
+    {
+      net_lock();
+      can_callback_free(conn->snd_dev, conn, conn->snd_cb);
+      conn->snd_cb = NULL;
+      net_unlock();
+    }
+
   nxmutex_lock(&g_free_lock);
 
   /* Remove the connection from the active list */

--- a/net/can/can_conn.c
+++ b/net/can/can_conn.c
@@ -158,6 +158,16 @@ void can_free(FAR struct can_conn_s *conn)
 
   DEBUGASSERT(conn->crefs == 0);
 
+#ifdef CONFIG_NET_CAN_RAW_RXNOTIFY
+  /* Disarm the receive notification so the worker cannot run against a
+   * connection that is going back to the pool.
+   */
+
+  conn->rxnotify_worker = NULL;
+  conn->rxnotify_arg    = NULL;
+  work_cancel(HPWORK, &conn->rxnotify_work);
+#endif
+
   /* Free the send callback of the socket.  The device it belongs to may
    * have been unregistered meanwhile; can_callback_free() checks that and
    * takes the callback out of the list of the connection either way.

--- a/net/can/can_conn.c
+++ b/net/can/can_conn.c
@@ -35,6 +35,7 @@
 #include <arch/irq.h>
 
 #include <nuttx/kmalloc.h>
+#include <nuttx/mm/iob.h>
 #include <nuttx/queue.h>
 #include <nuttx/mutex.h>
 #include <nuttx/net/netconfig.h>
@@ -152,6 +153,10 @@ void can_free(FAR struct can_conn_s *conn)
   /* Remove the connection from the active list */
 
   dq_rem(&conn->sconn.node, &g_active_can_connections);
+
+  /* Free the readahead queue */
+
+  iob_free_queue(&conn->readahead);
 
   /* Free the connection. */
 

--- a/net/can/can_conn.c
+++ b/net/can/can_conn.c
@@ -106,6 +106,16 @@ FAR struct can_conn_s *can_alloc(void)
   conn = NET_BUFPOOL_TRYALLOC(g_can_connections);
   if (conn != NULL)
     {
+#ifdef CONFIG_NET_CAN_SOCK_RXBUF
+      /* Hand the receive buffer of the connection to its byte ring.
+       * The pool zeroes a connection when it is freed, so the ring is set
+       * up once here, for as long as the connection is in use.
+       */
+
+      spin_lock_init(&conn->rxq_lock);
+      circbuf_init(&conn->rxq, conn->rxbuf, sizeof(conn->rxbuf));
+#endif
+
       /* FIXME SocketCAN default behavior enables loopback */
 
 #ifdef CONFIG_NET_CANPROTO_OPTIONS
@@ -167,9 +177,11 @@ void can_free(FAR struct can_conn_s *conn)
 
   dq_rem(&conn->sconn.node, &g_active_can_connections);
 
+#ifndef CONFIG_NET_CAN_SOCK_RXBUF
   /* Free the readahead queue */
 
   iob_free_queue(&conn->readahead);
+#endif
 
   /* Free the connection. */
 

--- a/net/can/can_getsockopt.c
+++ b/net/can/can_getsockopt.c
@@ -180,7 +180,11 @@ int can_getsockopt(FAR struct socket *psock, int level, int option,
             return -EINVAL;
           }
 
+#ifdef CONFIG_NET_CAN_SOCK_RXBUF
+        *(FAR int *)value = conn->recv_buffsize;
+#else
         *(FAR int *)value = conn->recv_buffnum * CONFIG_IOB_BUFSIZE;
+#endif
 
         break;
 #endif

--- a/net/can/can_input.c
+++ b/net/can/can_input.c
@@ -217,6 +217,22 @@ static int can_input_conn(FAR struct net_driver_s *dev,
 static int can_in(FAR struct net_driver_s *dev)
 {
   FAR struct can_conn_s *conn = can_active(dev, NULL);
+#ifdef CONFIG_NET_CAN_SOCK_RXBUF
+  uint16_t buflen = dev->d_len;
+
+  /* Every listener copies the frame out of the device buffer into its own
+   * receive buffer, so there is nothing to clone.  A frame that no
+   * socket is listening for is simply not retained anywhere.
+   */
+
+  for (; conn != NULL; conn = can_active(dev, conn))
+    {
+      dev->d_len = buflen;
+      can_input_conn(dev, conn);
+    }
+
+  return OK;
+#else
   FAR struct can_conn_s *nextconn;
 
   /* Do we have second connection that can hold this packet? */
@@ -244,6 +260,7 @@ static int can_in(FAR struct net_driver_s *dev)
   /* We can deliver the packet directly to the last listener. */
 
   return can_input_conn(dev, conn);
+#endif
 }
 
 /****************************************************************************
@@ -289,6 +306,13 @@ int can_input(FAR struct net_driver_s *dev)
       return ret;
     }
 
+#ifdef CONFIG_NET_CAN_SOCK_RXBUF
+  /* The listeners copy from the device buffer, so no I/O buffer is needed
+   * to receive a frame.
+   */
+
+  return can_in(dev);
+#else
   ret = netdev_input(dev, can_in, false);
   if (ret < 0)
     {
@@ -298,6 +322,7 @@ int can_input(FAR struct net_driver_s *dev)
     }
 
   return ret;
+#endif
 }
 
 #endif /* CONFIG_NET && CONFIG_NET_CAN */

--- a/net/can/can_recvmsg.c
+++ b/net/can/can_recvmsg.c
@@ -75,10 +75,6 @@ struct can_recvfrom_s
  * Private Functions
  ****************************************************************************/
 
-#ifdef CONFIG_NET_CANPROTO_OPTIONS
-static int can_recv_filter(FAR struct can_conn_s *conn, canid_t id);
-#endif
-
 /****************************************************************************
  * Name: can_add_recvlen
  *
@@ -108,6 +104,8 @@ static inline void can_add_recvlen(FAR struct can_recvfrom_s *pstate,
   pstate->pr_buffer  += recvlen;
   pstate->pr_buflen  -= recvlen;
 }
+
+#ifndef CONFIG_NET_CAN_SOCK_RXBUF
 
 /****************************************************************************
  * Name: can_recvfrom_newdata
@@ -213,6 +211,66 @@ static inline void can_newdata(FAR struct net_driver_s *dev,
 
   dev->d_len = 0;
 }
+#endif /* !CONFIG_NET_CAN_SOCK_RXBUF */
+
+#ifdef CONFIG_NET_CAN_SOCK_RXBUF
+
+/****************************************************************************
+ * Name: can_rxq_pop
+ *
+ * Description:
+ *   Remove the oldest record from the receive buffer of a socket
+ *   and copy its frame into the buffer of the reader.  A frame longer than
+ *   that buffer is truncated and the rest of its record is dropped, so the
+ *   record behind it stays intact.
+ *
+ * Input Parameters:
+ *   conn   - The CAN connection holding the frame
+ *   buf    - Where the frame is to be copied
+ *   buflen - The room in buf
+ *   tsout  - Receives the arrival time, or NULL if it is not wanted
+ *
+ * Returned Value:
+ *   The number of bytes copied, which is zero when the reader asked for
+ *   zero bytes, or -ENODATA if the buffer holds no frame.
+ *
+ ****************************************************************************/
+
+static int can_rxq_pop(FAR struct can_conn_s *conn, FAR void *buf,
+                       size_t buflen, FAR struct timeval *tsout)
+{
+  struct can_rxhdr_s hdr;
+  irqstate_t flags;
+  size_t recvlen;
+
+  flags = spin_lock_irqsave(&conn->rxq_lock);
+
+  if (circbuf_is_empty(&conn->rxq))
+    {
+      spin_unlock_irqrestore(&conn->rxq_lock, flags);
+      return -ENODATA;
+    }
+
+  circbuf_read(&conn->rxq, &hdr, sizeof(hdr));
+
+  recvlen = hdr.len < buflen ? hdr.len : buflen;
+  circbuf_read(&conn->rxq, buf, recvlen);
+  circbuf_skip(&conn->rxq, hdr.len - recvlen);
+
+  spin_unlock_irqrestore(&conn->rxq_lock, flags);
+
+#ifdef CONFIG_NET_TIMESTAMP
+  if (tsout != NULL)
+    {
+      *tsout = hdr.ts;
+    }
+#else
+  UNUSED(tsout);
+#endif
+
+  return (int)recvlen;
+}
+#endif
 
 /****************************************************************************
  * Name: can_readahead
@@ -227,13 +285,48 @@ static inline void can_newdata(FAR struct net_driver_s *dev,
  *   None
  *
  * Assumptions:
- *   The network is locked.
+ *   The network is locked.  With CONFIG_NET_CAN_SOCK_RXBUF this also runs
+ *   from can_recvfrom_eventhandler(), so from the receive interrupt on the
+ *   drivers that call can_input() from their interrupt handler.
  *
  ****************************************************************************/
 
 static inline int can_readahead(struct can_recvfrom_s *pstate)
 {
   FAR struct can_conn_s *conn = pstate->pr_conn;
+#ifdef CONFIG_NET_CAN_SOCK_RXBUF
+#ifdef CONFIG_NET_TIMESTAMP
+  struct timeval ts;
+  FAR struct timeval *tsout = &ts;
+#else
+  FAR struct timeval *tsout = NULL;
+#endif
+  int recvlen;
+
+  /* Take the oldest frame straight out of the receive buffer of
+   * this socket and into the buffer of the reader.
+   */
+
+  pstate->pr_recvlen = -1;
+
+  recvlen = can_rxq_pop(conn, pstate->pr_buffer, pstate->pr_buflen, tsout);
+  if (recvlen < 0)
+    {
+      return 0;
+    }
+
+#ifdef CONFIG_NET_TIMESTAMP
+  if (_SO_GETOPT(conn->sconn.s_options, SO_TIMESTAMP) &&
+      pstate->pr_msglen == sizeof(struct timeval))
+    {
+      memcpy(pstate->pr_msgbuf, &ts, sizeof(struct timeval));
+    }
+#endif
+
+  can_add_recvlen(pstate, recvlen);
+
+  return recvlen;
+#else
   FAR struct iob_s *iob;
   int recvlen;
 
@@ -300,50 +393,16 @@ static inline int can_readahead(struct can_recvfrom_s *pstate)
             }
         }
 
+      /* Update the accumulated size of the data read */
+
+      can_add_recvlen(pstate, recvlen);
+
       return recvlen;
     }
 
   return 0;
-}
-
-#ifdef CONFIG_NET_CANPROTO_OPTIONS
-static int can_recv_filter(FAR struct can_conn_s *conn, canid_t id)
-{
-  uint32_t i;
-
-#ifdef CONFIG_NET_CAN_ERRORS
-  /* error message frame */
-
-  if ((id & CAN_ERR_FLAG) != 0)
-    {
-      return id & conn->err_mask ? 1 : 0;
-    }
 #endif
-
-  for (i = 0; i < conn->filter_count; i++)
-    {
-      if (conn->filters[i].can_id & CAN_INV_FILTER)
-        {
-          if ((id & conn->filters[i].can_mask) !=
-                ((conn->filters[i].can_id & ~CAN_INV_FILTER) &
-                 conn->filters[i].can_mask))
-            {
-              return 1;
-            }
-        }
-      else
-        {
-          if ((id & conn->filters[i].can_mask) ==
-                (conn->filters[i].can_id & conn->filters[i].can_mask))
-            {
-              return 1;
-            }
-        }
-    }
-
-  return 0;
 }
-#endif
 
 static uint16_t can_recvfrom_eventhandler(FAR struct net_driver_s *dev,
                                           FAR void *pvpriv, uint16_t flags)
@@ -354,6 +413,49 @@ static uint16_t can_recvfrom_eventhandler(FAR struct net_driver_s *dev,
 
   if (pstate)
     {
+#ifdef CONFIG_NET_CAN_SOCK_RXBUF
+      if ((flags & CAN_NEWDATA) != 0)
+        {
+          FAR struct can_conn_s *conn = pstate->pr_conn;
+
+          /* The frame is already retained in the receive buffer
+           * of this socket, so just take it from there.  A reader that
+           * asked for zero bytes still consumes one frame.
+           */
+
+          can_readahead(pstate);
+          if (pstate->pr_recvlen < 0)
+            {
+              /* Nothing retained yet.  Keep waiting for the next
+               * frame.
+               */
+
+              return flags;
+            }
+
+          /* Don't allow any further call backs. */
+
+          pstate->pr_cb->flags = 0;
+          pstate->pr_cb->priv  = NULL;
+          pstate->pr_cb->event = NULL;
+
+          if (can_rxq_empty(conn))
+            {
+              /* Indicate that the data has been consumed.  Frames left
+               * behind still have to reach a poll(POLLIN) waiter on this
+               * socket.
+               */
+
+              flags &= ~CAN_NEWDATA;
+            }
+
+          /* Wake up the waiting thread, returning the number of bytes
+           * actually read.
+           */
+
+          nxsem_post(&pstate->pr_sem);
+        }
+#else
 #if defined(CONFIG_NET_CANPROTO_OPTIONS) || defined(CONFIG_NET_TIMESTAMP)
       struct can_conn_s *conn = pstate->pr_conn;
 #endif
@@ -418,6 +520,7 @@ static uint16_t can_recvfrom_eventhandler(FAR struct net_driver_s *dev,
 
           nxsem_post(&pstate->pr_sem);
         }
+#endif
     }
 
   return flags;
@@ -466,6 +569,65 @@ static ssize_t can_recvfrom_result(int result,
 
   return pstate->pr_recvlen;
 }
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_NET_CANPROTO_OPTIONS
+
+/****************************************************************************
+ * Name: can_recv_filter
+ *
+ * Description:
+ *   Check a CAN ID against the filters of a socket.
+ *
+ * Input Parameters:
+ *   conn - A pointer to the CAN connection structure
+ *   id   - The CAN ID of the frame, including its flags
+ *
+ * Returned Value:
+ *   One if the socket accepts the frame, zero if it does not.
+ *
+ ****************************************************************************/
+
+int can_recv_filter(FAR struct can_conn_s *conn, canid_t id)
+{
+  uint32_t i;
+
+#ifdef CONFIG_NET_CAN_ERRORS
+  /* error message frame */
+
+  if ((id & CAN_ERR_FLAG) != 0)
+    {
+      return id & conn->err_mask ? 1 : 0;
+    }
+#endif
+
+  for (i = 0; i < conn->filter_count; i++)
+    {
+      if (conn->filters[i].can_id & CAN_INV_FILTER)
+        {
+          if ((id & conn->filters[i].can_mask) !=
+                ((conn->filters[i].can_id & ~CAN_INV_FILTER) &
+                 conn->filters[i].can_mask))
+            {
+              return 1;
+            }
+        }
+      else
+        {
+          if ((id & conn->filters[i].can_mask) ==
+                (conn->filters[i].can_id & conn->filters[i].can_mask))
+            {
+              return 1;
+            }
+        }
+    }
+
+  return 0;
+}
+#endif
 
 /****************************************************************************
  * Name: can_recvmsg
@@ -536,13 +698,13 @@ ssize_t can_recvmsg(FAR struct socket *psock, FAR struct msghdr *msg,
    * socket has been disconnected.
    */
 
-  ret = can_readahead(&state);
-  if (ret > 0)
+  can_readahead(&state);
+
+  ret = state.pr_recvlen;
+  if (ret >= 0)
     {
       goto errout_with_state;
     }
-
-  ret = state.pr_recvlen;
 
   /* Handle non-blocking CAN sockets */
 

--- a/net/can/can_sendmsg.c
+++ b/net/can/can_sendmsg.c
@@ -85,6 +85,14 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
 
   if (pstate)
     {
+      /* A down device never polls, so the send cannot complete. */
+
+      if ((flags & NETDEV_DOWN) != 0)
+        {
+          pstate->snd_sent = -ENETDOWN;
+          goto end_wait;
+        }
+
       /* Check if the outgoing packet is available. It may have been claimed
        * by a send event handler serving a different thread -OR- if the
        * output buffer currently contains unprocessed incoming data. In
@@ -105,25 +113,52 @@ static uint16_t psock_send_eventhandler(FAR struct net_driver_s *dev,
 
       /* It looks like we are good to send the data */
 
-      else
+      else if (dev->d_buf == NULL)
         {
-          /* Copy the packet data into the device packet buffer and send it */
+          /* Drivers built on the netdev upper half hand the poll no device
+           * buffer.  Their frame goes out through devif_send() and an I/O
+           * buffer, with the control message appended after it.
+           */
 
           int ret = devif_send(dev, pstate->snd_buffer,
-                               pstate->snd_buflen + pstate->pr_msglen, 0);
-          dev->d_len = dev->d_sndlen - pstate->pr_msglen;
+                               pstate->snd_buflen, 0);
+
+          if (ret > 0 && pstate->pr_msglen > 0 &&
+              iob_trycopyin(dev->d_iob, pstate->pr_msgbuf,
+                            pstate->pr_msglen, pstate->snd_buflen,
+                            false) != (int)pstate->pr_msglen)
+            {
+              netdev_iob_release(dev);
+              ret = -ENOMEM;
+            }
+
           if (ret <= 0)
             {
               pstate->snd_sent = ret;
               goto end_wait;
             }
 
+          dev->d_sndlen    = pstate->snd_buflen + pstate->pr_msglen;
+          dev->d_len       = pstate->snd_buflen;
           pstate->snd_sent = pstate->snd_buflen;
+        }
+      else
+        {
+          /* Every other SocketCAN driver hands the poll its TX buffer.  The
+           * frame and the control message that follows it are written
+           * straight into it, without an I/O buffer.
+           */
+
+          memcpy(dev->d_buf, pstate->snd_buffer, pstate->snd_buflen);
           if (pstate->pr_msglen > 0) /* concat cmsg data after packet */
             {
               memcpy(dev->d_buf + pstate->snd_buflen, pstate->pr_msgbuf,
                      pstate->pr_msglen);
             }
+
+          dev->d_len       = pstate->snd_buflen;
+          dev->d_sndlen    = pstate->snd_buflen + pstate->pr_msglen;
+          pstate->snd_sent = pstate->snd_buflen;
         }
 
 end_wait:
@@ -226,6 +261,15 @@ ssize_t can_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
    */
 
   net_lock();
+
+  /* A down device never polls, so the send would wait for nothing. */
+
+  if ((dev->d_flags & IFF_UP) == 0)
+    {
+      net_unlock();
+      return -ENETDOWN;
+    }
+
   memset(&state, 0, sizeof(struct send_s));
   nxsem_init(&state.snd_sem, 0, 0); /* Doesn't really fail */
 
@@ -247,14 +291,41 @@ ssize_t can_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
     }
 #endif
 
-  /* Allocate resource to receive a callback */
+  /* The socket keeps one send callback and reuses it, so a send needs no
+   * callback allocation.  Drop it when the socket has been bound to another
+   * device, so that the allocation below picks up the current device.  An
+   * armed callback belongs to a send that is still waiting and is left
+   * alone.
+   */
 
-  state.snd_cb = can_callback_alloc(dev, conn);
+  if (conn->snd_cb != NULL && conn->snd_cb->event == NULL &&
+      conn->snd_dev != dev)
+    {
+      can_callback_free(conn->snd_dev, conn, conn->snd_cb);
+      conn->snd_cb = NULL;
+    }
+
+  if (conn->snd_cb == NULL)
+    {
+      conn->snd_dev = dev;
+      conn->snd_cb  = can_callback_alloc(dev, conn);
+    }
+
+  state.snd_cb = conn->snd_cb;
+  if (state.snd_cb != NULL && state.snd_cb->event != NULL)
+    {
+      /* Another thread is sending on this socket and holds the callback of
+       * the socket, so this send allocates one of its own.
+       */
+
+      state.snd_cb = can_callback_alloc(dev, conn);
+    }
+
   if (state.snd_cb)
     {
       /* Set up the callback in the connection */
 
-      state.snd_cb->flags = CAN_POLL;
+      state.snd_cb->flags = CAN_POLL | NETDEV_DOWN;
       state.snd_cb->priv  = (FAR void *)&state;
       state.snd_cb->event = psock_send_eventhandler;
 
@@ -272,12 +343,34 @@ ssize_t can_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
         }
       else
         {
-          ret = net_sem_timedwait(&state.snd_sem, UINT_MAX);
+          /* SO_SNDTIMEO bounds a wait that a full ring would never end. */
+
+          ret = net_sem_timedwait(&state.snd_sem,
+                                  _SO_TIMEOUT(conn->sconn.s_sndtimeo));
         }
 
-      /* Make sure that no further events are processed */
+      /* Make sure that no further events are processed.  The callback of
+       * the socket is kept for the next send and only disarmed, and only
+       * while it still carries this send: the event handler disarms it
+       * when it runs, and another sender may have armed it again since.
+       */
 
-      can_callback_free(dev, conn, state.snd_cb);
+      if (state.snd_cb != conn->snd_cb)
+        {
+          can_callback_free(dev, conn, state.snd_cb);
+        }
+      else if (state.snd_cb->priv == &state)
+        {
+          state.snd_cb->flags = 0;
+          state.snd_cb->priv  = NULL;
+          state.snd_cb->event = NULL;
+        }
+    }
+  else
+    {
+      /* No callback, so nothing will ever poll this send. */
+
+      ret = -ENOBUFS;
     }
 
   nxsem_destroy(&state.snd_sem);
@@ -292,6 +385,24 @@ ssize_t can_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
       return state.snd_sent;
     }
 
+  /* A positive snd_sent means the event handler has copied the frame and
+   * cleared the callback, so the frame is on its way even if the wait
+   * timed out.  The zero timeout of a MSG_DONTWAIT send releases the
+   * network lock before it takes the semaphore, and a poll on another
+   * thread can complete the send in that gap.
+   */
+
+  if (state.snd_sent > 0)
+    {
+#ifdef CONFIG_NET_STATISTICS
+      g_netstats.can.sent++;
+#endif
+
+      /* Return the number of bytes actually sent */
+
+      return state.snd_sent;
+    }
+
   /* If net_sem_wait failed, then we were probably reawakened by a signal.
    * In this case, net_sem_wait will have returned negated errno
    * appropriately.
@@ -301,12 +412,6 @@ ssize_t can_sendmsg(FAR struct socket *psock, FAR struct msghdr *msg,
     {
       return ret;
     }
-
-#ifdef CONFIG_NET_STATISTICS
-  g_netstats.can.sent++;
-#endif
-
-  /* Return the number of bytes actually sent */
 
   return state.snd_sent;
 }

--- a/net/can/can_setsockopt.c
+++ b/net/can/can_setsockopt.c
@@ -200,8 +200,12 @@ int can_setsockopt(FAR struct socket *psock, int level, int option,
           buffersize = MIN(buffersize, CONFIG_NET_MAX_RECV_BUFSIZE);
 #endif
 
+#ifdef CONFIG_NET_CAN_SOCK_RXBUF
+          conn->recv_buffsize = CAN_RXQ_CLAMP(buffersize);
+#else
           conn->recv_buffnum = (buffersize + CONFIG_IOB_BUFSIZE - 1)
                               / CONFIG_IOB_BUFSIZE;
+#endif
 
           break;
         }

--- a/net/can/can_setsockopt.c
+++ b/net/can/can_setsockopt.c
@@ -211,6 +211,35 @@ int can_setsockopt(FAR struct socket *psock, int level, int option,
         }
 #endif
 
+#ifdef CONFIG_NET_CAN_RAW_RXNOTIFY
+      case CAN_RAW_RXNOTIFY:
+        {
+          FAR const struct can_rxnotify_s *notify = value;
+
+          if (value_len != sizeof(struct can_rxnotify_s))
+            {
+              return -EINVAL;
+            }
+
+          net_lock();
+
+          /* The worker is cleared before the queued one is cancelled, so a
+           * frame arriving while this runs cannot re-queue it afterwards.
+           */
+
+          conn->rxnotify_worker = notify->worker;
+          conn->rxnotify_arg    = notify->arg;
+
+          if (notify->worker == NULL)
+            {
+              work_cancel(HPWORK, &conn->rxnotify_work);
+            }
+
+          net_unlock();
+        }
+        break;
+#endif
+
       default:
         nerr("ERROR: Unrecognized CAN option: %d\n", option);
         ret = -ENOPROTOOPT;

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -370,13 +370,13 @@ static int can_poll_local(FAR struct socket *psock, FAR struct pollfd *fds,
                           bool setup)
 {
   FAR struct can_conn_s *conn;
-  FAR struct can_poll_s *info;
+  FAR struct can_poll_s *info = NULL;
   FAR struct devif_callback_s *cb;
   pollevent_t eventset = 0;
   int ret = OK;
+  int i;
 
   conn = psock->s_conn;
-  info = conn->pollinfo;
 
   /* FIXME add NETDEV_DOWN support */
 
@@ -385,6 +385,25 @@ static int can_poll_local(FAR struct socket *psock, FAR struct pollfd *fds,
   if (setup)
     {
       net_lock();
+
+      /* Take the first free slot.  Every poll of the socket gets one of
+       * its own, so concurrent polls do not overwrite each other.
+       */
+
+      for (i = 0; i < CONFIG_NET_CAN_NPOLLWAITERS; i++)
+        {
+          if (conn->pollinfo[i].fds == NULL)
+            {
+              info = &conn->pollinfo[i];
+              break;
+            }
+        }
+
+      if (info == NULL)
+        {
+          ret = -EBUSY;
+          goto errout_with_lock;
+        }
 
       info->dev = conn->dev;
 
@@ -455,6 +474,8 @@ errout_with_lock:
 
       if (info != NULL)
         {
+          net_lock();
+
           /* Cancel any response notifications */
 
           can_callback_free(info->dev, conn, info->cb);
@@ -463,9 +484,14 @@ errout_with_lock:
 
           info->fds->priv = NULL;
 
-          /* Then free the poll info container */
+          /* Then free the poll info container.  The slot is free once fds
+           * is NULL, so it is cleared under the lock together with the
+           * callback that could still reach it.
+           */
 
+          info->fds   = NULL;
           info->psock = NULL;
+          net_unlock();
         }
     }
 

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -228,8 +228,12 @@ static int can_setup(FAR struct socket *psock)
        */
 
 #if CONFIG_NET_RECV_BUFSIZE > 0
+#  ifdef CONFIG_NET_CAN_SOCK_RXBUF
+      conn->recv_buffsize = CAN_RXQ_CLAMP(CONFIG_NET_RECV_BUFSIZE);
+#  else
       conn->recv_buffnum = (CONFIG_NET_RECV_BUFSIZE + CONFIG_IOB_BUFSIZE - 1)
                             / CONFIG_IOB_BUFSIZE;
+#  endif
 #endif
 
       /* Attach the connection instance to the socket */
@@ -447,7 +451,7 @@ static int can_poll_local(FAR struct socket *psock, FAR struct pollfd *fds,
 
       /* Check for read data availability now */
 
-      if (!IOB_QEMPTY(&conn->readahead))
+      if (!can_rxq_empty(conn))
         {
           /* Normal data may be read without blocking. */
 

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -454,9 +454,11 @@ static int can_poll_local(FAR struct socket *psock, FAR struct pollfd *fds,
           eventset |= POLLRDNORM;
         }
 
-      if (psock_can_cansend(psock) >= 0)
+      if (conn->dev == NULL && psock_can_cansend(psock) >= 0)
         {
-          /* A CAN frame may be sent without blocking. */
+          /* An unbound socket has no driver to ask, so a send is reported
+           * possible.
+           */
 
           eventset |= POLLWRNORM;
         }
@@ -464,6 +466,16 @@ static int can_poll_local(FAR struct socket *psock, FAR struct pollfd *fds,
       /* Check if any requested events are already in effect */
 
       poll_notify(&fds, 1, eventset);
+
+      /* Ask the driver of a bound socket to poll for TX data.  It polls
+       * only when it has a free mailbox, and the resulting CAN_POLL event
+       * is what reports POLLOUT, so POLLOUT reflects the mailbox state.
+       */
+
+      if ((fds->events & POLLOUT) != 0 && conn->dev != NULL)
+        {
+          netdev_txnotify_dev(conn->dev);
+        }
 
 errout_with_lock:
       net_unlock();

--- a/net/devif/devif_poll.c
+++ b/net/devif/devif_poll.c
@@ -1055,8 +1055,15 @@ int devif_poll(FAR struct net_driver_s *dev, devif_poll_callback_t callback)
         {
           /* Copy iob to flat buffer */
 
-          len = MAX(dev->d_len, dev->d_sndlen);
-          iob_copyout(buf, dev->d_iob, len, -llhdrlen);
+          if (dev->d_iob != NULL)
+            {
+              /* A protocol that writes its packet straight into the device
+               * buffer leaves d_iob NULL and there is nothing to copy out.
+               */
+
+              len = MAX(dev->d_len, dev->d_sndlen);
+              iob_copyout(buf, dev->d_iob, len, -llhdrlen);
+            }
 
           /* Restore flat buffer pointer */
 


### PR DESCRIPTION
**WIP, needs extensive testing** Tested on fmu-v6xrt (imxrt) only. Other SocketCAN boards build but need testing from other users. The NuttX side first needs a PR in NuttX upstream, before we can backport to NuttX our fork.

See PX4/PX4-Autopilot#28568 for PX4 side

### Solved Problem
SocketCAN uses the NuttX I/O buffer (IOB) pool that is shared with TCP and UDP. When another protocol holds the pool, CAN drops frames, and an unread CAN socket can take every buffer and hang the IP stack.

The uavcan node also only read frames on its 3 ms tick and made one `poll()` per frame, so a frame waited up to a tick and a burst of frames cost many polls.

### Solution
Add a Kconfig option in which SocketCAN no longer uses the IOB pool, so CAN cannot be starved by other protocols and cannot starve them. On top of that the TX and RX paths get faster, with lower receive latency and less work per frame.

**TX path**
- The frame is written straight into the FlexCAN driver TX buffer during the poll, no IOB in between.
- `POLLOUT` is reported only when a mailbox is free, so libuavcan queues the frame instead of trying a send that fails.
- The imxrt driver only polls for a new frame when a mailbox is free and retires completions on the high priority work queue, so a frame is never accepted and then dropped, and TX order is kept.

**RX path**
- Received frames go into a per-socket buffer (`NET_CAN_SOCK_RXBUF`, 512 bytes on the boards), filtered before the copy.
- `CAN_RAW_RXNOTIFY` wakes the uavcan node from the receive path once per batch of frames; the tick stays as fallback.
- The socketcan driver drains the socket like the reference libuavcan Linux driver, so a burst costs one `poll()` instead of one per frame.

**Other fixes**
- `uavcan stop` closes the sockets and releases the memory, so `uavcan start` works again and we don't leak memory.
- Sends retry on `ENOMEM` and `ENETDOWN` instead of dropping the frame.
- Fix buffer corruption in the FlexCAN driver when only using CAN2.0B not having room for the TX deadline.

### Test coverage
fmu-v6xrt with a single DroneCAN GNSS on CAN1
