### PR TITLE
fix(stm32h7): poll MDIO completion in microseconds, plus two upstream mdio fixes

### DIFF
--- a/arch/arm/src/stm32h7/stm32_mdio.c
+++ b/arch/arm/src/stm32h7/stm32_mdio.c
@@ -179,7 +179,7 @@ static int stm32_c22_write(struct mdio_lowerhalf_s *dev, uint8_t phydev,
 
   regval |= (((uint32_t)phydev << ETH_MACMDIOAR_PA_SHIFT) &
             ETH_MACMDIOAR_PA_MASK);
-  regval |= (((uint32_t)phydev << ETH_MACMDIOAR_RDA_SHIFT) &
+  regval |= (((uint32_t)regaddr << ETH_MACMDIOAR_RDA_SHIFT) &
             ETH_MACMDIOAR_RDA_MASK);
   regval |= (ETH_MACMDIOAR_MB | ETH_MACMDIOAR_GOC_WRITE);
 

--- a/arch/arm/src/stm32h7/stm32_mdio.c
+++ b/arch/arm/src/stm32h7/stm32_mdio.c
@@ -63,7 +63,7 @@ struct stm32_mdio_lowerhalf_s
 {
   struct mdio_lowerhalf_s base;
 
-  /* MDIO bus timeout in milliseconds */
+  /* MDIO bus timeout in microseconds */
 
   int timeout;
 };
@@ -95,7 +95,7 @@ struct stm32_mdio_lowerhalf_s g_stm32_mdio_lowerhalf =
     {
       .ops = &g_stm32_mdio_ops
     },
-  .timeout = 10
+  .timeout = 10000
 };
 
 /****************************************************************************
@@ -131,9 +131,14 @@ static int stm32_c22_read(struct mdio_lowerhalf_s *dev, uint8_t phydev,
 
   stm32_putreg(regval, STM32_ETH_MACMDIOAR);
 
-  /* Wait for the transfer to complete */
+  /* Wait for the transfer to complete.  A Clause 22 frame is 64 MDC
+   * cycles, about 30 us at a 2.5 MHz MDC, so poll at a fraction of that.
+   * A millisecond delay here turns every PHY register access into a
+   * busy-wait far longer than the transfer, and the autonegotiation link
+   * wait in stm32_phyinit() issues thousands of them.
+   */
 
-  for (to = priv->timeout; to >= 0; to--)
+  for (to = priv->timeout; to > 0; to -= 10)
     {
       if ((stm32_getreg(STM32_ETH_MACMDIOAR) & ETH_MACMDIOAR_MB) == 0)
         {
@@ -142,10 +147,10 @@ static int stm32_c22_read(struct mdio_lowerhalf_s *dev, uint8_t phydev,
           break;
         }
 
-      up_mdelay(5);
+      up_udelay(10);
     }
 
-  if (to <= 0)
+  if (retval < 0)
     {
       ninfo("MII transfer timed out: phydev: %04x regaddr: %04x\n",
             phydev, regaddr);
@@ -192,7 +197,7 @@ static int stm32_c22_write(struct mdio_lowerhalf_s *dev, uint8_t phydev,
 
   /* Wait for the transfer to complete */
 
-  for (to = priv->timeout; to >= 0; to--)
+  for (to = priv->timeout; to > 0; to -= 10)
     {
       if ((stm32_getreg(STM32_ETH_MACMDIOAR) & ETH_MACMDIOAR_MB) == 0)
         {
@@ -200,10 +205,10 @@ static int stm32_c22_write(struct mdio_lowerhalf_s *dev, uint8_t phydev,
           break;
         }
 
-      up_mdelay(5);
+      up_udelay(10);
     }
 
-  if (to <= 0)
+  if (retval < 0)
     {
       ninfo("MII transfer timed out: phydevaddr: %04x phyregaddr: %04x"
             "value: %04x\n", phydev, regaddr, value);

--- a/arch/arm/src/stm32h7/stm32_mdio.c
+++ b/arch/arm/src/stm32h7/stm32_mdio.c
@@ -46,6 +46,7 @@ static void stm32_checksetup(void);
 
 #include <nuttx/mutex.h>
 #include <nuttx/config.h>
+#include <nuttx/nuttx.h>
 
 #include <debug.h>
 #include <errno.h>
@@ -58,9 +59,9 @@ static void stm32_checksetup(void);
  * Private Types
  ****************************************************************************/
 
-struct stm32_mdio_bus_s
+struct stm32_mdio_lowerhalf_s
 {
-  struct mdio_lowerhalf_s *lower;
+  struct mdio_lowerhalf_s base;
 
   /* MDIO bus timeout in milliseconds */
 
@@ -88,14 +89,12 @@ const struct mdio_ops_s g_stm32_mdio_ops =
   .reset = NULL,
 };
 
-struct mdio_lowerhalf_s g_stm32_mdio_lowerhalf =
+struct stm32_mdio_lowerhalf_s g_stm32_mdio_lowerhalf =
 {
-  .ops = &g_stm32_mdio_ops
-};
-
-struct stm32_mdio_bus_s g_stm32_mdio_bus =
-{
-  .lower = &g_stm32_mdio_lowerhalf,
+  .base =
+    {
+      .ops = &g_stm32_mdio_ops
+    },
   .timeout = 10
 };
 
@@ -110,7 +109,8 @@ static int stm32_c22_read(struct mdio_lowerhalf_s *dev, uint8_t phydev,
   uint32_t regval;
 
   int retval = -ETIMEDOUT;
-  struct stm32_mdio_bus_s *priv = (struct stm32_mdio_bus_s *)dev;
+  struct stm32_mdio_lowerhalf_s *priv =
+         container_of(dev, struct stm32_mdio_lowerhalf_s, base);
 
   /* Configure the MACMDIOAR register, preserving CSR Clock Range CR[3:0]
    * bits
@@ -161,7 +161,8 @@ static int stm32_c22_write(struct mdio_lowerhalf_s *dev, uint8_t phydev,
   uint32_t regval;
 
   int retval = -ETIMEDOUT;
-  struct stm32_mdio_bus_s *priv = (struct stm32_mdio_bus_s *)dev;
+  struct stm32_mdio_lowerhalf_s *priv =
+         container_of(dev, struct stm32_mdio_lowerhalf_s, base);
 
   /* Configure the MACMDIOAR register, preserving CSR Clock Range CR[3:0]
    * bits
@@ -228,5 +229,5 @@ static int stm32_c22_write(struct mdio_lowerhalf_s *dev, uint8_t phydev,
 
 struct mdio_bus_s *stm32_mdio_bus_initialize(void)
 {
-  return mdio_register(&g_stm32_mdio_lowerhalf);
+  return mdio_register(&g_stm32_mdio_lowerhalf.base);
 }


### PR DESCRIPTION
## Summary

Backports three `stm32_mdio.c` fixes for STM32H7 ethernet: two already on apache master (private-structure use, RDA field in the Clause 22 write) and apache/nuttx#20067 (merged as 304cbb1372), which replaces the 5 ms busy-wait between MDIO completion checks with 10 us polling.

## Problem

Every PHY register access on H7 costs a 5 ms `up_mdelay()` because the transfer (~30 us) is never complete on the first check. `stm32_phyinit()` issues 6552 of them waiting for link-up, so on any H7 board booting without an ethernet cable (`STM32H7_AUTONEG` + `NETINIT_MONITOR`: ark fmu-v6s/v6x, px4 fmu-v6x, ...) `netinit` pins the core at ~44% for the first ~65 s, priority-inherited to 100, with the net lock held. The UDP MAVLink instance and any other socket user stalls until the link wait times out. Steady state after that is 0.4%, one 5 ms read per poll.

The other two commits are needed for the fix to cherry-pick cleanly and are real bugs: the lower-half cast reads `timeout` from the wrong object, and the C22 write put the PHY address in the register-address field.

## Solution

Poll every 10 us with a 10 ms bound. Measured on ARK FMU-V6X (STM32H753, LAN8742A), no cable, `top once` every 2 s from power-on (shell up at ~12 s):

| | before | after |
|---|---|---|
| netinit CPU, boot to 65 s | 44% | 1.6% for 2 s, then 0.003% |
| UDP MAVLink unblocked at | ~65 s | ~2 s |
