### PR TITLE
[BACKPORT] fs/shm: Add a flag FS_SHMFS_NO_ALIGN to remove SHM alignment

### DIFF
--- a/fs/shm/Kconfig
+++ b/fs/shm/Kconfig
@@ -19,4 +19,14 @@ config FS_SHMFS_VFS_PATH
 		The path to where shared memory objects will exist in the VFS
 		namespace.
 
+config FS_SHMFS_NO_ALIGN
+	bool "Skip cache-line alignment/padding of shm objects"
+	default n
+	---help---
+		Skip cache-line alignment of the shm object metadata header and
+		the object length. Saves RAM in FLAT builds where shm objects
+		are never used as DMA targets and no cache maintenance is
+		performed on their contents. Callers that need DMA-safe shm
+		buffers must not enable this.
+
 endif # FS_SHMFS

--- a/fs/shm/shmfs_alloc.c
+++ b/fs/shm/shmfs_alloc.c
@@ -53,7 +53,11 @@ FAR struct shmfs_object_s *shmfs_alloc_object(size_t length)
 
   size_t hdr_size = sizeof(struct shmfs_object_s);
   size_t alloc_size = length;
+#ifdef CONFIG_FS_SHMFS_NO_ALIGN
+  size_t cachesize = 0;
+#else
   size_t cachesize = up_get_dcache_linesize();
+#endif
 
   if (cachesize > 0)
     {


### PR DESCRIPTION

## Summary

This is a backport from NuttX mainline, which can be used on small systems to save RAM if the SHM object doesn't need to be cache-aligned.

## Impact

Has no impact on the current PX4, which doesn't use posix shm for anything, but is needed for https://github.com/PX4/PX4-Autopilot/pull/27331 to reduce SRAM consumption.

## Testing

Tested on fmu-v5, fmu-v5x, fmu-v6xrt w. the SHM-based uORB implementation.