### PR TITLE
[BACKPORT] arch/arm/src/imxrt: keep the boot ROM's XIP FlexSPI clock

### DIFF
--- a/arch/arm/src/imxrt/Kconfig
+++ b/arch/arm/src/imxrt/Kconfig
@@ -1943,6 +1943,31 @@ menuconfig IMXRT_FLEXSPI2_XIP
 		FlexSPI2 is used as XIP thus already
 		initialized by the bootloader
 
+config IMXRT_XIP_KEEP_BOOTROM_FLEXSPI_CLOCK
+	bool "Keep the boot ROM's XIP FlexSPI clock root"
+	default y
+	depends on IMXRT_CLOCKCONFIG_VER2
+	---help---
+		When executing in place from flash, the XIP FlexSPI clock must not be
+		reconfigured during the initial clock setup. The boot ROM configures
+		the	clock for its flash read sequence, and changing it before the board
+		installs a suitable high-speed read sequence can break instruction
+		fetch. The board's flash setup may reconfigure the clock afterward.
+
+choice
+	prompt "Boot ROM XIP FlexSPI instance"
+	depends on IMXRT_XIP_KEEP_BOOTROM_FLEXSPI_CLOCK
+	default IMXRT_XIP_BOOTROM_FLEXSPI1
+
+config IMXRT_XIP_BOOTROM_FLEXSPI1
+	bool "FLEXSPI1"
+
+config IMXRT_XIP_BOOTROM_FLEXSPI2
+	bool "FLEXSPI2"
+	depends on IMXRT_HAVE_FLEXSPI2
+
+endchoice
+
 endmenu # FLEXSPI Peripherals
 
 menu "ADC Peripherals"

--- a/arch/arm/src/imxrt/imxrt_clockconfig_ver2.c
+++ b/arch/arm/src/imxrt/imxrt_clockconfig_ver2.c
@@ -51,6 +51,12 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
+#ifdef CONFIG_IMXRT_XIP_BOOTROM_FLEXSPI2
+#  define XIP_BOOTROM_FLEXSPI_CLOCK_ROOT CCM_CR_FLEXSPI2
+#else
+#  define XIP_BOOTROM_FLEXSPI_CLOCK_ROOT CCM_CR_FLEXSPI1
+#endif
+
 #define VIDEO_PLL_MIN_FREQ 650000000
 #define OSC24_FREQ         24000000
 
@@ -715,6 +721,19 @@ void imxrt_clockconfig()
 
   for (int i = 0; i < IMXRT_CCM_CR_COUNT; i++)
     {
+#ifdef CONFIG_IMXRT_XIP_KEEP_BOOTROM_FLEXSPI_CLOCK
+
+      /* Do not reconfigure the XIP flash clock during initial clock setup.
+       * The board may change it after installing a suitable high-speed read
+       * sequence.
+       */
+
+      if (i == XIP_BOOTROM_FLEXSPI_CLOCK_ROOT)
+        {
+          continue;
+        }
+#endif
+
       reg = getreg32(IMXRT_CCM_CR_CTRL(i));
 
       reg &= ~(CCM_CR_CTRL_MUX_MASK |


### PR DESCRIPTION
## Summary

When executing in place from flash, the XIP FlexSPI clock must not be reconfigured during the initial clock setup. The boot ROM configures the clock for its flash read sequence, and changing it before the board installs a suitable high-speed read sequence can break instruction fetch. The board's flash setup may reconfigure the clock afterward.
